### PR TITLE
 revert files after build_catalog script

### DIFF
--- a/hack/build_catalog.sh
+++ b/hack/build_catalog.sh
@@ -88,6 +88,3 @@ podman build --platform="${DEFAULT_PLATFORM}" -f "${CATALOG_DOCKER_FILE}" -t "${
 echo "Pushing catalog image ${CATALOG_IMAGE}"
 podman push "${CATALOG_IMAGE}"
 echo "Catalog image ${CATALOG_IMAGE} pushed successfully"
-
-echo "Restoring files after running the script"
-restore


### PR DESCRIPTION
## Description

We were leaving the updated files in the system. This change will revert to the original template files after script is completed its run.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
