### PR TITLE
OLS-342:  add console plugin.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ bin/
 # Test binary, built with `go test -c`
 *.test
 
+# downloaded files for running tests
+.testcrds/
+
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 

--- a/Makefile
+++ b/Makefile
@@ -112,8 +112,27 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: test
-test: manifests generate fmt vet envtest ## Run tests.
+test: manifests generate fmt vet envtest test-crds ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
+
+OS_CONSOLE_CRD_URL = https://raw.githubusercontent.com/openshift/api/master/operator/v1/00_console-operator.crd.yaml
+OS_CONSOLE_PLUGIN_CRD_URL = https://raw.githubusercontent.com/openshift/api/master/console/v1/90_consoleplugin.crd.yaml
+TEST_CRD_DIR = .testcrds
+OS_CONSOLE_CRD_FILE = $(TEST_CRD_DIR)/openshift-console-crd.yaml
+OS_CONSOLE_PLUGIN_CRD_FILE = $(TEST_CRD_DIR)/openshift-console-plugin-crd.yaml
+
+.PHONY: test-crds
+test-crds: $(TEST_CRD_DIR) $(OS_CONSOLE_CRD_FILE) $(OS_CONSOLE_PLUGIN_CRD_FILE)  ## Test Dependencies CRDs
+
+$(TEST_CRD_DIR):
+	mkdir -p $(TEST_CRD_DIR)
+
+$(OS_CONSOLE_CRD_FILE): $(TEST_CRD_DIR) 
+	wget -O $(OS_CONSOLE_CRD_FILE) $(OS_CONSOLE_CRD_URL)
+
+$(OS_CONSOLE_PLUGIN_CRD_FILE): $(TEST_CRD_DIR) 
+	wget -O $(OS_CONSOLE_PLUGIN_CRD_FILE) $(OS_CONSOLE_PLUGIN_CRD_URL)
+
 
 .PHONY: lint
 lint: ## Run golangci-lint against code.
@@ -131,9 +150,10 @@ build: manifests generate fmt vet ## Build manager binary.
 
 LIGHTSPEED_SERVICE_IMG ?= quay.io/openshift/lightspeed-service-api:latest
 LIGHTSPEED_SERVICE_REDIS_IMG ?= quay.io/openshift/lightspeed-service-redis:latest
+CONSOLE_PLUGIN_IMG ?= quay.io/openshift/lightspeed-console-plugin:latest
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./cmd/main.go --images="lightspeed-service=$(LIGHTSPEED_SERVICE_IMG),lightspeed-service-redis=$(LIGHTSPEED_SERVICE_REDIS_IMG)"
+	go run ./cmd/main.go --images="lightspeed-service=$(LIGHTSPEED_SERVICE_IMG),lightspeed-service-redis=$(LIGHTSPEED_SERVICE_REDIS_IMG),console-plugin=$(CONSOLE_PLUGIN_IMG)"
 
 # If you wish built the manager image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,6 +29,8 @@ import (
 	k8sflag "k8s.io/component-base/cli/flag"
 	"k8s.io/utils/ptr"
 
+	consolev1 "github.com/openshift/api/console/v1"
+	openshiftv1 "github.com/openshift/api/operator/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -49,11 +51,14 @@ var (
 	defaultImages = map[string]string{
 		"lightspeed-service":       controller.OLSAppServerImageDefault,
 		"lightspeed-service-redis": controller.OLSAppRedisServerImageDefault,
+		"console-plugin":           controller.ConsoleUIImageDefault,
 	}
 )
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(consolev1.AddToScheme(scheme))
+	utilruntime.Must(openshiftv1.AddToScheme(scheme))
 
 	utilruntime.Must(olsv1alpha1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -17,6 +17,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - console.openshift.io
+  resources:
+  - consoleexternalloglinks
+  - consolelinks
+  - consoleplugins
+  - consoleplugins/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - update
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -78,3 +90,12 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - consoles
+  verbs:
+  - get
+  - list
+  - update
+  - watch

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/go-logr/logr v1.3.0
 	github.com/onsi/ginkgo/v2 v2.13.0
 	github.com/onsi/gomega v1.29.0
-	github.com/stretchr/testify v1.8.4
 	k8s.io/api v0.29.1
 	k8s.io/apimachinery v0.29.1
 	k8s.io/client-go v0.29.1
@@ -45,15 +44,14 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/openshift/api v0.0.0-20240306072808-610cbc77dbab
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.16.0 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.10.1 // indirect
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/objx v0.5.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/onsi/ginkgo/v2 v2.13.0 h1:0jY9lJquiL8fcf3M4LAXN5aMlS/b2BV86HFFPCPMgE4
 github.com/onsi/ginkgo/v2 v2.13.0/go.mod h1:TE309ZR8s5FsKKpuB1YAQYBzCaAfUgatB/xlT/ETL/o=
 github.com/onsi/gomega v1.29.0 h1:KIA/t2t5UBzoirT4H9tsML45GEbo3ouUnBHsCfD2tVg=
 github.com/onsi/gomega v1.29.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
+github.com/openshift/api v0.0.0-20240306072808-610cbc77dbab h1:L3k198pZJhluvJZzD/ySpkKqJzQh5MgWlsT4U6NOYUY=
+github.com/openshift/api v0.0.0-20240306072808-610cbc77dbab/go.mod h1:CxgbWAlvu2iQB0UmKTtRu1YfepRg1/vJ64n2DlIEVz4=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -112,7 +114,6 @@ github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -52,4 +52,24 @@ const (
 
 	/*** state cache keys ***/
 	OLSConfigHashStateCacheKey = "olsconfigmap-hash"
+
+	/*** console UI plugin ***/
+	// ConsoleUIConfigMapName is the name of the console UI nginx configmap
+	ConsoleUIConfigMapName = "lightspeed-console-plugin"
+	// ConsoleUIServiceCertSecretName is the name of the console UI service certificate secret
+	ConsoleUIServiceCertSecretName = "lightspeed-console-plugin-cert"
+	// ConsoleUIServiceName is the name of the console UI service
+	ConsoleUIServiceName = "lightspeed-console-plugin"
+	// ConsoleUIDeploymentName is the name of the console UI deployment
+	ConsoleUIDeploymentName = "lightspeed-console-plugin"
+	// ConsoleUIImage is the image of the console UI plugin
+	ConsoleUIImageDefault = "quay.io/openshift/lightspeed-console-plugin:latest"
+	// ConsoleUIHTTPSPort is the port number of the console UI service
+	ConsoleUIHTTPSPort = 9443
+	// ConsoleUIPluginName is the name of the console UI plugin
+	ConsoleUIPluginName = "lightspeed-console-plugin"
+	// ConsoleUIPluginDisplayName is the display name of the console UI plugin
+	ConsoleUIPluginDisplayName = "Lightspeed Console"
+	// ConsoleCRName is the name of the console custom resource
+	ConsoleCRName = "cluster"
 )

--- a/internal/controller/ols_console_reconciliator.go
+++ b/internal/controller/ols_console_reconciliator.go
@@ -1,0 +1,202 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	consolev1 "github.com/openshift/api/console/v1"
+	openshiftv1 "github.com/openshift/api/operator/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	olsv1alpha1 "github.com/openshift/lightspeed-operator/api/v1alpha1"
+)
+
+func (r *OLSConfigReconciler) reconcileConsoleUI(ctx context.Context, olsconfig *olsv1alpha1.OLSConfig) error {
+	r.logger.Info("reconcileConsoleUI starts")
+	tasks := []ReconcileTask{
+		{
+			Name: "reconcile Console Plugin ConfigMap",
+			Task: r.reconcileConsoleUIConfigMap,
+		},
+		{
+			Name: "reconcile Console Plugin Service",
+			Task: r.reconcileConsoleUIService,
+		},
+		{
+			Name: "reconcile Console Plugin Deployment",
+			Task: r.reconcileConsoleUIDeployment,
+		},
+		{
+			Name: "reconcile Console Plugin",
+			Task: r.reconcileConsoleUIPlugin,
+		},
+		{
+			Name: "activate Console Plugin",
+			Task: r.activateConsoleUI,
+		},
+	}
+
+	for _, task := range tasks {
+		err := task.Task(ctx, olsconfig)
+		if err != nil {
+			r.logger.Error(err, "reconcileAppServer error", "task", task.Name)
+			return fmt.Errorf("failed to %s: %w", task.Name, err)
+		}
+	}
+
+	r.logger.Info("reconcileAppServer completes")
+
+	return nil
+}
+
+func (r *OLSConfigReconciler) reconcileConsoleUIConfigMap(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
+	cm, err := r.generateConsoleUIConfigMap(cr)
+	if err != nil {
+		return fmt.Errorf("failed to generate Console Plugin configmap: %w", err)
+	}
+	foundCm := &corev1.ConfigMap{}
+	err = r.Client.Get(ctx, client.ObjectKey{Name: ConsoleUIConfigMapName, Namespace: cr.Namespace}, foundCm)
+	if err != nil && errors.IsNotFound(err) {
+		r.logger.Info("creating Console UI configmap", "configmap", cm.Name)
+		err = r.Create(ctx, cm)
+		if err != nil {
+			return fmt.Errorf("failed to create Console UI configmap: %w", err)
+		}
+		r.logger.Info("Console configmap created", "configmap", cm.Name)
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to get Console UI configmap: %w", err)
+	}
+	err = r.Update(ctx, cm)
+	if err != nil {
+		return fmt.Errorf("failed to update Console UI configmap: %w", err)
+	}
+	r.logger.Info("Console configmap reconciled", "configmap", cm.Name)
+
+	return nil
+}
+func (r *OLSConfigReconciler) reconcileConsoleUIService(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
+	service, err := r.generateConsoleUIService(cr)
+	if err != nil {
+		return fmt.Errorf("failed to generate Console Plugin service: %w", err)
+	}
+	foundService := &corev1.Service{}
+	err = r.Client.Get(ctx, client.ObjectKey{Name: ConsoleUIServiceName, Namespace: cr.Namespace}, foundService)
+	if err != nil && errors.IsNotFound(err) {
+		r.logger.Info("creating Console UI service", "service", service.Name)
+		err = r.Create(ctx, service)
+		if err != nil {
+			return fmt.Errorf("failed to create Console UI service: %w", err)
+		}
+		r.logger.Info("Console UI service created", "service", service.Name)
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to get Console UI service: %w", err)
+	}
+	err = r.Update(ctx, service)
+	if err != nil {
+		return fmt.Errorf("failed to update Console UI service: %w", err)
+	}
+
+	err = r.Client.Get(ctx, client.ObjectKey{Name: ConsoleUIServiceName, Namespace: cr.Namespace}, foundService)
+	if err != nil {
+		return fmt.Errorf("failed to get Console UI service: %w", err)
+	}
+
+	r.logger.Info("Console UI service reconciled", "service", service.Name)
+
+	return nil
+}
+func (r *OLSConfigReconciler) reconcileConsoleUIDeployment(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
+	deployment, err := r.generateConsoleUIDeployment(cr)
+	if err != nil {
+		return fmt.Errorf("failed to generate Console Plugin deployment: %w", err)
+	}
+	foundDeployment := &appsv1.Deployment{}
+	err = r.Client.Get(ctx, client.ObjectKey{Name: ConsoleUIDeploymentName, Namespace: cr.Namespace}, foundDeployment)
+	if err != nil && errors.IsNotFound(err) {
+		r.logger.Info("creating Console UI deployment", "deployment", deployment.Name)
+		err = r.Create(ctx, deployment)
+		if err != nil {
+			return fmt.Errorf("failed to create Console UI deployment: %w", err)
+		}
+		r.logger.Info("Console UI deployment created", "deployment", deployment.Name)
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to get Console UI deployment: %w", err)
+	}
+
+	if deploymentSpecEqual(&foundDeployment.Spec, &deployment.Spec) {
+		r.logger.Info("Console UI deployment unchanged", "deployment", deployment.Name)
+		return nil
+	}
+
+	err = r.Update(ctx, deployment)
+	if err != nil {
+		return fmt.Errorf("failed to update Console UI deployment: %w", err)
+	}
+	r.logger.Info("Console UI deployment reconciled", "deployment", deployment.Name)
+
+	return nil
+}
+
+func (r *OLSConfigReconciler) reconcileConsoleUIPlugin(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
+	plugin, err := r.generateConsoleUIPlugin(cr)
+	if err != nil {
+		return fmt.Errorf("failed to generate Console Plugin: %w", err)
+	}
+	foundPlugin := &consolev1.ConsolePlugin{}
+	err = r.Client.Get(ctx, client.ObjectKey{Name: ConsoleUIPluginName}, foundPlugin)
+	if err != nil && errors.IsNotFound(err) {
+		r.logger.Info("creating Console Plugin", "plugin", plugin.Name)
+		err = r.Create(ctx, plugin)
+		if err != nil {
+			return fmt.Errorf("failed to create Console Plugin: %w", err)
+		}
+		r.logger.Info("Console Plugin created", "plugin", plugin.Name)
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to get Console Plugin: %w", err)
+	}
+
+	if apiequality.Semantic.DeepEqual(foundPlugin.Spec, plugin.Spec) {
+		r.logger.Info("Console Plugin unchanged, skip reconciliaiton", "plugin", plugin.Name)
+		return nil
+	}
+
+	plugin.SetResourceVersion(foundPlugin.GetResourceVersion())
+	err = r.Update(ctx, plugin)
+	if err != nil {
+		return fmt.Errorf("failed to update Console Plugin: %w", err)
+	}
+	r.logger.Info("Console Plugin reconciled", "plugin", plugin.Name)
+
+	return nil
+}
+
+func (r *OLSConfigReconciler) activateConsoleUI(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
+	console := &openshiftv1.Console{}
+	err := r.Client.Get(ctx, client.ObjectKey{Name: ConsoleCRName}, console)
+	if err != nil {
+		return fmt.Errorf("failed to get Console: %w", err)
+	}
+	if console.Spec.Plugins == nil {
+		console.Spec.Plugins = []string{ConsoleUIPluginName}
+	} else if !slices.Contains(console.Spec.Plugins, ConsoleUIPluginName) {
+		console.Spec.Plugins = append(console.Spec.Plugins, ConsoleUIPluginName)
+	} else {
+		return nil
+	}
+	err = r.Update(ctx, console)
+	if err != nil {
+		return fmt.Errorf("failed to update Console: %w", err)
+	}
+	r.logger.Info("Console UI plugin activated")
+	return nil
+}

--- a/internal/controller/ols_console_reconciliator_test.go
+++ b/internal/controller/ols_console_reconciliator_test.go
@@ -1,0 +1,77 @@
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	consolev1 "github.com/openshift/api/console/v1"
+	openshiftv1 "github.com/openshift/api/operator/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Console UI reconciliator", Ordered, func() {
+
+	Context("Creation logic", Ordered, func() {
+		BeforeAll(func() {
+			console := openshiftv1.Console{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: ConsoleCRName,
+				},
+				Spec: openshiftv1.ConsoleSpec{
+					Plugins: []string{"monitoring-plugin"},
+					OperatorSpec: openshiftv1.OperatorSpec{
+						ManagementState: openshiftv1.Managed,
+					},
+				},
+			}
+			err := k8sClient.Create(ctx, &console)
+			Expect(err).NotTo(HaveOccurred())
+
+		})
+
+		It("should reconcile from OLSConfig custom resource", func() {
+			By("Reconcile the OLSConfig custom resource")
+			err := reconciler.reconcileConsoleUI(ctx, cr)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should create a service lightspeed-console-plugin", func() {
+			By("Get the service")
+			svc := &corev1.Service{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: ConsoleUIServiceName, Namespace: cr.Namespace}, svc)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should create a config map lightspeed-console-plugin", func() {
+			By("Get the config map")
+			cm := &corev1.ConfigMap{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: ConsoleUIConfigMapName, Namespace: cr.Namespace}, cm)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should create a deployment lightspeed-console-plugin", func() {
+			By("Get the deployment")
+			dep := &appsv1.Deployment{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: ConsoleUIDeploymentName, Namespace: cr.Namespace}, dep)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should create a console plugin lightspeed-console-plugin", func() {
+			By("Get the console plugin")
+			plugin := &consolev1.ConsolePlugin{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: ConsoleUIPluginName}, plugin)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should activate the console plugin", func() {
+			By("Get the console plugin")
+			console := &openshiftv1.Console{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: ConsoleCRName}, console)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(console.Spec.Plugins).To(ContainElement(ConsoleUIPluginName))
+		})
+
+	})
+})

--- a/internal/controller/ols_console_ui_assets.go
+++ b/internal/controller/ols_console_ui_assets.go
@@ -1,0 +1,235 @@
+package controller
+
+import (
+	consolev1 "github.com/openshift/api/console/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	olsv1alpha1 "github.com/openshift/lightspeed-operator/api/v1alpha1"
+)
+
+func generateConsoleUILabels() map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/component":  "console-plugin",
+		"app.kubernetes.io/managed-by": "lightspeed-operator",
+		"app.kubernetes.io/name":       "lightspeed-console-plugin",
+		"app.kubernetes.io/part-of":    "openshift-lightspeed",
+	}
+}
+
+func (r *OLSConfigReconciler) generateConsoleUIConfigMap(cr *olsv1alpha1.OLSConfig) (*corev1.ConfigMap, error) {
+	nginxConfig := `
+			error_log /dev/stdout info;
+			events {}
+			http {
+				access_log         /dev/stdout;
+				include            /etc/nginx/mime.types;
+				default_type       application/octet-stream;
+				keepalive_timeout  65;
+				server {
+					listen              9443 ssl;
+					listen              [::]:9443 ssl;
+					ssl_certificate     /var/cert/tls.crt;
+					ssl_certificate_key /var/cert/tls.key;
+					root                /usr/share/nginx/html;
+				}
+			}`
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ConsoleUIConfigMapName,
+			Namespace: cr.Namespace,
+			Labels:    generateConsoleUILabels(),
+		},
+		Data: map[string]string{
+			"nginx.conf": nginxConfig,
+		},
+	}
+	if err := controllerutil.SetControllerReference(cr, cm, r.Scheme); err != nil {
+		return nil, err
+	}
+
+	return cm, nil
+
+}
+
+func (r *OLSConfigReconciler) generateConsoleUIService(cr *olsv1alpha1.OLSConfig) (*corev1.Service, error) {
+	service := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ConsoleUIServiceName,
+			Namespace: cr.Namespace,
+			Labels:    generateConsoleUILabels(),
+			Annotations: map[string]string{
+				"service.beta.openshift.io/serving-cert-secret-name": ConsoleUIServiceCertSecretName,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Port:       ConsoleUIHTTPSPort,
+					Name:       "https",
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.Parse("https"),
+				},
+			},
+			Selector: generateConsoleUILabels(),
+		},
+	}
+
+	if err := controllerutil.SetControllerReference(cr, &service, r.Scheme); err != nil {
+		return nil, err
+	}
+
+	return &service, nil
+}
+
+func (r *OLSConfigReconciler) generateConsoleUIDeployment(cr *olsv1alpha1.OLSConfig) (*appsv1.Deployment, error) {
+
+	replicas := int32(2)
+	val_fasle := false
+	val_true := true
+	volumeDefaultMode := int32(420)
+	maxUnavailable := intstr.FromString("25%")
+	maxSurge := intstr.FromString("25%")
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ConsoleUIDeploymentName,
+			Namespace: cr.Namespace,
+			Labels:    generateConsoleUILabels(),
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: generateConsoleUILabels(),
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: generateConsoleUILabels(),
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "lightspeed-console-plugin",
+							Image: ConsoleUIImageDefault,
+							Ports: []corev1.ContainerPort{
+								{
+									ContainerPort: ConsoleUIHTTPSPort,
+									Name:          "https",
+									Protocol:      corev1.ProtocolTCP,
+								},
+							},
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: &val_fasle,
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+									corev1.ResourceMemory: resource.MustParse("50Mi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("100Mi"),
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "lightspeed-console-plugin-cert",
+									MountPath: "/var/cert",
+									ReadOnly:  true,
+								},
+								{
+									Name:      "nginx-config",
+									MountPath: "/etc/nginx/nginx.conf",
+									SubPath:   "nginx.conf",
+									ReadOnly:  true,
+								},
+							},
+						},
+					},
+					RestartPolicy: corev1.RestartPolicyAlways,
+					Volumes: []corev1.Volume{
+						{
+							Name: "lightspeed-console-plugin-cert",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName:  ConsoleUIServiceCertSecretName,
+									DefaultMode: &volumeDefaultMode,
+								},
+							},
+						},
+						{
+							Name: "nginx-config",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: ConsoleUIConfigMapName,
+									},
+									DefaultMode: &volumeDefaultMode,
+								},
+							},
+						},
+					},
+					DNSPolicy: corev1.DNSClusterFirst,
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: &val_true,
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: "RuntimeDefault",
+						},
+					},
+				},
+			},
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxUnavailable: &maxUnavailable,
+					MaxSurge:       &maxSurge,
+				},
+			},
+		},
+	}
+
+	if err := controllerutil.SetControllerReference(cr, deployment, r.Scheme); err != nil {
+		return nil, err
+	}
+
+	return deployment, nil
+}
+
+func (r *OLSConfigReconciler) generateConsoleUIPlugin(cr *olsv1alpha1.OLSConfig) (*consolev1.ConsolePlugin, error) {
+	plugin := &consolev1.ConsolePlugin{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   ConsoleUIPluginName,
+			Labels: generateConsoleUILabels(),
+		},
+		Spec: consolev1.ConsolePluginSpec{
+			Backend: consolev1.ConsolePluginBackend{
+				Service: &consolev1.ConsolePluginService{
+					Name:      ConsoleUIServiceName,
+					Namespace: cr.Namespace,
+					Port:      ConsoleUIHTTPSPort,
+					BasePath:  "/",
+				},
+				Type: consolev1.Service,
+			},
+			DisplayName: "Lightspeed Console Plugin",
+			I18n: consolev1.ConsolePluginI18n{
+				LoadType: consolev1.Preload,
+			},
+		},
+	}
+
+	// todo: set the owner reference after changing the CRD to cluster scoped
+	// if err := controllerutil.SetControllerReference(cr, plugin, r.Scheme); err != nil {
+	// 	return nil, err
+	// }
+
+	return plugin, nil
+}

--- a/internal/controller/ols_console_ui_assets_test.go
+++ b/internal/controller/ols_console_ui_assets_test.go
@@ -1,0 +1,90 @@
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	olsv1alpha1 "github.com/openshift/lightspeed-operator/api/v1alpha1"
+)
+
+var _ = Describe("Console UI assets", func() {
+
+	var cr *olsv1alpha1.OLSConfig
+	var r *OLSConfigReconciler
+	var rOptions *OLSConfigReconcilerOptions
+	labels := map[string]string{
+		"app.kubernetes.io/component":  "console-plugin",
+		"app.kubernetes.io/managed-by": "lightspeed-operator",
+		"app.kubernetes.io/name":       "lightspeed-console-plugin",
+		"app.kubernetes.io/part-of":    "openshift-lightspeed",
+	}
+
+	Context("complete custom resource", func() {
+		BeforeEach(func() {
+			rOptions = &OLSConfigReconcilerOptions{
+				ConsoleUIImage: ConsoleUIImageDefault,
+			}
+			cr = getCompleteOLSConfigCR()
+			r = &OLSConfigReconciler{
+				Options:    *rOptions,
+				logger:     logf.Log.WithName("olsconfig.reconciler"),
+				Client:     k8sClient,
+				Scheme:     k8sClient.Scheme(),
+				stateCache: make(map[string]string),
+			}
+		})
+
+		It("should generate the nginx config map", func() {
+			cm, err := r.generateConsoleUIConfigMap(cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cm.Name).To(Equal(ConsoleUIConfigMapName))
+			Expect(cm.Namespace).To(Equal(cr.Namespace))
+			Expect(cm.Labels).To(Equal(labels))
+
+			// todo: check the nginx config
+		})
+
+		It("should generate the console UI service", func() {
+			svc, err := r.generateConsoleUIService(cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(svc.Name).To(Equal(ConsoleUIServiceName))
+			Expect(svc.Namespace).To(Equal(cr.Namespace))
+			Expect(svc.Labels).To(Equal(labels))
+			Expect(svc.ObjectMeta.Annotations["service.beta.openshift.io/serving-cert-secret-name"]).To(Equal(ConsoleUIServiceCertSecretName))
+			Expect(svc.Spec.Ports[0].Port).To(Equal(int32(ConsoleUIHTTPSPort)))
+			Expect(svc.Spec.Ports[0].TargetPort.StrVal).To(Equal("https"))
+			Expect(svc.Spec.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
+
+		})
+
+		It("should generate the console UI deployment", func() {
+			dep, err := r.generateConsoleUIDeployment(cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dep.Name).To(Equal(ConsoleUIDeploymentName))
+			Expect(dep.Namespace).To(Equal(cr.Namespace))
+			Expect(dep.Labels).To(Equal(labels))
+			Expect(dep.Spec.Template.Labels).To(Equal(labels))
+			Expect(dep.Spec.Template.Spec.Containers[0].Name).To(Equal("lightspeed-console-plugin"))
+			Expect(dep.Spec.Template.Spec.Containers[0].Image).To(Equal(r.Options.ConsoleUIImage))
+			Expect(dep.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort).To(Equal(int32(ConsoleUIHTTPSPort)))
+			Expect(dep.Spec.Template.Spec.Containers[0].Ports[0].Name).To(Equal("https"))
+			Expect(dep.Spec.Template.Spec.Containers[0].Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
+		})
+
+		It("should generate the console UI plugin", func() {
+			plugin, err := r.generateConsoleUIPlugin(cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(plugin.Name).To(Equal(ConsoleUIPluginName))
+			Expect(plugin.Labels).To(Equal(labels))
+			Expect(plugin.Spec.Backend.Service.Name).To(Equal(ConsoleUIServiceName))
+			Expect(plugin.Spec.Backend.Service.Namespace).To(Equal(cr.Namespace))
+			Expect(plugin.Spec.Backend.Service.Port).To(Equal(int32(ConsoleUIHTTPSPort)))
+			Expect(plugin.Spec.Backend.Service.BasePath).To(Equal("/"))
+		})
+
+	})
+
+})

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -24,6 +24,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	consolev1 "github.com/openshift/api/console/v1"
+	openshiftv1 "github.com/openshift/api/operator/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -61,7 +63,10 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "config", "crd", "bases"),
+			filepath.Join("..", "..", ".testcrds"),
+		},
 		ErrorIfCRDPathMissing: true,
 	}
 
@@ -72,6 +77,12 @@ var _ = BeforeSuite(func() {
 	Expect(cfg).NotTo(BeNil())
 
 	err = olsv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = consolev1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = openshiftv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -130,3 +130,44 @@ func podVolumeEqual(a, b []corev1.Volume) bool {
 
 	return true
 }
+
+// deploymentSpecEqual compares two appsv1.DeploymentSpec and returns true if they are equal.
+func deploymentSpecEqual(a, b *appsv1.DeploymentSpec) bool {
+	if !apiequality.Semantic.DeepEqual(a.Template.Spec.NodeSelector, b.Template.Spec.NodeSelector) || // check node selector
+		!apiequality.Semantic.DeepEqual(a.Template.Spec.Tolerations, b.Template.Spec.Tolerations) || // check toleration
+		!apiequality.Semantic.DeepEqual(a.Strategy, b.Strategy) || // check strategy
+		!podVolumeEqual(a.Template.Spec.Volumes, b.Template.Spec.Volumes) || // check volumes
+		*a.Replicas != *b.Replicas { // check replicas
+		return false
+	}
+
+	// check containers
+	if len(a.Template.Spec.Containers) != len(b.Template.Spec.Containers) {
+		return false
+	}
+	for i := range a.Template.Spec.Containers {
+		if !containerSpecEqual(&a.Template.Spec.Containers[i], &b.Template.Spec.Containers[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// containerSpecEqual compares two corev1.Container and returns true if they are equal.
+// checks performed on limited fields
+func containerSpecEqual(a, b *corev1.Container) bool {
+	return (a.Name == b.Name || // check name
+		a.Image != b.Image || // check image
+		apiequality.Semantic.DeepEqual(a.Ports, b.Ports) || // check ports
+		apiequality.Semantic.DeepEqual(a.Env, b.Env) || // check env
+		apiequality.Semantic.DeepEqual(a.Args, b.Args) || // check arguments
+		apiequality.Semantic.DeepEqual(a.VolumeMounts, b.VolumeMounts) || // check volume mounts
+		apiequality.Semantic.DeepEqual(a.Resources, b.Resources) || // check resources
+		apiequality.Semantic.DeepEqual(a.SecurityContext, b.SecurityContext) || // check security context
+		a.ImagePullPolicy == b.ImagePullPolicy || // check image pull policy
+		apiequality.Semantic.DeepEqual(a.LivenessProbe, b.LivenessProbe) || // check liveness probe
+		apiequality.Semantic.DeepEqual(a.ReadinessProbe, b.ReadinessProbe) || // check readiness probe
+		apiequality.Semantic.DeepEqual(a.StartupProbe, b.StartupProbe)) // check startup probe
+
+}


### PR DESCRIPTION
## Description

Deploy + activate console plugin.
This PR is the base of [PR#30](https://github.com/openshift/lightspeed-operator/pull/30) deleting the console plugin when the CR OLSConfig is deleted.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #[OLS-342](https://issues.redhat.com//browse/OLS-342)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
