### PR TITLE
OLS-227: add E2E test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,8 +112,8 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: test
-test: manifests generate fmt vet envtest test-crds ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
+test: manifests generate fmt vet envtest test-crds ## Run local tests.
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./internal/... -coverprofile cover.out
 
 OS_CONSOLE_CRD_URL = https://raw.githubusercontent.com/openshift/api/master/operator/v1/zz_generated.crd-manifests/0000_50_console_01_consoles.crd.yaml
 OS_CONSOLE_PLUGIN_CRD_URL = https://raw.githubusercontent.com/openshift/api/master/console/v1/zz_generated.crd-manifests/90_consoleplugins.crd.yaml
@@ -133,6 +133,16 @@ $(OS_CONSOLE_CRD_FILE): $(TEST_CRD_DIR)
 $(OS_CONSOLE_PLUGIN_CRD_FILE): $(TEST_CRD_DIR)
 	wget -O $(OS_CONSOLE_PLUGIN_CRD_FILE) $(OS_CONSOLE_PLUGIN_CRD_URL)
 
+
+.PHONY: test-e2e
+test-e2e: ## Run e2e tests with an Openshift cluster. Requires KUBECONFIG and LLM_TOKEN environment variables.
+ifndef KUBECONFIG
+	$(error KUBECONFIG environment variable is not set)
+endif
+ifndef LLM_TOKEN
+	$(error LLM_TOKEN  environment variable is not set)
+endif
+	go test ./test/e2e  -ginkgo.v -ginkgo.progress -test.v
 
 .PHONY: lint
 lint: ## Run golangci-lint against code.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,9 @@ INFO:     Uvicorn running on http://0.0.0.0:8080 (Press CTRL+C to quit)
 ```
 
 #### Redis Secret Management
+
 By default redis server spins up with a randomly generated password located in the secret `lightspeed-redis-secret`. One can go edit password their password to a desired value to get it reflected across the system. In addition to that redis secret name can also be explicitly specified in cluster CR as shown in the below example.
+
 ```
 conversationCache:
   redis:
@@ -178,6 +180,78 @@ If you have updated the API definitions, you must update the CRD manifests with 
 
 ```shell
 make manifests
+```
+
+## Tests
+
+### Unit Tests
+
+To run the unit tests, we can run the following command
+
+```shell
+make test
+```
+
+When using Visual Studio Code, we can use the debugger settings below to execute the test in debug mode
+
+```json
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Integration test ",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "program": "${workspaceFolder}/internal/controller",
+            "args": [
+                // "--ginkgo.v", # verbose output from Ginkgo test framework
+            ],
+            "env": {
+                "KUBEBUILDER_ASSETS": "${workspaceFolder}/bin/k8s/1.27.1-linux-amd64"
+            },
+        },
+    ]
+}
+```
+
+### End to End tests
+
+To run the end to end tests with a Openshift cluster, we need to have a running operator in the namespace `openshift-lightspeed`.
+Please refer to the section [Running on the cluster](#running-on-the-cluster).
+Then we should set 2 environment variables:
+
+1. $KUBECONFIG - the path to the config file of kubenetes client
+2. $LLM_TOKEN - the access token given by the LLM provider, here we use OpenAI for testing.
+
+Then we can launch the end to end test by
+
+```shell
+make  test-e2e
+```
+
+When using Visual Studio Code, we can use the debugger settings below to execute the test in debug mode
+
+```json
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch E2E test ",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "program": "${workspaceFolder}/test/e2e",
+            "args": [
+                // "--ginkgo.v", # verbose output from Ginkgo test framework
+            ],
+            "env": {
+                "KUBECONFIG": "/path/to/kubeconfig",
+                "LLM_TOKEN": "sk-xxxxxxxx"
+            },
+        },
+    ]
+}
 ```
 
 **NOTE:** Run `make --help` for more information on all potential `make` targets

--- a/test/e2e/assets.go
+++ b/test/e2e/assets.go
@@ -1,0 +1,79 @@
+package e2e
+
+import (
+	"fmt"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	olsv1alpha1 "github.com/openshift/lightspeed-operator/api/v1alpha1"
+)
+
+func generateLLMTokenSecret(name string) (*corev1.Secret, error) { // nolint:unused
+	token := os.Getenv(LLMTokenEnvVar)
+	if token == "" {
+		return nil, fmt.Errorf("LLM token not found in $%s", LLMTokenEnvVar)
+	}
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: OLSNameSpace,
+		},
+		StringData: map[string]string{
+			LLMApiTokenFileName: token,
+		},
+	}, nil
+}
+
+func generateOLSConfig() (*olsv1alpha1.OLSConfig, error) { // nolint:unused
+	llmProvider := os.Getenv(LLMProviderEnvVar)
+	if llmProvider == "" {
+		llmProvider = LLMDefaultProvider
+	}
+	llmModel := os.Getenv(LLMModelEnvVar)
+	if llmModel == "" {
+		llmModel = OpenAIDefaultModel
+	}
+	replicas := int32(1)
+	maxMemory := intstr.Parse("100mb")
+	return &olsv1alpha1.OLSConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: OLSCRName,
+		},
+		Spec: olsv1alpha1.OLSConfigSpec{
+			LLMConfig: olsv1alpha1.LLMSpec{
+				Providers: []olsv1alpha1.ProviderSpec{
+					{
+						Name: llmProvider,
+						Models: []olsv1alpha1.ModelSpec{
+							{
+								Name: llmModel,
+							},
+						},
+						CredentialsSecretRef: corev1.LocalObjectReference{
+							Name: LLMTokenFirstSecretName,
+						},
+					},
+				},
+			},
+			OLSConfig: olsv1alpha1.OLSSpec{
+				ConversationCache: olsv1alpha1.ConversationCacheSpec{
+					Type: olsv1alpha1.Redis,
+					Redis: olsv1alpha1.RedisSpec{
+						MaxMemory:       &maxMemory,
+						MaxMemoryPolicy: "allkeys-lru",
+					},
+				},
+				DefaultModel:    llmModel,
+				DefaultProvider: llmProvider,
+				LogLevel:        "INFO",
+				DisableAuth:     true,
+				DeploymentConfig: olsv1alpha1.DeploymentConfig{
+					Replicas: &replicas,
+				},
+			},
+		},
+	}, nil
+}

--- a/test/e2e/client.go
+++ b/test/e2e/client.go
@@ -1,0 +1,262 @@
+package e2e
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	// DefaultTimeout is the default timeout for client operations
+	DefaultClientTimeout = 30 * time.Second
+	// DefaultPollInterval is the default interval for polling
+	DefaultPollInterval = 5 * time.Second
+	// DefaultPollTimeout is the default timeout for polling
+	DefaultPollTimeout = 5 * time.Minute
+)
+
+type Client struct {
+	kClient        client.Client
+	timeout        time.Duration
+	ctx            context.Context
+	kubeconfigPath string
+}
+
+var singletonClient *Client
+
+func GetClient() (*Client, error) {
+	if singletonClient != nil {
+		return singletonClient, nil
+	}
+
+	kubeconfigPath := os.Getenv("KUBECONFIG")
+	if kubeconfigPath == "" {
+		return nil, fmt.Errorf("KUBECONFIG environment variable not set")
+	}
+
+	// Get a Kubernetes rest config
+	cfg, err := config.GetConfig()
+	if err != nil {
+		fmt.Printf("Error getting config: %s\n", err)
+		return nil, err
+	}
+
+	// Create a new client
+	k8sClient, err := client.New(cfg, client.Options{})
+	if err != nil {
+		fmt.Printf("Error creating client: %s\n", err)
+		return nil, err
+	}
+	singletonClient = &Client{
+		kClient:        k8sClient,
+		timeout:        DefaultClientTimeout,
+		ctx:            context.Background(),
+		kubeconfigPath: kubeconfigPath,
+	}
+
+	return singletonClient, nil
+
+}
+
+func (c *Client) Create(o client.Object) (err error) {
+	ctx, cancel := context.WithTimeout(c.ctx, c.timeout)
+	defer cancel()
+
+	return c.kClient.Create(ctx, o)
+}
+
+func (c *Client) Get(o client.Object) (err error) {
+	ctx, cancel := context.WithTimeout(c.ctx, c.timeout)
+	defer cancel()
+	nsName := client.ObjectKeyFromObject(o)
+	return c.kClient.Get(ctx, nsName, o)
+}
+
+func (c *Client) Update(o client.Object) (err error) {
+	ctx, cancel := context.WithTimeout(c.ctx, c.timeout)
+	defer cancel()
+	return c.kClient.Update(ctx, o)
+}
+
+func (c *Client) Delete(o client.Object) (err error) {
+	ctx, cancel := context.WithTimeout(c.ctx, c.timeout)
+	defer cancel()
+	return c.kClient.Delete(ctx, o)
+}
+
+func (c *Client) List(o client.ObjectList, opts ...client.ListOption) (err error) {
+	ctx, cancel := context.WithTimeout(c.ctx, c.timeout)
+	defer cancel()
+	return c.kClient.List(ctx, o, opts...)
+}
+
+func (c *Client) WaitForDeploymentRollout(dep *appsv1.Deployment) error {
+	var lastErr error
+	err := wait.PollUntilContextTimeout(c.ctx, DefaultPollInterval, DefaultPollTimeout, true, func(ctx context.Context) (bool, error) {
+		err := c.Get(dep)
+		if err != nil {
+			lastErr = fmt.Errorf("failed to get Deployment: %w", err)
+			return false, nil
+		}
+		if dep.Generation > dep.Status.ObservedGeneration {
+			lastErr = fmt.Errorf("current generation %d, observed generation %d",
+				dep.Generation, dep.Status.ObservedGeneration)
+			return false, nil
+		}
+		if dep.Status.UpdatedReplicas != dep.Status.Replicas {
+			lastErr = fmt.Errorf("the number of replicas (%d) does not match the number of updated replicas (%d)",
+				dep.Status.Replicas, dep.Status.UpdatedReplicas)
+			return false, nil
+		}
+		if dep.Status.UnavailableReplicas != 0 {
+			lastErr = fmt.Errorf("got %d unavailable replicas",
+				dep.Status.UnavailableReplicas)
+			return false, nil
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("WaitForDeploymentRollout - waiting for rollout of the deployment %s/%s: %w ; last error: %w", dep.GetNamespace(), dep.GetName(), err, lastErr)
+	}
+
+	return nil
+}
+
+func (c *Client) WaitForConfigMapContainString(cm *corev1.ConfigMap, key, substr string) error {
+	var lastErr error
+	err := wait.PollUntilContextTimeout(c.ctx, DefaultPollInterval, DefaultPollTimeout, true, func(ctx context.Context) (bool, error) {
+		err := c.Get(cm)
+		if err != nil {
+			lastErr = fmt.Errorf("failed to get ConfigMap: %w", err)
+			return false, nil
+		}
+		filedata, ok := cm.Data[key]
+		if !ok {
+			lastErr = fmt.Errorf("key %q not found in ConfigMap", key)
+			return false, nil
+		}
+		if !strings.Contains(filedata, substr) {
+			lastErr = fmt.Errorf("substring \"%q\" not found in key %q of ConfigMap", substr, key)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("WaitForConfigMapContainString - waiting for the ConfigMap %s/%s containing the string \"\": %w ; last error: %w", cm.GetNamespace(), cm.GetName(), err, lastErr)
+	}
+
+	return nil
+}
+
+func (c *Client) WaitForServiceCreated(service *corev1.Service) error {
+	var lastErr error
+	err := wait.PollUntilContextTimeout(c.ctx, DefaultPollInterval, DefaultPollTimeout, true, func(ctx context.Context) (bool, error) {
+		err := c.Get(service)
+		if err != nil {
+			lastErr = fmt.Errorf("failed to get Service: %w", err)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("WaitForServiceCreated - waiting for the Service %s/%s to be created: %w ; last error: %w", service.GetNamespace(), service.GetName(), err, lastErr)
+	}
+
+	return nil
+}
+
+func (c *Client) WaitForSecretCreated(secret *corev1.Secret) error {
+	var lastErr error
+	err := wait.PollUntilContextTimeout(c.ctx, DefaultPollInterval, DefaultPollTimeout, true, func(ctx context.Context) (bool, error) {
+		err := c.Get(secret)
+		if err != nil {
+			lastErr = fmt.Errorf("failed to get Secret: %w", err)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("WaitForSecretCreated - waiting for the Secret %s/%s to be created: %w ; last error: %w", secret.GetNamespace(), secret.GetName(), err, lastErr)
+	}
+
+	return nil
+}
+
+func (c *Client) ForwardPort(serviceName, namespaceName string, port int) (string, func(), error) {
+
+	ctx, cancel := context.WithCancel(c.ctx)
+	// #nosec G204
+	cmd := exec.CommandContext(ctx, "oc", "port-forward", fmt.Sprintf("service/%s", serviceName), fmt.Sprintf(":%d", port), "-n", namespaceName, "--kubeconfig", c.kubeconfigPath)
+
+	cleanUp := func() {
+		cancel()
+		_ = cmd.Wait() // wait to clean up resources but ignore returned error since cancel kills the process
+	}
+
+	stdOut, err := cmd.StdoutPipe()
+	if err != nil {
+		cleanUp()
+		return "", nil, fmt.Errorf("fail to open stdout: %w", err)
+	}
+
+	stdErr, err := cmd.StderrPipe()
+	if err != nil {
+		cleanUp()
+		return "", nil, fmt.Errorf("fail to open stderr: %w", err)
+	}
+	go func() {
+		scanner := bufio.NewScanner(stdErr)
+		for scanner.Scan() {
+			logf.Log.Info(scanner.Text())
+		}
+		if err != nil {
+			logf.Log.Error(err, "scanner error", "stderr", scanner.Err())
+		}
+	}()
+
+	err = cmd.Start()
+	if err != nil {
+		cleanUp()
+		return "", nil, fmt.Errorf("fail to run command: %w", err)
+	}
+
+	scanner := bufio.NewScanner(stdOut)
+	if !scanner.Scan() {
+		err := scanner.Err()
+		if err == nil {
+			err = errors.New("got EOF")
+		}
+		cleanUp()
+		return "", nil, fmt.Errorf("fail to read stdout: %w", err)
+	}
+	output := scanner.Text()
+
+	re := regexp.MustCompile(`^Forwarding from [^:]+:(\d+)`)
+	matches := re.FindStringSubmatch(output)
+	if len(matches) != 2 {
+		cleanUp()
+		return "", nil, fmt.Errorf("fail to parse port's value: %q: %w", output, err)
+	}
+	_, err = strconv.Atoi(matches[1])
+	if err != nil {
+		cleanUp()
+		return "", nil, fmt.Errorf("fail to convert port's value: %q: %w", output, err)
+	}
+
+	return fmt.Sprintf("127.0.0.1:%s", matches[1]), cleanUp, nil
+}

--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -1,0 +1,46 @@
+package e2e
+
+const (
+	// OLSNameSpace is the namespace where the operator is deployed
+	OLSNameSpace = "openshift-lightspeed"
+	// OperatorDeploymentName is the name of the operator deployment
+	OperatorDeploymentName = "lightspeed-operator-controller-manager"
+	// LLMTokenEnvVar is the environment variable containing the LLM API token
+	LLMTokenEnvVar = "LLM_TOKEN"
+	// LLMTokenFirstSecretName is the name of the first secret containing the LLM API token
+	LLMTokenFirstSecretName = "llm-token-first" // #nosec G101
+	// LLMTokenSecondSecretName is the name of the second secret containing the LLM API token
+	LLMTokenSecondSecretName = "llm-token-second" // #nosec G101
+	// LLMApiTokenFileName
+	LLMApiTokenFileName = "apitoken"
+	// LLMDefaultProvider
+	LLMDefaultProvider = "openai"
+	// LLMProviderEnvVar is the environment variable containing the LLM provider
+	LLMProviderEnvVar = "LLM_PROVIDER"
+	// OpenAIDefaultModel is the default model to use
+	OpenAIDefaultModel = "gpt-3.5-turbo"
+	// OpenAIAlternativeModel is the alternative model to test model change
+	OpenAIAlternativeModel = "gpt-4-1106-preview"
+	// LLMModelEnvVar is the environment variable containing the LLM model
+	LLMModelEnvVar = "LLM_MODEL"
+	// OLSCRName is the name of the OLSConfig CR
+	OLSCRName = "cluster"
+	// AppServerDeploymentName is the name of the OLS application server deployment
+	AppServerDeploymentName = "lightspeed-app-server"
+	// AppServerServiceName is the name of the OLS application server service
+	AppServerServiceName = "lightspeed-app-server"
+	// AppServerServiceHTTPSPort is the port number of the OLS application server service
+	AppServerServiceHTTPSPort = 8443
+	// OLSConsolePluginDeploymentName is the name of the OLS console plugin deployment
+	OLSConsolePluginDeploymentName = "lightspeed-console-plugin"
+	// OLSConsolePluginServiceName is the name of the OLS console plugin service
+	OLSConsolePluginServiceName = "lightspeed-console-plugin"
+	// OLSConsolePluginServiceHTTPSPort is the port number of the OLS console plugin service
+	OLSConsolePluginServiceHTTPSPort = 9443
+	// AppServerConfigMapName is the name of the OLS application server config map
+	AppServerConfigMapName = "olsconfig"
+	// AppServerConfigMapKey is the key of config file in the OLS application server config map
+	AppServerConfigMapKey = "olsconfig.yaml"
+	// AppServerTLSSecretName is the name of the OLS application server TLS secret
+	AppServerTLSSecretName = "lightspeed-tls" // #nosec G101
+)

--- a/test/e2e/http_client.go
+++ b/test/e2e/http_client.go
@@ -1,0 +1,111 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+type HTTPSClient struct {
+	host       string
+	serverName string
+	caCertPool *x509.CertPool
+	ctx        context.Context
+}
+
+func NewHTTPSClient(host, serverName string, certificate []byte) *HTTPSClient {
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(certificate)
+	return &HTTPSClient{
+		host:       host,
+		serverName: serverName,
+		caCertPool: caCertPool,
+		ctx:        context.Background(),
+	}
+}
+
+func (c *HTTPSClient) Get(queryUrl string) (*http.Response, error) {
+	var rt http.RoundTripper = &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs:    c.caCertPool,
+			ServerName: c.serverName,
+			MinVersion: tls.VersionTLS12,
+		},
+	}
+	var resp *http.Response
+	u, err := url.Parse(queryUrl)
+	if err != nil {
+		return nil, err
+	}
+	u.Host = c.host
+	u.Scheme = "https"
+	var body []byte = make([]byte, 1024)
+	req, err := http.NewRequest(http.MethodGet, u.String(), bytes.NewBuffer(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Host = c.host
+	resp, err = (&http.Client{Transport: rt}).Do(req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (c *HTTPSClient) PostJson(queryUrl string, body []byte) (*http.Response, error) {
+	var rt http.RoundTripper = &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs:    c.caCertPool,
+			ServerName: c.serverName,
+			MinVersion: tls.VersionTLS12,
+		},
+	}
+	var resp *http.Response
+	u, err := url.Parse(queryUrl)
+	if err != nil {
+		return nil, err
+	}
+	u.Host = c.host
+	u.Scheme = "https"
+	req, err := http.NewRequest(http.MethodPost, u.String(), bytes.NewBuffer(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Host = c.host
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = (&http.Client{Transport: rt}).Do(req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (c *HTTPSClient) waitForHTTPSGetStatus(queryUrl string, statusCode int) error { // nolint:unused
+	var lastErr error
+	err := wait.PollUntilContextTimeout(c.ctx, DefaultPollInterval, DefaultPollTimeout, true, func(ctx context.Context) (bool, error) {
+		var resp *http.Response
+		resp, lastErr = c.Get(queryUrl)
+		if lastErr != nil {
+			return false, nil
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != statusCode {
+			lastErr = fmt.Errorf("unexpected status code %d", resp.StatusCode)
+			return false, nil
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to wait for HTTPS response status: %w, lastErr: %w", err, lastErr)
+	}
+
+	return nil
+}

--- a/test/e2e/reconciliation_test.go
+++ b/test/e2e/reconciliation_test.go
@@ -1,0 +1,217 @@
+package e2e
+
+import (
+	"path"
+	"slices"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	olsv1alpha1 "github.com/openshift/lightspeed-operator/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+var _ = Describe("Reconciliation From OLSConfig CR", Ordered, func() {
+	var cr *olsv1alpha1.OLSConfig
+	var err error
+	var client *Client
+
+	BeforeAll(func() {
+		client, err = GetClient()
+		Expect(err).NotTo(HaveOccurred())
+		By("Creating a OLSConfig CR")
+		cr, err = generateOLSConfig()
+		Expect(err).NotTo(HaveOccurred())
+		err = client.Create(cr)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterAll(func() {
+		client, err = GetClient()
+		Expect(err).NotTo(HaveOccurred())
+		By("Deleting the OLSConfig CR")
+		Expect(cr).NotTo(BeNil())
+		err = client.Delete(cr)
+		Expect(err).NotTo(HaveOccurred())
+
+	})
+
+	It("should setup application server", func() {
+
+		By("make application server deployment running")
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      AppServerDeploymentName,
+				Namespace: OLSNameSpace,
+			},
+		}
+		err = client.WaitForDeploymentRollout(deployment)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("exposing its HTTPS port in a service")
+		service := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      AppServerServiceName,
+				Namespace: OLSNameSpace,
+			},
+		}
+		err = client.Get(service)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(service.Spec.Ports).To(ContainElement(corev1.ServicePort{
+			Name:       "https",
+			Protocol:   corev1.ProtocolTCP,
+			Port:       AppServerServiceHTTPSPort,
+			TargetPort: intstr.FromString("https"),
+		}))
+
+	})
+
+	It("should setup console plugin", func() {
+
+		By("make console plugin deployment running")
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      OLSConsolePluginDeploymentName,
+				Namespace: OLSNameSpace,
+			},
+		}
+		err = client.WaitForDeploymentRollout(deployment)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("exposing its HTTPS port in a service")
+		service := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      OLSConsolePluginServiceName,
+				Namespace: OLSNameSpace,
+			},
+		}
+		err = client.Get(service)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(service.Spec.Ports).To(ContainElement(corev1.ServicePort{
+			Name:       "https",
+			Protocol:   corev1.ProtocolTCP,
+			Port:       OLSConsolePluginServiceHTTPSPort,
+			TargetPort: intstr.FromString("https"),
+		}))
+	})
+
+	It("should setup a cache", func() {
+		// todo: implement this test after replacing redis with other solution
+	})
+
+	It("should reconcile app deployment after changing deployment settings", func() {
+
+		By("update the replica number in the OLSConfig CR")
+		err = client.Get(cr)
+		Expect(err).NotTo(HaveOccurred())
+		*cr.Spec.OLSConfig.DeploymentConfig.Replicas = *cr.Spec.OLSConfig.DeploymentConfig.Replicas + 1
+		err = client.Update(cr)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("check the replica number of the deployment that should be updated")
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      AppServerDeploymentName,
+				Namespace: OLSNameSpace,
+			},
+		}
+		err = client.WaitForDeploymentRollout(deployment)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(*deployment.Spec.Replicas).To(Equal(*cr.Spec.OLSConfig.DeploymentConfig.Replicas))
+
+	})
+
+	It("should reconcile app configmap after changing application settings", func() {
+		By("fetch the app deployment generation")
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      AppServerDeploymentName,
+				Namespace: OLSNameSpace,
+			},
+		}
+		err = client.Get(deployment)
+		Expect(err).NotTo(HaveOccurred())
+		generation := deployment.Generation
+
+		By("update LogLevel in the OLSConfig CR")
+		err = client.Get(cr)
+		Expect(err).NotTo(HaveOccurred())
+		if cr.Spec.OLSConfig.LogLevel == "DEBUG" {
+			cr.Spec.OLSConfig.LogLevel = "INFO"
+		} else {
+			cr.Spec.OLSConfig.LogLevel = "DEBUG"
+		}
+		err = client.Update(cr)
+		Expect(err).NotTo(HaveOccurred())
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      AppServerConfigMapName,
+				Namespace: OLSNameSpace,
+			},
+		}
+
+		By("wait for the app configmap to be updated")
+		err = client.WaitForConfigMapContainString(configMap, AppServerConfigMapKey, "app_log_level: "+cr.Spec.OLSConfig.LogLevel)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("check the app deployment generation that should be inscreased")
+		err = client.WaitForDeploymentRollout(deployment)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deployment.Generation).To(BeNumerically(">", generation))
+		generation = deployment.Generation
+
+		By("update models in the OLSConfig CR")
+		cr.Spec.OLSConfig.DefaultModel = OpenAIAlternativeModel
+		if !slices.Contains(cr.Spec.LLMConfig.Providers[0].Models, olsv1alpha1.ModelSpec{Name: OpenAIAlternativeModel}) {
+			cr.Spec.LLMConfig.Providers[0].Models = append(cr.Spec.LLMConfig.Providers[0].Models, olsv1alpha1.ModelSpec{Name: OpenAIAlternativeModel})
+		}
+
+		err = client.Update(cr)
+		Expect(err).NotTo(HaveOccurred())
+		By("wait for the app configmap to be updated")
+		configMap = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      AppServerConfigMapName,
+				Namespace: OLSNameSpace,
+			},
+		}
+		err = client.WaitForConfigMapContainString(configMap, AppServerConfigMapKey, "default_model: "+OpenAIAlternativeModel)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("check the app deployment generation that should be inscreased")
+		err = client.WaitForDeploymentRollout(deployment)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deployment.Generation).To(BeNumerically(">", generation))
+		generation = deployment.Generation
+
+		By("change LLM token secret reference")
+		cr.Spec.LLMConfig.Providers[0].CredentialsSecretRef.Name = LLMTokenSecondSecretName
+		err = client.Update(cr)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("check the app deployment generation that should be inscreased")
+		err = client.WaitForDeploymentRollout(deployment)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deployment.Generation).To(BeNumerically(">", generation))
+
+		By("check the app configmap to contain the new secret volume")
+		err = client.WaitForConfigMapContainString(configMap, AppServerConfigMapKey, path.Join("/etc/apikeys", LLMTokenSecondSecretName))
+		Expect(err).NotTo(HaveOccurred())
+
+		By("check the deployment to mounted the new secret volume")
+		var secretVolumeDefaultMode = int32(420)
+		Expect(deployment.Spec.Template.Spec.Volumes).To(ContainElement(corev1.Volume{
+			Name: "secret-" + LLMTokenSecondSecretName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  LLMTokenSecondSecretName,
+					DefaultMode: &secretVolumeDefaultMode,
+				},
+			},
+		}))
+
+	})
+
+})

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -1,0 +1,96 @@
+package e2e
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	olsv1alpha1 "github.com/openshift/lightspeed-operator/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "End-to-End Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	err := olsv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	client, err := GetClient()
+	if err != nil {
+		Fail("Failed to create client")
+	}
+
+	By("Check the operator is ready")
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      OperatorDeploymentName,
+			Namespace: OLSNameSpace,
+		},
+	}
+	err = client.WaitForDeploymentRollout(deployment)
+	if err != nil && errors.IsNotFound(err) {
+		Fail("Operator deployment not found")
+	} else {
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	By("Create 2 LLM token secrets")
+	secret, err := generateLLMTokenSecret(LLMTokenFirstSecretName)
+	Expect(err).NotTo(HaveOccurred())
+	err = client.Create(secret)
+	if errors.IsAlreadyExists(err) {
+		err = client.Update(secret)
+	}
+	Expect(err).NotTo(HaveOccurred())
+
+	secret, err = generateLLMTokenSecret(LLMTokenSecondSecretName)
+	Expect(err).NotTo(HaveOccurred())
+	err = client.Create(secret)
+	if errors.IsAlreadyExists(err) {
+		err = client.Update(secret)
+	}
+	Expect(err).NotTo(HaveOccurred())
+
+})
+
+var _ = AfterSuite(func() {
+	client, err := GetClient()
+	if err != nil {
+		Fail("Failed to create client")
+	}
+
+	By("Delete the 2 LLM token Secrets")
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      LLMTokenFirstSecretName,
+			Namespace: OLSNameSpace,
+		},
+	}
+	err = client.Delete(secret)
+	if !errors.IsNotFound(err) {
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	secret = &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      LLMTokenSecondSecretName,
+			Namespace: OLSNameSpace,
+		},
+	}
+	err = client.Delete(secret)
+	if !errors.IsNotFound(err) {
+		Expect(err).NotTo(HaveOccurred())
+	}
+})

--- a/test/e2e/tls_test.go
+++ b/test/e2e/tls_test.go
@@ -1,0 +1,130 @@
+package e2e
+
+import (
+	"io"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	olsv1alpha1 "github.com/openshift/lightspeed-operator/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("TLS activation", Ordered, func() {
+	const serviceAnnotationKeyTLSSecret = "service.beta.openshift.io/serving-cert-secret-name"
+	var cr *olsv1alpha1.OLSConfig
+	var err error
+	var client *Client
+	var cleanUpFuncs []func()
+	var forwardHost string
+
+	BeforeAll(func() {
+		client, err = GetClient()
+		Expect(err).NotTo(HaveOccurred())
+		By("Creating a OLSConfig CR")
+		cr, err = generateOLSConfig()
+		Expect(err).NotTo(HaveOccurred())
+		err = client.Create(cr)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("wait for application server deployment rollout")
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      AppServerDeploymentName,
+				Namespace: OLSNameSpace,
+			},
+		}
+		err = client.WaitForDeploymentRollout(deployment)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("forwarding the HTTPS port to a local port")
+		var cleanUp func()
+		forwardHost, cleanUp, err = client.ForwardPort(AppServerServiceName, OLSNameSpace, AppServerServiceHTTPSPort)
+		Expect(err).NotTo(HaveOccurred())
+		cleanUpFuncs = append(cleanUpFuncs, cleanUp)
+
+	})
+
+	AfterAll(func() {
+		for _, cleanUp := range cleanUpFuncs {
+			cleanUp()
+		}
+
+		client, err = GetClient()
+		Expect(err).NotTo(HaveOccurred())
+		By("Deleting the OLSConfig CR")
+		Expect(cr).NotTo(BeNil())
+		err = client.Delete(cr)
+		Expect(err).NotTo(HaveOccurred())
+
+	})
+
+	It("should activate TLS on service HTTPS port", func() {
+
+		By("Wait for the application service created")
+		service := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      AppServerServiceName,
+				Namespace: OLSNameSpace,
+			},
+		}
+		err = client.WaitForServiceCreated(service)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("check the secret holding TLS ceritificates is created")
+		secretName, ok := service.ObjectMeta.Annotations[serviceAnnotationKeyTLSSecret]
+		Expect(ok).To(BeTrue())
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: OLSNameSpace,
+			},
+		}
+		err = client.WaitForSecretCreated(secret)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("check the deployment has the certificate secret mounted")
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      AppServerDeploymentName,
+				Namespace: OLSNameSpace,
+			},
+		}
+		err = client.Get(deployment)
+		Expect(err).NotTo(HaveOccurred())
+		var secretVolumeDefaultMode = int32(420)
+		Expect(deployment.Spec.Template.Spec.Volumes).To(ContainElement(corev1.Volume{
+			Name: "secret-" + AppServerTLSSecretName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  secretName,
+					DefaultMode: &secretVolumeDefaultMode,
+				},
+			},
+		}))
+
+		By("check HTTPS Get on /metrics endpoint")
+		const inClusterHost = "lightspeed-app-server.openshift-lightspeed.svc.cluster.local"
+		certificate, ok := secret.Data["tls.crt"]
+		Expect(ok).To(BeTrue())
+
+		httpsClient := NewHTTPSClient(forwardHost, inClusterHost, certificate)
+
+		err = httpsClient.waitForHTTPSGetStatus("/metrics", http.StatusOK)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("check HTTPS Post on /v1/query endpoint")
+		reqBody := []byte(`{"query": "write a deployment yaml for the mongodb image"}`)
+		var resp *http.Response
+		resp, err = httpsClient.PostJson("/v1/query", reqBody)
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		body, err := io.ReadAll(resp.Body)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(body).NotTo(BeEmpty())
+
+	})
+})


### PR DESCRIPTION
## Description

End to end tests consist of reconciliation test and the TLS settings verification.

Please have a look on this [PR on liveness and readiness probes](https://github.com/openshift/lightspeed-operator/pull/61), too. The retry of portforwarding in TLS tests can be reduced to a single forward in the test setup if we have the readiness probe.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes # [OLS-227](https://issues.redhat.com//browse/OLS-227)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
1. Have a running Openshift cluster.
2. Run the operator `make deploy`
3. Set these 2 environment variables:
    - $KUBECONFIG - the path to the config file of kubenetes client
    - $LLM_TOKEN - the access token given by the LLM provider, here we use OpenAI for testing.
4. run the e2e test `make test-e2e` 

The output should looks like this 
```shell
➜  lightspeed-operator git:(e2e-test) ✗ make test-e2e
go test ./test/e2e  -ginkgo.v -ginkgo.progress -test.v
=== RUN   TestE2E
Running Suite: End-to-End Suite - /home/hsun/lightspeed-operator/test/e2e
=========================================================================
Random Seed: 1711531851

Will run 6 of 6 specs
------------------------------
[BeforeSuite]
/home/hsun/lightspeed-operator/test/e2e/suite_test.go:24
  STEP: Check the operator is ready @ 03/27/24 10:30:51.107
  STEP: Create 2 LLM token secrets @ 03/27/24 10:30:51.533
[BeforeSuite] PASSED [0.724 seconds]
------------------------------
TLS activation should activate TLS on service HTTPS port
/home/hsun/lightspeed-operator/test/e2e/tls_test.go:47
  STEP: Creating a OLSConfig CR @ 03/27/24 10:30:51.83
  STEP: wait for application server deployment rollout @ 03/27/24 10:30:52.03
  STEP: Wait for the application service created @ 03/27/24 10:30:57.126
  STEP: check the secret holding TLS ceritificates is created @ 03/27/24 10:30:57.221
  STEP: check the deploy has the certificate secret mounted @ 03/27/24 10:30:57.316
  STEP: check HTTPS connection on forwarded port @ 03/27/24 10:30:57.316
  STEP: Forward the HTTPS port to a local port @ 03/27/24 10:30:57.316
  STEP: send HTTPS request to forwared port @ 03/27/24 10:30:58.34
  2024-03-27T10:30:58+01:00     INFO    E0327 10:30:58.534694  105258 portforward.go:409] an error occurred forwarding 33075 -> 8443: error forwarding port 8443 to pod e43054f3493d37acc3395ef58ae95543c22b07093044029757c5f344895954d1, uid : port forward into network namespace "/var/run/netns/f036d519-9f05-4d8c-98f3-2e95fd7cda41": failed to connect to localhost:8443 inside namespace e43054f3493d37acc3395ef58ae95543c22b07093044029757c5f344895954d1: dial tcp [::1]:8443: connect: connection refused
  2024-03-27T10:30:58+01:00     INFO    error: lost connection to pod
  STEP: Forward the HTTPS port to a local port @ 03/27/24 10:31:02.319
  STEP: send HTTPS request to forwared port @ 03/27/24 10:31:03.358
  2024-03-27T10:31:03+01:00     INFO    E0327 10:31:03.550317  105381 portforward.go:409] an error occurred forwarding 33319 -> 8443: error forwarding port 8443 to pod e43054f3493d37acc3395ef58ae95543c22b07093044029757c5f344895954d1, uid : port forward into network namespace "/var/run/netns/f036d519-9f05-4d8c-98f3-2e95fd7cda41": failed to connect to localhost:8443 inside namespace e43054f3493d37acc3395ef58ae95543c22b07093044029757c5f344895954d1: dial tcp [::1]:8443: connect: connection refused
  2024-03-27T10:31:03+01:00     INFO    error: lost connection to pod
  STEP: Forward the HTTPS port to a local port @ 03/27/24 10:31:07.32
  STEP: send HTTPS request to forwared port @ 03/27/24 10:31:08.363
  2024-03-27T10:31:08+01:00     INFO    E0327 10:31:08.557925  105480 portforward.go:409] an error occurred forwarding 45261 -> 8443: error forwarding port 8443 to pod e43054f3493d37acc3395ef58ae95543c22b07093044029757c5f344895954d1, uid : port forward into network namespace "/var/run/netns/f036d519-9f05-4d8c-98f3-2e95fd7cda41": failed to connect to localhost:8443 inside namespace e43054f3493d37acc3395ef58ae95543c22b07093044029757c5f344895954d1: dial tcp [::1]:8443: connect: connection refused
  2024-03-27T10:31:08+01:00     INFO    error: lost connection to pod
  STEP: Forward the HTTPS port to a local port @ 03/27/24 10:31:12.32
  STEP: send HTTPS request to forwared port @ 03/27/24 10:31:13.327
  2024-03-27T10:31:13+01:00     INFO    E0327 10:31:13.523750  105550 portforward.go:409] an error occurred forwarding 41221 -> 8443: error forwarding port 8443 to pod e43054f3493d37acc3395ef58ae95543c22b07093044029757c5f344895954d1, uid : port forward into network namespace "/var/run/netns/f036d519-9f05-4d8c-98f3-2e95fd7cda41": failed to connect to localhost:8443 inside namespace e43054f3493d37acc3395ef58ae95543c22b07093044029757c5f344895954d1: dial tcp [::1]:8443: connect: connection refused
  2024-03-27T10:31:13+01:00     INFO    error: lost connection to pod
  STEP: Forward the HTTPS port to a local port @ 03/27/24 10:31:17.32
  STEP: send HTTPS request to forwared port @ 03/27/24 10:31:18.336
  2024-03-27T10:31:18+01:00     INFO    E0327 10:31:18.527997  105614 portforward.go:409] an error occurred forwarding 46655 -> 8443: error forwarding port 8443 to pod e43054f3493d37acc3395ef58ae95543c22b07093044029757c5f344895954d1, uid : port forward into network namespace "/var/run/netns/f036d519-9f05-4d8c-98f3-2e95fd7cda41": failed to connect to localhost:8443 inside namespace e43054f3493d37acc3395ef58ae95543c22b07093044029757c5f344895954d1: dial tcp [::1]:8443: connect: connection refused
  2024-03-27T10:31:18+01:00     INFO    error: lost connection to pod
  STEP: Forward the HTTPS port to a local port @ 03/27/24 10:31:22.317
  STEP: send HTTPS request to forwared port @ 03/27/24 10:31:23.342
  2024-03-27T10:31:23+01:00     INFO    E0327 10:31:23.536492  105733 portforward.go:409] an error occurred forwarding 41177 -> 8443: error forwarding port 8443 to pod e43054f3493d37acc3395ef58ae95543c22b07093044029757c5f344895954d1, uid : port forward into network namespace "/var/run/netns/f036d519-9f05-4d8c-98f3-2e95fd7cda41": failed to connect to localhost:8443 inside namespace e43054f3493d37acc3395ef58ae95543c22b07093044029757c5f344895954d1: dial tcp [::1]:8443: connect: connection refused
  2024-03-27T10:31:23+01:00     INFO    error: lost connection to pod
  STEP: Forward the HTTPS port to a local port @ 03/27/24 10:31:27.32
  STEP: send HTTPS request to forwared port @ 03/27/24 10:31:28.348
  2024-03-27T10:31:28+01:00     INFO    E0327 10:31:28.546397  105803 portforward.go:409] an error occurred forwarding 40359 -> 8443: error forwarding port 8443 to pod d9e07af5d6511c680a79e2c71ab7f1f600d554742837b3e6445b17cb9a4d5de2, uid : port forward into network namespace "/var/run/netns/820e2497-9842-493e-bd0b-6503152a80eb": failed to connect to localhost:8443 inside namespace d9e07af5d6511c680a79e2c71ab7f1f600d554742837b3e6445b17cb9a4d5de2: dial tcp [::1]:8443: connect: connection refused
  2024-03-27T10:31:28+01:00     INFO    error: lost connection to pod
  STEP: Forward the HTTPS port to a local port @ 03/27/24 10:31:32.32
  STEP: send HTTPS request to forwared port @ 03/27/24 10:31:33.235
  STEP: Deleting the OLSConfig CR @ 03/27/24 10:31:33.652
• [41.921 seconds]
------------------------------
Reconciliation From OLSConfig CR should setup application server
/home/hsun/lightspeed-operator/test/e2e/reconciliation_test.go:41
  STEP: Creating a OLSConfig CR @ 03/27/24 10:31:33.751
  STEP: make application server deployment running @ 03/27/24 10:31:33.856
  STEP: exposing its HTTPS port in a service @ 03/27/24 10:31:38.953
• [5.301 seconds]
------------------------------
Reconciliation From OLSConfig CR should setup console plugin
/home/hsun/lightspeed-operator/test/e2e/reconciliation_test.go:71
  STEP: make console plugin deployment running @ 03/27/24 10:31:39.052
  STEP: exposing its HTTPS port in a service @ 03/27/24 10:31:39.149
• [0.204 seconds]
------------------------------
Reconciliation From OLSConfig CR should setup a cache
/home/hsun/lightspeed-operator/test/e2e/reconciliation_test.go:100
• [0.000 seconds]
------------------------------
Reconciliation From OLSConfig CR should reconcile app deployment after changing deployment settings
/home/hsun/lightspeed-operator/test/e2e/reconciliation_test.go:104
  STEP: update the replica number in the OLSConfig CR @ 03/27/24 10:31:39.256
  STEP: check the replica number of the deployment that should be updated @ 03/27/24 10:31:39.361
• [5.222 seconds]
------------------------------
Reconciliation From OLSConfig CR should reconcile app configmap after changing application settings
/home/hsun/lightspeed-operator/test/e2e/reconciliation_test.go:124
  STEP: fetch the app deployment generation @ 03/27/24 10:31:44.478
  STEP: update LogLevel in the OLSConfig CR @ 03/27/24 10:31:44.574
  STEP: wait for the app configmap to be updated @ 03/27/24 10:31:44.674
  STEP: check the app deployment generation that should be inscreased @ 03/27/24 10:31:44.781
  STEP: update models in the OLSConfig CR @ 03/27/24 10:32:04.882
  STEP: wait for the app configmap to be updated @ 03/27/24 10:32:04.985
  STEP: check the app deployment generation that should be inscreased @ 03/27/24 10:32:05.081
  STEP: change LLM token secret reference @ 03/27/24 10:32:15.187
  STEP: check the app deployment generation that should be inscreased @ 03/27/24 10:32:15.286
  STEP: check the app configmap to contain the new secret volume @ 03/27/24 10:32:25.385
  STEP: check the deployment to mounted the new secret volume @ 03/27/24 10:32:25.498
  STEP: Deleting the OLSConfig CR @ 03/27/24 10:32:25.498
• [41.122 seconds]
------------------------------
[AfterSuite]
/home/hsun/lightspeed-operator/test/e2e/suite_test.go:68
  STEP: Delete the 2 LLM token Secrets @ 03/27/24 10:32:25.6
[AfterSuite] PASSED [0.199 seconds]
------------------------------

Ran 6 of 6 Specs in 94.693 seconds
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 0 Skipped
You're using deprecated Ginkgo functionality:
=============================================
  --ginkgo.progress is deprecated .  The functionality provided by --progress was confusing and is no longer needed.  Use --show-node-events instead to see node entry and exit events included in the timeline of failed and verbose specs.  Or you can run with -vv to always see all node events.  Lastly, --poll-progress-after and the PollProgressAfter decorator now provide a better mechanism for debugging specs that tend to get stuck.

To silence deprecations that can be silenced set the following environment variable:
  ACK_GINKGO_DEPRECATIONS=2.13.0

--- PASS: TestE2E (94.69s)
PASS
ok      github.com/openshift/lightspeed-operator/test/e2e       94.703s
```
