### PR TITLE
OLS-433: enable user token passing in the consoleplugin config

### DIFF
--- a/internal/controller/ols_console_ui_assets.go
+++ b/internal/controller/ols_console_ui_assets.go
@@ -206,7 +206,7 @@ func (r *OLSConfigReconciler) generateConsoleUIPlugin(cr *olsv1alpha1.OLSConfig)
 			Proxy: []consolev1.ConsolePluginProxy{
 				{
 					Alias:         ConsoleProxyAlias,
-					Authorization: consolev1.None,
+					Authorization: consolev1.UserToken,
 					Endpoint: consolev1.ConsolePluginProxyEndpoint{
 						Service: &consolev1.ConsolePluginProxyServiceConfig{
 							Name:      OLSAppServerServiceName,


### PR DESCRIPTION
## Description

note: does not enable auth in the OLS backend yet because that is still blocked by OLS-432.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.