### PR TITLE
OLS-199: restart app server deployment after configmap update

### DIFF
--- a/internal/controller/ols_app_server_reconciliator_test.go
+++ b/internal/controller/ols_app_server_reconciliator_test.go
@@ -116,6 +116,34 @@ var _ = Describe("App server reconciliator", Ordered, func() {
 
 		})
 
+		It("should trigger rolling update of the deployment when changing the generated config", func() {
+
+			By("Get the deployment")
+			dep := &appsv1.Deployment{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: OLSAppServerDeploymentName, Namespace: cr.Namespace}, dep)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dep.Spec.Template.Annotations).NotTo(BeNil())
+			oldHash := dep.Spec.Template.Annotations[OLSConfigHashKey]
+			Expect(oldHash).NotTo(BeEmpty())
+
+			By("Update the OLSConfig custom resource")
+			olsConfig := &olsv1alpha1.OLSConfig{}
+			err = k8sClient.Get(ctx, crNamespacedName, olsConfig)
+			Expect(err).NotTo(HaveOccurred())
+			olsConfig.Spec.OLSConfig.LogLevel = "ERROR"
+
+			By("Reconcile the app server")
+			err = reconciler.reconcileAppServer(ctx, olsConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Get the deployment")
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: OLSAppServerDeploymentName, Namespace: cr.Namespace}, dep)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dep.Spec.Template.Annotations).NotTo(BeNil())
+			Expect(dep.Annotations[OLSConfigHashKey]).NotTo(Equal(oldHash))
+			Expect(dep.Annotations[OLSConfigHashKey]).NotTo(Equal(oldHash))
+		})
+
 	})
 
 })

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -16,6 +16,15 @@ func updateDeploymentAnnotations(deployment *appsv1.Deployment, annotations map[
 	}
 }
 
+func updateDeploymentTemplateAnnotations(deployment *appsv1.Deployment, annotations map[string]string) {
+	if deployment.Spec.Template.Annotations == nil {
+		deployment.Spec.Template.Annotations = make(map[string]string)
+	}
+	for k, v := range annotations {
+		deployment.Spec.Template.Annotations[k] = v
+	}
+}
+
 func hashBytes(sourceStr []byte) (string, error) {
 	hashFunc := sha256.New()
 	_, err := hashFunc.Write(sourceStr)


### PR DESCRIPTION
## Description

This PR adds the logics to restart app server deployment after an update of `olsconfig` configmap. So that the new config is reloaded by the lightspeed app server. 

It fixes a bug that when operator starts with an existing `olsconfig` configmap, the deployment is updated infinitely because the state cache does not have the configmap's hash. 

Adding the config reload completes the flow described in [OLS-199](https://issues.redhat.com//browse/OLS-199).

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes # [OLS-199](https://issues.redhat.com//browse/OLS-199)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
