### PR TITLE
OLS-341: Add code linter to the OLS operator

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,21 @@
+run:
+   timeout: 5m
+   tests: false
+   modules-download-mode: readonly
+output:
+   format: colored-tab
+   sort-results: true
+linters:
+   disable-all: true
+   enable:
+   - errcheck
+   - gosimple
+   - govet
+   - gosec
+   - goimports
+   - ineffassign
+   - staticcheck
+   - unused
+linters-settings:
+   goimports:
+     local-prefixes: github.com/openshift/lightspeed-operator

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,14 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
 
+.PHONY: lint
+lint: ## Run golangci-lint against code.
+	golangci-lint run --config=.golangci.yaml
+
+.PHONY: lint-fix
+lint-fix: ## Fix found issues (if it's supported by the linter).
+	golangci-lint run --fix
+
 ##@ Build
 
 .PHONY: build

--- a/README.md
+++ b/README.md
@@ -168,3 +168,4 @@ To develop the Operator you'll need the following tools:
 - [go](https://golang.org/dl/), version 1.21
 - [docker](https://docs.docker.com/install/), version 17.03+.
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) or [oc](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html#installing-openshift-cli) and access to an OpenShift cluster of a compatible version.
+- [golangci-lint](https://golangci-lint.run/usage/install/#local-installation), version v1.54.2


### PR DESCRIPTION
## Description

Added code linting with the most basic checks.

I deliberately didn't add `golangci-lint` installation via `Makefile`.
Everyone decides how to do this on their workstation, but the PR can be changed if necessary.

Prow's pipeline configuration will be done from another [PR](https://github.com/openshift/release/pull/49054).

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes [OLS-341](https://issues.redhat.com/browse/OLS-341)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
