### PR TITLE
fix: update annotations based on ConfigMap data hash

### DIFF
--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -3,8 +3,12 @@ package controller
 import (
 	"crypto/sha256"
 	"fmt"
+	"io"
+	"sort"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func updateDeploymentAnnotations(deployment *appsv1.Deployment, annotations map[string]string) {
@@ -16,11 +20,21 @@ func updateDeploymentAnnotations(deployment *appsv1.Deployment, annotations map[
 	}
 }
 
-func hashBytes(sourceStr []byte) (string, error) {
-	hashFunc := sha256.New()
-	_, err := hashFunc.Write(sourceStr)
-	if err != nil {
-		return "", fmt.Errorf("failed to generate hash %w", err)
+func getSHAfromConfigmap(configmap *corev1.ConfigMap) string {
+	values := []string{}
+	for k, v := range configmap.Data {
+		values = append(values, k+"="+v)
 	}
-	return fmt.Sprintf("%x", hashFunc.Sum(nil)), nil
+	sort.Strings(values)
+	return generateSHA(strings.Join(values, ";"))
+}
+
+func generateSHA(data string) string {
+	hasher := sha256.New()
+	_, err := io.WriteString(hasher, data)
+	if err != nil {
+		return ""
+	}
+	sha := hasher.Sum(nil)
+	return fmt.Sprintf("%x", sha)
 }


### PR DESCRIPTION
## Description

The current logic calculates a hash for the `AppSrvConfigFile` struct instead of ConfigMap data.

The update allows us to calculate the hash specifically for the `.data` field in the ConfigMap.

The changes will also allow us to correctly compare hashes for the existing and generated ConfigMap.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
