### PR TITLE
Bumping OLS deployment resources

### DIFF
--- a/internal/controller/ols_app_server_assets.go
+++ b/internal/controller/ols_app_server_assets.go
@@ -199,11 +199,11 @@ func (r *OLSConfigReconciler) generateOLSDeployment(cr *olsv1alpha1.OLSConfig) (
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("100m"),
-									corev1.ResourceMemory: resource.MustParse("128Mi"),
+									corev1.ResourceMemory: resource.MustParse("1Gi"),
 								},
 								Limits: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("500m"),
-									corev1.ResourceMemory: resource.MustParse("512Mi"),
+									corev1.ResourceMemory: resource.MustParse("2Gi"),
 								},
 							},
 						},


### PR DESCRIPTION
## Description

Bumping up OLS deployment resources as it was failing due to memory issues. Related slack [thread](https://redhat-internal.slack.com/archives/C068JAU4Y0P/p1707501758727439).

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
Tested in local by bringing up the operator with `make install run` command
Verified that OLS is coming up
```
[vchalla@vchalla-thinkpadp1gen2 ~]$ oc logs pod/lightspeed-app-server-c66b95cc9-tph4l -f
Matplotlib created a temporary cache directory at /tmp/matplotlib-3avg61nb because the default path (/.config/matplotlib) is not a writable directory; it is highly recommended to set the MPLCONFIGDIR environment variable to a writable directory, in particular to speed up the import of Matplotlib and to better support multiprocessing.
2024-02-09 19:32:58,672 [ols.app.main:main.py:29] INFO: Config loaded from /etc/ols/..2024_02_09_19_32_42.3010976195/olsconfig.yaml
2024-02-09 19:32:58,672 [ols.app.main:main.py:35] INFO: Embedded Gradio UI is disabled. To enable set enable_dev_ui: true in the dev section of the configuration file
INFO:     Started server process [1]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8080 (Press CTRL+C to quit)
```
