### PR TITLE
bugfix: update volumes in app server deployment after changing token secret in CR

### DIFF
--- a/internal/controller/ols_app_server_deployment.go
+++ b/internal/controller/ols_app_server_deployment.go
@@ -184,6 +184,16 @@ func (r *OLSConfigReconciler) updateOLSDeployment(ctx context.Context, existingD
 		changed = true
 	}
 
+	// validate volumes including token secrets and application config map
+	if !podVolumeEqual(existingDeployment.Spec.Template.Spec.Volumes, desiredDeployment.Spec.Template.Spec.Volumes) {
+		changed = true
+		existingDeployment.Spec.Template.Spec.Volumes = desiredDeployment.Spec.Template.Spec.Volumes
+		_, err := setDeploymentContainerVolumeMounts(existingDeployment, "lightspeed-service-api", desiredDeployment.Spec.Template.Spec.Containers[0].VolumeMounts)
+		if err != nil {
+			return err
+		}
+	}
+
 	if changed {
 		r.logger.Info("updating OLS deployment", "name", existingDeployment.Name)
 		if err := r.Update(ctx, existingDeployment); err != nil {

--- a/internal/controller/ols_app_server_reconciliator.go
+++ b/internal/controller/ols_app_server_reconciliator.go
@@ -79,8 +79,9 @@ func (r *OLSConfigReconciler) reconcileOLSConfigMap(ctx context.Context, cr *ols
 		r.logger.Info("OLS configmap reconciliation skipped", "configmap", foundCm.Name, "hash", foundCm.Annotations[OLSConfigHashKey])
 		return nil
 	}
-
-	err = r.Update(ctx, cm)
+	foundCm.Data = cm.Data
+	foundCm.Annotations = cm.Annotations
+	err = r.Update(ctx, foundCm)
 	if err != nil {
 		return fmt.Errorf("failed to update OLS configmap: %w", err)
 	}

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -54,6 +54,21 @@ func setDeploymentContainerResources(deployment *appsv1.Deployment, resources *c
 	return false, nil
 }
 
+// setDeploymentContainerVolumeMounts sets the volume mounts for a specific container in a given deployment.
+func setDeploymentContainerVolumeMounts(deployment *appsv1.Deployment, containerName string, volumeMounts []corev1.VolumeMount) (bool, error) {
+	containerIndex, err := getContainerIndex(deployment, containerName)
+	if err != nil {
+		return false, err
+	}
+	existingVolumeMounts := deployment.Spec.Template.Spec.Containers[containerIndex].VolumeMounts
+	if !apiequality.Semantic.DeepEqual(existingVolumeMounts, volumeMounts) {
+		deployment.Spec.Template.Spec.Containers[containerIndex].VolumeMounts = volumeMounts
+		return true, nil
+	}
+
+	return false, nil
+}
+
 // getContainerIndex returns the index of the container with the specified name in a given deployment.
 func getContainerIndex(deployment *appsv1.Deployment, containerName string) (int, error) {
 	for i, container := range deployment.Spec.Template.Spec.Containers {
@@ -71,4 +86,47 @@ func hashBytes(sourceStr []byte) (string, error) {
 		return "", fmt.Errorf("failed to generate hash %w", err)
 	}
 	return fmt.Sprintf("%x", hashFunc.Sum(nil)), nil
+}
+
+// podVolumEqual compares two slices of corev1.Volume and returns true if they are equal.
+// covers 3 volume types: Secret, ConfigMap, EmptyDir
+func podVolumeEqual(a, b []corev1.Volume) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	aVolumeMap := make(map[string]corev1.Volume)
+	for _, v := range a {
+		aVolumeMap[v.Name] = v
+	}
+	bVolumeMap := make(map[string]corev1.Volume)
+	for _, v := range b {
+		bVolumeMap[v.Name] = v
+	}
+	for name, aVolume := range aVolumeMap {
+		if bVolume, exist := bVolumeMap[name]; exist {
+			if aVolume.Secret != nil && bVolume.Secret != nil {
+				if aVolume.Secret.SecretName != bVolume.Secret.SecretName {
+					return false
+				}
+				continue
+			}
+			if aVolume.ConfigMap != nil && bVolume.ConfigMap != nil {
+				if aVolume.ConfigMap.Name != bVolume.ConfigMap.Name {
+					return false
+				}
+				continue
+			}
+			if aVolume.EmptyDir != nil && bVolume.EmptyDir != nil {
+				if aVolume.EmptyDir.Medium != bVolume.EmptyDir.Medium {
+					return false
+				}
+				continue
+			}
+
+			return false
+		}
+		return false
+	}
+
+	return true
 }


### PR DESCRIPTION
## Description

This PR fixes the bug that when changing the spec.llm.providers.credentialsSecretRef.name or adding new provider tokens, the volumes in the lightspeed-app-server deployment is not updated accordingly. 

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
