### PR TITLE
chore: sets owner as a Controller OwnerReference

### DIFF
--- a/internal/controller/ols_app_server_assets.go
+++ b/internal/controller/ols_app_server_assets.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/yaml"
 )
 
@@ -20,11 +21,15 @@ func (r *OLSConfigReconciler) generateServiceAccount(cr *olsv1alpha1.OLSConfig) 
 			Namespace: cr.Namespace,
 		},
 	}
+
+	if err := controllerutil.SetControllerReference(cr, &sa, r.Scheme); err != nil {
+		return nil, err
+	}
+
 	return &sa, nil
 }
 
 func (r *OLSConfigReconciler) generateOLSConfigMap(cr *olsv1alpha1.OLSConfig) (*corev1.ConfigMap, error) {
-
 	providerConfigs := []ProviderConfig{}
 	for _, provider := range cr.Spec.LLMConfig.Providers {
 		credentialPath := path.Join(APIKeyMountRoot, provider.CredentialsSecretRef.Name, LLMApiTokenFileName)
@@ -94,11 +99,14 @@ func (r *OLSConfigReconciler) generateOLSConfigMap(cr *olsv1alpha1.OLSConfig) (*
 		},
 	}
 
+	if err := controllerutil.SetControllerReference(cr, &cm, r.Scheme); err != nil {
+		return nil, err
+	}
+
 	return &cm, nil
 }
 
 func (r *OLSConfigReconciler) generateOLSDeployment(cr *olsv1alpha1.OLSConfig) (*appsv1.Deployment, error) {
-
 	// mount points of API key secret
 	const OLSConfigMountPath = "/etc/ols"
 	const OLSConfigVolumeName = "cm-olsconfig"
@@ -215,6 +223,10 @@ func (r *OLSConfigReconciler) generateOLSDeployment(cr *olsv1alpha1.OLSConfig) (
 		},
 	}
 
+	if err := controllerutil.SetControllerReference(cr, &deployment, r.Scheme); err != nil {
+		return nil, err
+	}
+
 	return &deployment, nil
 }
 
@@ -247,6 +259,10 @@ func (r *OLSConfigReconciler) generateService(cr *olsv1alpha1.OLSConfig) (*corev
 			},
 			Selector: DeploymentSelectorLabels,
 		},
+	}
+
+	if err := controllerutil.SetControllerReference(cr, &service, r.Scheme); err != nil {
+		return nil, err
 	}
 
 	return &service, nil


### PR DESCRIPTION
## Description

Add `SetControllerReference` [function](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/controller/controllerutil#SetControllerReference) to manage controller resources. 

This is used for garbage collection of the controlled object and for reconciling the owner object.
## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
