### PR TITLE
OLS-90: Define a configuration CRD to specify OLS configuration

### DIFF
--- a/config/crd/bases/ols.openshift.io_olsconfigs.yaml
+++ b/config/crd/bases/ols.openshift.io_olsconfigs.yaml
@@ -1,0 +1,196 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.12.0
+  name: olsconfigs.ols.openshift.io
+spec:
+  group: ols.openshift.io
+  names:
+    kind: OLSConfig
+    listKind: OLSConfigList
+    plural: olsconfigs
+    singular: olsconfig
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: OLSConfig is the Schema for the olsconfigs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OLSConfigSpec defines the desired state of OLSConfig
+            properties:
+              llm:
+                description: LLMSpec defines the desired state of the large language
+                  model (LLM).
+                properties:
+                  providers:
+                    items:
+                      description: ModelSpec defines the desired state of LLM provider.
+                      properties:
+                        credentialsSecretRef:
+                          description: Name of a Kubernetes Secret resource containing
+                            API provider credentials.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        models:
+                          description: List of models from the provider
+                          items:
+                            description: ModelSpec defines the desired state of in-memory
+                              cache.
+                            properties:
+                              name:
+                                description: Model name
+                                type: string
+                              url:
+                                description: Model API URL
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        name:
+                          description: Provider name
+                          type: string
+                        url:
+                          description: Provider API URL
+                          type: string
+                      type: object
+                    type: array
+                required:
+                - providers
+                type: object
+              ols:
+                description: OLSSpec defines the desired state of OLS deployment.
+                properties:
+                  classifierModel:
+                    description: Classifier model name
+                    type: string
+                  classifierProvider:
+                    description: Classifier provider name
+                    type: string
+                  conversationCache:
+                    description: Conversation cache settings
+                    properties:
+                      memory:
+                        description: MemorySpec defines the desired of in-memory cache.
+                        properties:
+                          maxEntries:
+                            default: 1000
+                            description: 'Maximum number of cache entries. Default:
+                              "1000"'
+                            type: integer
+                        type: object
+                      redis:
+                        description: RedisSpec defines the desired state of Redis.
+                        properties:
+                          host:
+                            description: Redis host
+                            type: string
+                          maxMemory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Redis maxmemory
+                            x-kubernetes-int-or-string: true
+                          maxMemoryPolicy:
+                            default: allkeys-lru
+                            description: 'Redis maxmemory policy. Default: "allkeys-lru"'
+                            type: string
+                          port:
+                            default: 6379
+                            description: 'Redis port. Default: "6379"'
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                        type: object
+                      type:
+                        default: memory
+                        description: 'Conversation cache type. Default: "memory"'
+                        enum:
+                        - redis
+                        - memory
+                        type: string
+                    type: object
+                  defaultModel:
+                    description: Default model for usage
+                    type: string
+                  defaultProvider:
+                    description: Default provider for usage
+                    type: string
+                  deployment:
+                    description: OLS deployment settings
+                    properties:
+                      replicas:
+                        default: 1
+                        description: 'Defines the number of desired OLS pods. Default:
+                          "1"'
+                        format: int32
+                        type: integer
+                    type: object
+                  enableDeveloperUI:
+                    default: false
+                    description: 'Enable developer UI. Default: "false"'
+                    type: boolean
+                  logLevel:
+                    default: INFO
+                    description: 'Log level. Default: "INFO". Valid options are DEBUG,
+                      INFO, WARNING, ERROR and CRITICAL.'
+                    enum:
+                    - DEBUG
+                    - INFO
+                    - WARNING
+                    - ERROR
+                    - CRITICAL
+                    type: string
+                  summarizerModel:
+                    description: Summarizer model name
+                    type: string
+                  summarizerProvider:
+                    description: Summarizer provider name
+                    type: string
+                  validatorModel:
+                    description: Validator model name
+                    type: string
+                  validatorProvider:
+                    description: Validator provider name
+                    type: string
+                  yamlModel:
+                    description: YAML model name
+                    type: string
+                  yamlProvider:
+                    description: YAML provider name
+                    type: string
+                type: object
+            required:
+            - llm
+            type: object
+          status:
+            description: OLSConfigStatus defines the observed state of OLS deployment.
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
## Description

Added CRD for further implementation of the operator
This CRD corresponds to the [application configuration](https://github.com/openshift/lightspeed-service/blob/main/ols/app/models/config.py)

The operator source code will be added later.
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Closes https://issues.redhat.com/browse/OLS-90

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.