### PR TITLE
feat: Add waitForSecret function to wait for the creation of a secret

### DIFF
--- a/internal/controller/ols_app_server_reconciliator.go
+++ b/internal/controller/ols_app_server_reconciliator.go
@@ -169,6 +169,11 @@ func (r *OLSConfigReconciler) reconcileSARRoleBinding(ctx context.Context, cr *o
 }
 
 func (r *OLSConfigReconciler) reconcileDeployment(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
+	// Wait for the TLS secret to be created before proceeding with the deployment.
+	if err := r.waitForSecret(ctx, OLSCertsSecretName); err != nil {
+		return fmt.Errorf("failed to get %s secret: %w", OLSCertsSecretName, err)
+	}
+
 	desiredDeployment, err := r.generateOLSDeployment(cr)
 	if err != nil {
 		return fmt.Errorf("failed to generate OLS deployment: %w", err)


### PR DESCRIPTION
## Description

The function waits for the specified Kubernetes secret to be created before the timeout expires. 
When using [service serving] (https://docs.openshift.com/container-platform/4.15/security/certificates/service-serving-certificate.html) certificate secrets, we must be sure that the secret exists before creating the deployment.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
