### PR TITLE
Enable TLS for OLS Service and add disbale_auth

### DIFF
--- a/api/v1alpha1/olsconfig_types.go
+++ b/api/v1alpha1/olsconfig_types.go
@@ -56,6 +56,9 @@ type OLSSpec struct {
 	// +kubebuilder:validation:Enum=DEBUG;INFO;WARNING;ERROR;CRITICAL
 	// +kubebuilder:default=INFO
 	LogLevel string `json:"logLevel,omitempty"`
+	// Disable Authorization for OLS server. Default: "false"
+	// +kubebuilder:default=false
+	DisableAuth bool `json:"disableAuth,omitempty"`
 	// Default model for usage
 	DefaultModel string `json:"defaultModel,omitempty"`
 	// Default provider for usage

--- a/config/crd/bases/ols.openshift.io_olsconfigs.yaml
+++ b/config/crd/bases/ols.openshift.io_olsconfigs.yaml
@@ -195,6 +195,10 @@ spec:
                             type: object
                         type: object
                     type: object
+                  disableAuth:
+                    default: false
+                    description: 'Disable Authorization for OLS server. Default: "false"'
+                    type: boolean
                   logLevel:
                     default: INFO
                     description: 'Log level. Default: "INFO". Valid options are DEBUG,

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -50,8 +50,6 @@ const (
 	// RedisSecretHashKey is the key of the hash value of OLS Redis secret
 	// #nosec G101
 	RedisSecretHashKey = "hash/redis-secret"
-	// OLSAppServerServiceName is the name of the OLS application server service
-	OLSAppServerServiceName = "lightspeed-app-server"
 	// RedisServiceName is the name of OLS application redis server service
 	RedisServiceName = "lightspeed-redis-server"
 	// RedisSecretName is the name of OLS application redis secret
@@ -59,9 +57,13 @@ const (
 	// OLSAppRedisCertsName is the name of the OLS application redis certs secret
 	RedisCertsSecretName = "lightspeed-redis-certs"
 	// OLSAppServerContainerPort is the port number of the lightspeed-service-api container exposes
-	OLSAppServerContainerPort = 8080
-	// OLSAppServerServicePort is the port number of the OLS application server service
-	OLSAppServerServicePort = 8080
+	OLSAppServerContainerPort = 8443
+	// OLSAppServerServicePort is the port number for OLS application server service.
+	OLSAppServerServicePort = 8443
+	// OLSAppServerServiceName is the name of the OLS application server service
+	OLSAppServerServiceName = "lightspeed-app-server"
+	// OLSCertsSecretName is the name of the TLS secret for OLS.
+	OLSCertsSecretName = "lightspeed-tls" // #nosec G101
 	// RedisServicePort is the port number of the OLS redis server service
 	RedisServicePort = 6379
 	// RedisMaxMemory is the max memory of the OLS redis cache
@@ -70,7 +72,9 @@ const (
 	RedisMaxMemoryPolicy = "allkeys-lru"
 	// OLSDefaultCacheType is the default cache type for OLS
 	OLSDefaultCacheType = "redis"
-
+	// Annotation key for serving certificate secret name
+	// #nosec G101
+	ServingCertSecretAnnotationKey = "service.beta.openshift.io/serving-cert-secret-name"
 	/*** state cache keys ***/
 	OLSConfigHashStateCacheKey   = "olsconfigmap-hash"
 	RedisConfigHashStateCacheKey = "olsredisconfig-hash"

--- a/internal/controller/ols_app_redis_assets.go
+++ b/internal/controller/ols_app_redis_assets.go
@@ -107,7 +107,8 @@ func (r *OLSConfigReconciler) generateRedisDeployment(cr *olsv1alpha1.OLSConfig)
 									corev1.ResourceMemory: resource.MustParse("1Gi"),
 								},
 							},
-							Command: []string{"redis-server",
+							Command: []string{
+								"redis-server",
 								"--port", "0",
 								"--tls-port", "6379",
 								"--tls-cert-file", path.Join(OLSAppCertsMountRoot, "tls.crt"),
@@ -115,7 +116,8 @@ func (r *OLSConfigReconciler) generateRedisDeployment(cr *olsv1alpha1.OLSConfig)
 								"--tls-ca-cert-file", path.Join(OLSAppCertsMountRoot, RedisCAVolume, "service-ca.crt"),
 								"--tls-auth-clients", "optional",
 								"--protected-mode", "no",
-								"--requirepass", redisPassword},
+								"--requirepass", redisPassword,
+							},
 						},
 					},
 					Volumes: volumes,
@@ -175,7 +177,7 @@ func (r *OLSConfigReconciler) generateRedisService(cr *olsv1alpha1.OLSConfig) (*
 			Namespace: r.Options.Namespace,
 			Labels:    generateRedisSelectorLabels(),
 			Annotations: map[string]string{
-				"service.beta.openshift.io/serving-cert-secret-name": RedisCertsSecretName,
+				ServingCertSecretAnnotationKey: RedisCertsSecretName,
 			},
 		},
 		Spec: corev1.ServiceSpec{

--- a/internal/controller/ols_app_server_deployment.go
+++ b/internal/controller/ols_app_server_deployment.go
@@ -50,10 +50,23 @@ func (r *OLSConfigReconciler) generateOLSDeployment(cr *olsv1alpha1.OLSConfig) (
 		credentialMountPath := path.Join(APIKeyMountRoot, provider.CredentialsSecretRef.Name)
 		secretMounts[provider.CredentialsSecretRef.Name] = credentialMountPath
 	}
-
+	// Redis volume
 	redisSecretName := cr.Spec.OLSConfig.ConversationCache.Redis.CredentialsSecret
 	redisCredentialsMountPath := path.Join(CredentialsMountRoot, redisSecretName)
 	secretMounts[redisSecretName] = redisCredentialsMountPath
+	// TLS volume
+	tlsSecretNameMountPath := path.Join(OLSAppCertsMountRoot, OLSCertsSecretName)
+	secretMounts[OLSCertsSecretName] = tlsSecretNameMountPath
+
+	// Container ports
+	ports := []corev1.ContainerPort{
+		{
+			ContainerPort: OLSAppServerContainerPort,
+			Name:          "https",
+			Protocol:      corev1.ProtocolTCP,
+		},
+	}
+
 	// declare api key secrets and OLS config map as volumes to the pod
 	volumes := []corev1.Volume{}
 	for secretName := range secretMounts {
@@ -130,13 +143,7 @@ func (r *OLSConfigReconciler) generateOLSDeployment(cr *olsv1alpha1.OLSConfig) (
 							Name:            "lightspeed-service-api",
 							Image:           r.Options.LightspeedServiceImage,
 							ImagePullPolicy: corev1.PullIfNotPresent,
-							Ports: []corev1.ContainerPort{
-								{
-									ContainerPort: OLSAppServerContainerPort,
-									Name:          "http",
-									Protocol:      corev1.ProtocolTCP,
-								},
-							},
+							Ports:           ports,
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: &[]bool{false}[0],
 							},

--- a/internal/controller/ols_app_server_reconciliator.go
+++ b/internal/controller/ols_app_server_reconciliator.go
@@ -194,7 +194,6 @@ func (r *OLSConfigReconciler) reconcileDeployment(ctx context.Context, cr *olsv1
 	}
 
 	err = r.updateOLSDeployment(ctx, existingDeployment, desiredDeployment)
-
 	if err != nil {
 		return fmt.Errorf("failed to update OLS deployment: %w", err)
 	}
@@ -221,6 +220,19 @@ func (r *OLSConfigReconciler) reconcileService(ctx context.Context, cr *olsv1alp
 	} else if err != nil {
 		return fmt.Errorf("failed to get OLS service: %w", err)
 	}
+
+	if serviceEqual(foundService, service) &&
+		foundService.ObjectMeta.Annotations != nil &&
+		foundService.ObjectMeta.Annotations[ServingCertSecretAnnotationKey] == service.ObjectMeta.Annotations[ServingCertSecretAnnotationKey] {
+		r.logger.Info("OLS service unchanged, reconciliation skipped", "service", service.Name)
+		return nil
+	}
+
+	err = r.Update(ctx, service)
+	if err != nil {
+		return fmt.Errorf("failed to update OLS service: %w", err)
+	}
+
 	r.logger.Info("OLS service reconciled", "service", service.Name)
 	return nil
 }

--- a/internal/controller/ols_console_reconciliator.go
+++ b/internal/controller/ols_console_reconciliator.go
@@ -85,6 +85,7 @@ func (r *OLSConfigReconciler) reconcileConsoleUIConfigMap(ctx context.Context, c
 
 	return nil
 }
+
 func (r *OLSConfigReconciler) reconcileConsoleUIService(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
 	service, err := r.generateConsoleUIService(cr)
 	if err != nil {
@@ -106,7 +107,7 @@ func (r *OLSConfigReconciler) reconcileConsoleUIService(ctx context.Context, cr 
 
 	if serviceEqual(foundService, service) &&
 		foundService.ObjectMeta.Annotations != nil &&
-		foundService.ObjectMeta.Annotations["service.beta.openshift.io/serving-cert-secret-name"] == service.ObjectMeta.Annotations["service.beta.openshift.io/serving-cert-secret-name"] {
+		foundService.ObjectMeta.Annotations[ServingCertSecretAnnotationKey] == service.ObjectMeta.Annotations[ServingCertSecretAnnotationKey] {
 		r.logger.Info("Console UI service unchanged, reconciliation skipped", "service", service.Name)
 		return nil
 	}
@@ -120,6 +121,7 @@ func (r *OLSConfigReconciler) reconcileConsoleUIService(ctx context.Context, cr 
 
 	return nil
 }
+
 func (r *OLSConfigReconciler) reconcileConsoleUIDeployment(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
 	deployment, err := r.generateConsoleUIDeployment(cr)
 	if err != nil {

--- a/internal/controller/ols_console_ui_assets.go
+++ b/internal/controller/ols_console_ui_assets.go
@@ -54,7 +54,6 @@ func (r *OLSConfigReconciler) generateConsoleUIConfigMap(cr *olsv1alpha1.OLSConf
 	}
 
 	return cm, nil
-
 }
 
 func (r *OLSConfigReconciler) generateConsoleUIService(cr *olsv1alpha1.OLSConfig) (*corev1.Service, error) {
@@ -64,7 +63,7 @@ func (r *OLSConfigReconciler) generateConsoleUIService(cr *olsv1alpha1.OLSConfig
 			Namespace: r.Options.Namespace,
 			Labels:    generateConsoleUILabels(),
 			Annotations: map[string]string{
-				"service.beta.openshift.io/serving-cert-secret-name": ConsoleUIServiceCertSecretName,
+				ServingCertSecretAnnotationKey: ConsoleUIServiceCertSecretName,
 			},
 		},
 		Spec: corev1.ServiceSpec{
@@ -88,7 +87,6 @@ func (r *OLSConfigReconciler) generateConsoleUIService(cr *olsv1alpha1.OLSConfig
 }
 
 func (r *OLSConfigReconciler) generateConsoleUIDeployment(cr *olsv1alpha1.OLSConfig) (*appsv1.Deployment, error) {
-
 	replicas := int32(2)
 	val_true := true
 	volumeDefaultMode := int32(420)

--- a/internal/controller/types.go
+++ b/internal/controller/types.go
@@ -58,6 +58,8 @@ type OLSConfig struct {
 	Logging LoggingConfig `json:"logging_config,omitempty"`
 	// Conversation cache
 	ConversationCache ConversationCacheConfig `json:"conversation_cache,omitempty"`
+	// TLS configuration
+	TLSConfig TLSConfig `json:"tls_config,omitempty"`
 }
 
 type LoggingConfig struct {
@@ -90,6 +92,11 @@ type RedisCacheConfig struct {
 }
 
 type DevConfig struct {
-	// TLS enable/disable
-	DisableTLS bool `json:"disable_tls" default:"false"`
+	// User Authorization enable/disable
+	DisableAuth bool `json:"disable_auth" default:"false"`
+}
+
+type TLSConfig struct {
+	TLSCertificatePath string `json:"tls_certificate_path,omitempty"`
+	TLSKeyPath         string `json:"tls_key_path,omitempty"`
 }

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -221,7 +221,6 @@ func containerSpecEqual(a, b *corev1.Container) bool {
 		apiequality.Semantic.DeepEqual(a.LivenessProbe, b.LivenessProbe) && // check liveness probe
 		apiequality.Semantic.DeepEqual(a.ReadinessProbe, b.ReadinessProbe) && // check readiness probe
 		apiequality.Semantic.DeepEqual(a.StartupProbe, b.StartupProbe)) // check startup probe
-
 }
 
 // serviceEqual compares two v1.Service and returns true if they are equal.


### PR DESCRIPTION
## Description
TLS is enabled for OLS Service .
Provides ability to disable Authorization in CR. 
Example : 
```
apiVersion: ols.openshift.io/v1alpha1
kind: OLSConfig
metadata:
  name: cluster
  namespace: openshift-lightspeed
spec:
  llm:
    providers:
    - credentialsSecretRef:
        name: openai-api-keys
      models:
      - name: gpt-3.5-turbo
      name: openai
      url: https://api.openai.com/v1
  ols:
    conversationCache:
      redis:
        maxMemory: 2000mb
        maxMemoryPolicy: allkeys-lru
      type: redis
    defaultModel: gpt-3.5-turbo
    defaultProvider: openai
    enableDeveloperUI: false
    logLevel: INFO
    deployment:
      replicas: 1
    disable_auth: true
    ```

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
