### PR TITLE
OLS-366: OLS Service service-account to have SAR create RBAC Role

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -99,3 +99,17 @@ rules:
   - list
   - update
   - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - '*'

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -12,6 +12,10 @@ const (
 	OLSNamespaceDefault = "openshift-lightspeed"
 	// OLSAppServerServiceAccountName is the name of service account running the application server
 	OLSAppServerServiceAccountName = "lightspeed-app-server"
+	// OLSAppServerSARRoleName is the name of the SAR role for the service account running the application server
+	OLSAppServerSARRoleName = OLSAppServerServiceAccountName + "-sar-role"
+	// OLSAppServerSARRoleBindingName is the name of the SAR role binding for the service account running the application server
+	OLSAppServerSARRoleBindingName = OLSAppServerSARRoleName + "-binding"
 	// OLSAppServerDeploymentName is the name of the OLS application server deployment
 	OLSAppServerDeploymentName = "lightspeed-app-server"
 	// OLSAppRedisDeploymentName is the name of OLS application redis deployment

--- a/internal/controller/ols_app_server_assets.go
+++ b/internal/controller/ols_app_server_assets.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	v1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -27,6 +29,53 @@ func (r *OLSConfigReconciler) generateServiceAccount(cr *olsv1alpha1.OLSConfig) 
 	}
 
 	return &sa, nil
+}
+
+func (r *OLSConfigReconciler) generateSARClusterRole(cr *olsv1alpha1.OLSConfig) (*rbacv1.ClusterRole, error) {
+	role := rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: OLSAppServerSARRoleName,
+		},
+		Rules: []v1.PolicyRule{
+			{
+				APIGroups: []string{"authorization.k8s.io"},
+				Resources: []string{"subjectaccessreviews"},
+				Verbs:     []string{"create"},
+			},
+		},
+	}
+
+	if err := controllerutil.SetControllerReference(cr, &role, r.Scheme); err != nil {
+		return nil, err
+	}
+
+	return &role, nil
+}
+
+func (r *OLSConfigReconciler) generateSARClusterRoleBinding(cr *olsv1alpha1.OLSConfig) (*rbacv1.ClusterRoleBinding, error) {
+	rb := rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: OLSAppServerSARRoleBindingName,
+		},
+		Subjects: []v1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      OLSAppServerServiceAccountName,
+				Namespace: r.Options.Namespace,
+			},
+		},
+		RoleRef: v1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     OLSAppServerSARRoleName,
+		},
+	}
+
+	if err := controllerutil.SetControllerReference(cr, &rb, r.Scheme); err != nil {
+		return nil, err
+	}
+
+	return &rb, nil
 }
 
 func (r *OLSConfigReconciler) generateOLSConfigMap(cr *olsv1alpha1.OLSConfig) (*corev1.ConfigMap, error) {

--- a/internal/controller/ols_app_server_reconciliator_test.go
+++ b/internal/controller/ols_app_server_reconciliator_test.go
@@ -8,7 +8,9 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("App server reconciliator", Ordered, func() {
@@ -27,6 +29,22 @@ var _ = Describe("App server reconciliator", Ordered, func() {
 			By("Get the service account")
 			sa := &corev1.ServiceAccount{}
 			err := k8sClient.Get(ctx, types.NamespacedName{Name: OLSAppServerServiceAccountName, Namespace: OLSNamespaceDefault}, sa)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should create a SAR cluster role lightspeed-app-server-sar-role", func() {
+
+			By("Get the SAR cluster role")
+			role := &rbacv1.ClusterRole{}
+			err := k8sClient.Get(ctx, client.ObjectKey{Name: OLSAppServerSARRoleName}, role)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should create a SAR cluster role binding lightspeed-app-server-sar-role-binding", func() {
+
+			By("Get the SAR cluster role binding")
+			rb := &rbacv1.ClusterRoleBinding{}
+			err := k8sClient.Get(ctx, client.ObjectKey{Name: OLSAppServerSARRoleBindingName}, rb)
 			Expect(err).NotTo(HaveOccurred())
 		})
 

--- a/internal/controller/olsconfig_controller.go
+++ b/internal/controller/olsconfig_controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -64,6 +65,8 @@ type OLSConfigReconcilerOptions struct {
 // +kubebuilder:rbac:groups=console.openshift.io,resources=consolelinks;consoleexternalloglinks;consoleplugins;consoleplugins/finalizers,verbs=get;create;update;delete
 // Modify console CR to activate console plugin
 // +kubebuilder:rbac:groups=operator.openshift.io,resources=consoles,verbs=watch;list;get;update
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=*
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=*
 
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.15.0/pkg/reconcile
@@ -122,6 +125,8 @@ func (r *OLSConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&olsv1alpha1.OLSConfig{}).
 		Owns(&appsv1.Deployment{}, generationChanged).
 		Owns(&corev1.ServiceAccount{}).
+		Owns(&rbacv1.ClusterRole{}).
+		Owns(&rbacv1.ClusterRoleBinding{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.ConfigMap{}).
 		Complete(r)


### PR DESCRIPTION
## Description

Added reconciliation of a SAR role and a role binding for the role and the SA.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes # https://issues.redhat.com/browse/OLS-366

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
```
$ oc get clusterrole/lightspeed-app-server-sar-role -oyaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  creationTimestamp: "2024-03-19T16:44:03Z"
  name: lightspeed-app-server-sar-role
  ownerReferences:
  - apiVersion: ols.openshift.io/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: OLSConfig
    name: cluster
    uid: 33271e23-32c4-492e-a85a-5b7f388561dc
  resourceVersion: "36448"
  uid: 581f4f77-e170-4227-bffe-4a7d8afea45e
rules:
- apiGroups:
  - authorization.k8s.io
  resources:
  - subjectaccessreviews
  verbs:
  - create
$ oc get clusterrolebinding/lightspeed-app-server-sar-role-binding -oyaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  creationTimestamp: "2024-03-19T16:44:03Z"
  name: lightspeed-app-server-sar-role-binding
  ownerReferences:
  - apiVersion: ols.openshift.io/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: OLSConfig
    name: cluster
    uid: 33271e23-32c4-492e-a85a-5b7f388561dc
  resourceVersion: "36449"
  uid: 2a7caacd-264e-4291-91de-6eae421530eb
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: lightspeed-app-server-sar-role
subjects:
- kind: ServiceAccount
  name: lightspeed-app-server
  namespace: openshift-lightspeed
$ 
```
