### PR TITLE
DevUI should always be disabled when OLS is managed by the operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ spec:
       type: redis
     defaultModel: ibm/granite-13b-chat-v2
     defaultProvider: bam
-    enableDeveloperUI: false
     logLevel: INFO
     deployment:
       replicas: 1

--- a/api/v1alpha1/olsconfig_types.go
+++ b/api/v1alpha1/olsconfig_types.go
@@ -56,9 +56,6 @@ type OLSSpec struct {
 	// +kubebuilder:validation:Enum=DEBUG;INFO;WARNING;ERROR;CRITICAL
 	// +kubebuilder:default=INFO
 	LogLevel string `json:"logLevel,omitempty"`
-	// Enable developer UI. Default: "false"
-	// +kubebuilder:default=false
-	EnableDeveloperUI bool `json:"enableDeveloperUI,omitempty"`
 	// Default model for usage
 	DefaultModel string `json:"defaultModel,omitempty"`
 	// Default provider for usage

--- a/bundle/manifests/ols.openshift.io_olsconfigs.yaml
+++ b/bundle/manifests/ols.openshift.io_olsconfigs.yaml
@@ -178,10 +178,6 @@ spec:
                             type: object
                         type: object
                     type: object
-                  enableDeveloperUI:
-                    default: false
-                    description: 'Enable developer UI. Default: "false"'
-                    type: boolean
                   logLevel:
                     default: INFO
                     description: 'Log level. Default: "INFO". Valid options are DEBUG,

--- a/config/crd/bases/ols.openshift.io_olsconfigs.yaml
+++ b/config/crd/bases/ols.openshift.io_olsconfigs.yaml
@@ -195,10 +195,6 @@ spec:
                             type: object
                         type: object
                     type: object
-                  enableDeveloperUI:
-                    default: false
-                    description: 'Enable developer UI. Default: "false"'
-                    type: boolean
                   logLevel:
                     default: INFO
                     description: 'Log level. Default: "INFO". Valid options are DEBUG,


### PR DESCRIPTION
## Description

The devui was really just a hack until we had a console ui, now that we have one and it's always going to be available when OLS is installed via the operator, there is no reason to enable the devui.

also it definitely shouldn't be something users are exposed to in the CRD

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.