### PR TITLE
add proxy from UI to backend service

### DIFF
--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -68,4 +68,7 @@ const (
 	ConsoleUIPluginDisplayName = "Lightspeed Console"
 	// ConsoleCRName is the name of the console custom resource
 	ConsoleCRName = "cluster"
+	// ConsoleProxyAlias is the alias of the console proxy
+	// The console backend exposes following proxy endpoint: /api/proxy/plugin/<plugin-name>/<proxy-alias>/<request-path>?<optional-query-parameters>
+	ConsoleProxyAlias = "ols"
 )

--- a/internal/controller/ols_console_ui_assets.go
+++ b/internal/controller/ols_console_ui_assets.go
@@ -205,6 +205,20 @@ func (r *OLSConfigReconciler) generateConsoleUIPlugin(cr *olsv1alpha1.OLSConfig)
 			I18n: consolev1.ConsolePluginI18n{
 				LoadType: consolev1.Preload,
 			},
+			Proxy: []consolev1.ConsolePluginProxy{
+				{
+					Alias:         ConsoleProxyAlias,
+					Authorization: consolev1.None,
+					Endpoint: consolev1.ConsolePluginProxyEndpoint{
+						Service: &consolev1.ConsolePluginProxyServiceConfig{
+							Name:      OLSAppServerServiceName,
+							Namespace: r.Options.Namespace,
+							Port:      OLSAppServerServicePort,
+						},
+						Type: consolev1.ProxyTypeService,
+					},
+				},
+			},
 		},
 	}
 

--- a/internal/controller/ols_console_ui_assets_test.go
+++ b/internal/controller/ols_console_ui_assets_test.go
@@ -5,9 +5,9 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-
+	consolev1 "github.com/openshift/api/console/v1"
 	olsv1alpha1 "github.com/openshift/lightspeed-operator/api/v1alpha1"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var _ = Describe("Console UI assets", func() {
@@ -84,6 +84,14 @@ var _ = Describe("Console UI assets", func() {
 			Expect(plugin.Spec.Backend.Service.Namespace).To(Equal(OLSNamespaceDefault))
 			Expect(plugin.Spec.Backend.Service.Port).To(Equal(int32(ConsoleUIHTTPSPort)))
 			Expect(plugin.Spec.Backend.Service.BasePath).To(Equal("/"))
+			Expect(plugin.Spec.Backend.Type).To(Equal(consolev1.Service))
+
+			Expect(plugin.Spec.Proxy).To(HaveLen(1))
+			Expect(plugin.Spec.Proxy[0].Endpoint.Service.Name).To(Equal(OLSAppServerServiceName))
+			Expect(plugin.Spec.Proxy[0].Endpoint.Service.Port).To(Equal(int32(OLSAppServerServicePort)))
+			Expect(plugin.Spec.Proxy[0].Endpoint.Service.Namespace).To(Equal(OLSNamespaceDefault))
+			Expect(plugin.Spec.Proxy[0].Endpoint.Type).To(Equal(consolev1.ProxyTypeService))
+
 		})
 
 	})


### PR DESCRIPTION
## Description

This PR completes the[ previous PR on console plugin](https://github.com/openshift/lightspeed-operator/pull/30), by adding a proxy to the OLS application service. 

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
