### PR TITLE
OLS-241: Set tls to disabled by default for now

### DIFF
--- a/internal/controller/ols_app_server_assets.go
+++ b/internal/controller/ols_app_server_assets.go
@@ -76,9 +76,14 @@ func (r *OLSConfigReconciler) generateOLSConfigMap(cr *olsv1alpha1.OLSConfig) (*
 		ConversationCache: conversationCache,
 	}
 
+	devConfig := DevConfig{
+		DisableTLS: true,
+	}
+
 	appSrvConfigFile := AppSrvConfigFile{
 		LLMProviders: providerConfigs,
 		OLSConfig:    olsConfig,
+		DevConfig:    devConfig,
 	}
 	configFileBytes, err := yaml.Marshal(appSrvConfigFile)
 	if err != nil {

--- a/internal/controller/ols_app_server_assets_test.go
+++ b/internal/controller/ols_app_server_assets_test.go
@@ -92,6 +92,9 @@ var _ = Describe("App server assets", func() {
 						},
 					},
 				},
+				DevConfig: DevConfig{
+					DisableTLS: true,
+				},
 			}
 
 			Expect(olsconfigGenerated).To(Equal(olsConfigExpected))
@@ -214,7 +217,9 @@ var _ = Describe("App server assets", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cm.Name).To(Equal(OLSConfigCmName))
 			Expect(cm.Namespace).To(Equal(OLSNamespaceDefault))
-			const expectedConfigStr = `llm_providers: []
+			const expectedConfigStr = `dev_config:
+  disable_tls: true
+llm_providers: []
 ols_config:
   conversation_cache:
     redis:

--- a/internal/controller/types.go
+++ b/internal/controller/types.go
@@ -26,6 +26,7 @@ type DeleteTask struct {
 type AppSrvConfigFile struct {
 	LLMProviders []ProviderConfig `json:"llm_providers"`
 	OLSConfig    OLSConfig        `json:"ols_config,omitempty"`
+	DevConfig    DevConfig        `json:"dev_config,omitempty"`
 }
 
 type ProviderConfig struct {
@@ -82,4 +83,9 @@ type RedisCacheConfig struct {
 	MaxMemory *intstr.IntOrString `json:"max_memory,omitempty" default:"1024mb"`
 	// Redis maxmemory policy
 	MaxMemoryPolicy string `json:"max_memory_policy,omitempty" default:"allkeys-lru"`
+}
+
+type DevConfig struct {
+	// TLS enable/disable
+	DisableTLS bool `json:"disable_tls" default:"false"`
 }


### PR DESCRIPTION
## Description

https://github.com/openshift/lightspeed-service/pull/524 is going to enable tls by default, but the operator isn't ready for TLS to be enabled, so this disables
TLS for now.


## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.