### PR TITLE
OLS-252: Ensure that OLS supports cluster-wide HTTP/HTTPS proxy

### DIFF
--- a/internal/controller/ols_app_server_assets.go
+++ b/internal/controller/ols_app_server_assets.go
@@ -6,7 +6,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	v1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -44,7 +43,7 @@ func (r *OLSConfigReconciler) generateSARClusterRole(cr *olsv1alpha1.OLSConfig) 
 		ObjectMeta: metav1.ObjectMeta{
 			Name: OLSAppServerSARRoleName,
 		},
-		Rules: []v1.PolicyRule{
+		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{"authorization.k8s.io"},
 				Resources: []string{"subjectaccessreviews"},
@@ -65,14 +64,14 @@ func (r *OLSConfigReconciler) generateSARClusterRoleBinding(cr *olsv1alpha1.OLSC
 		ObjectMeta: metav1.ObjectMeta{
 			Name: OLSAppServerSARRoleBindingName,
 		},
-		Subjects: []v1.Subject{
+		Subjects: []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
 				Name:      OLSAppServerServiceAccountName,
 				Namespace: r.Options.Namespace,
 			},
 		},
-		RoleRef: v1.RoleRef{
+		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "ClusterRole",
 			Name:     OLSAppServerSARRoleName,

--- a/internal/controller/ols_app_server_deployment.go
+++ b/internal/controller/ols_app_server_deployment.go
@@ -154,12 +154,10 @@ func (r *OLSConfigReconciler) generateOLSDeployment(cr *olsv1alpha1.OLSConfig) (
 								AllowPrivilegeEscalation: &[]bool{false}[0],
 							},
 							VolumeMounts: volumeMounts,
-							Env: []corev1.EnvVar{
-								{
-									Name:  "OLS_CONFIG_FILE",
-									Value: path.Join(OLSConfigMountPath, OLSConfigFilename),
-								},
-							},
+							Env: append(getProxyEnvVars(), corev1.EnvVar{
+								Name:  "OLS_CONFIG_FILE",
+								Value: path.Join(OLSConfigMountPath, OLSConfigFilename),
+							}),
 							Resources: *resources,
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{

--- a/internal/controller/ols_console_ui_assets.go
+++ b/internal/controller/ols_console_ui_assets.go
@@ -118,6 +118,7 @@ func (r *OLSConfigReconciler) generateConsoleUIDeployment(cr *olsv1alpha1.OLSCon
 								},
 							},
 							ImagePullPolicy: corev1.PullIfNotPresent,
+							Env:             getProxyEnvVars(),
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("10m"),

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -3,6 +3,8 @@ package controller
 import (
 	"crypto/sha256"
 	"fmt"
+	"os"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -284,4 +286,17 @@ func SetDefaults_Deployment(obj *appsv1.Deployment) {
 		obj.Spec.ProgressDeadlineSeconds = new(int32)
 		*obj.Spec.ProgressDeadlineSeconds = 600
 	}
+}
+
+func getProxyEnvVars() []corev1.EnvVar {
+	envVars := []corev1.EnvVar{}
+	for _, envvar := range []string{"HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "NO_PROXY", "no_proxy"} {
+		if value := os.Getenv(envvar); value != "" {
+			envVars = append(envVars, corev1.EnvVar{
+				Name:  strings.ToLower(envvar),
+				Value: value,
+			})
+		}
+	}
+	return envVars
 }


### PR DESCRIPTION
## Description

Make the operator pass the http[s]_proxy, etc environment variables that the OLM sets up for it to the operands: the OLS and the console server.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes # https://issues.redhat.com/browse/OLS-252

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
