### PR TITLE
add liveness and readiness probe to application server deployment

### DIFF
--- a/internal/controller/ols_app_server_assets_test.go
+++ b/internal/controller/ols_app_server_assets_test.go
@@ -402,6 +402,12 @@ ols_config:
 				},
 			}))
 			Expect(dep.Spec.Selector.MatchLabels).To(Equal(generateAppServerSelectorLabels()))
+			Expect(dep.Spec.Template.Spec.Containers[0].LivenessProbe).ToNot(BeNil())
+			Expect(dep.Spec.Template.Spec.Containers[0].LivenessProbe.HTTPGet.Port).To(Equal(intstr.FromString("https")))
+			Expect(dep.Spec.Template.Spec.Containers[0].LivenessProbe.HTTPGet.Path).To(Equal("/liveness"))
+			Expect(dep.Spec.Template.Spec.Containers[0].ReadinessProbe).ToNot(BeNil())
+			Expect(dep.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Port).To(Equal(intstr.FromString("https")))
+			Expect(dep.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Path).To(Equal("/readiness"))
 		})
 	})
 })

--- a/internal/controller/ols_app_server_deployment.go
+++ b/internal/controller/ols_app_server_deployment.go
@@ -8,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	olsv1alpha1 "github.com/openshift/lightspeed-operator/api/v1alpha1"
@@ -155,6 +156,28 @@ func (r *OLSConfigReconciler) generateOLSDeployment(cr *olsv1alpha1.OLSConfig) (
 								},
 							},
 							Resources: *resources,
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path:   "/readiness",
+										Port:   intstr.FromString("https"),
+										Scheme: corev1.URISchemeHTTPS,
+									},
+								},
+								InitialDelaySeconds: 60,
+								PeriodSeconds:       10,
+							},
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path:   "/liveness",
+										Port:   intstr.FromString("https"),
+										Scheme: corev1.URISchemeHTTPS,
+									},
+								},
+								InitialDelaySeconds: 60,
+								PeriodSeconds:       10,
+							},
 						},
 					},
 					Volumes:            volumes,


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

both endpoints are called periodically
```log
2024-03-27 10:45:46,355 [__main__:runner.py:49] INFO: Config loaded from /etc/ols/..2024_03_27_10_44_49.3941281926/olsconfig.yaml
2024-03-27 10:45:46,355 [ols.src.rag_index.index_loader:index_loader.py:53] WARNING: Embedding model path is not set.
2024-03-27 10:45:46,355 [ols.src.rag_index.index_loader:index_loader.py:54] WARNING: Embedding model is set to default
2024-03-27 10:45:46,355 [ols.src.rag_index.index_loader:index_loader.py:73] WARNING: Index path is not set.
2024-03-27 10:45:46,355 [ols.src.rag_index.index_loader:index_loader.py:91] WARNING: Proceeding without RAG content. Either there is an error or required parameters are not set.
/usr/local/lib/python3.11/site-packages/genai/text/generation/__init__.py:13: DeprecationWarning: Deprecated import of TextGenerationParameters from module genai.text.generation. Please use `from genai.schema import TextGenerationParameters`.
return _deprecated_schema_import(name, __name__)
/usr/local/lib/python3.11/site-packages/ibm_watson_machine_learning/foundation_models/extensions/langchain/llm.py:60: WatsonxLLMDeprecationWarning: ibm_watson_machine_learning.foundation_models.extensions.langchain.WatsonxLLM is deprecated and will not be supported in the future. Please import from langchain-ibm instead.
To install langchain-ibm run `pip install -U langchain-ibm`.
_raise_watsonxllm_deprecation_warning()
2024-03-27 10:46:05,515 [matplotlib.font_manager:font_manager.py:1578] INFO: generated new fontManager
2024-03-27 10:46:08,744 [ols.app.main:main.py:27] INFO: Embedded Gradio UI is disabled. To enable set `enable_dev_ui: true` in the `dev_config` section of the configuration file.
INFO: Started server process [1]
INFO: Waiting for application startup.
INFO: Application startup complete.
INFO: Uvicorn running on https://0.0.0.0:8443 (Press CTRL+C to quit)
INFO: 10.132.0.2:37250 - "GET /readiness HTTP/1.1" 200 OK
INFO: 10.132.0.2:37234 - "GET /liveness HTTP/1.1" 200 OK
INFO: 10.132.0.2:51496 - "GET /readiness HTTP/1.1" 200 OK
INFO: 10.132.0.2:51498 - "GET /liveness HTTP/1.1" 200 OK
INFO: 10.132.0.2:54408 - "GET /readiness HTTP/1.1" 200 OK
```
