### PR TITLE
OLS-444: add a clusterrole to allow user access OLS API endpoint

### DIFF
--- a/bundle/manifests/lightspeed-operator-query-access_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/lightspeed-operator-query-access_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: user-access
+    app.kubernetes.io/created-by: lightspeed-operator
+    app.kubernetes.io/instance: query-access
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: lightspeed-operator
+  name: lightspeed-operator-query-access
+rules:
+- nonResourceURLs:
+  - /ols-access
+  verbs:
+  - get

--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-04-03T03:27:50Z"
+    createdAt: "2024-04-05T08:25:31Z"
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-lightspeed
     operators.operatorframework.io/builder: operator-sdk-v1.33.0

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
 - ../crd
 - ../rbac
 - ../manager
+- ../user-access
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook

--- a/config/user-access/kustomization.yaml
+++ b/config/user-access/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  # this clusterrole is used by users to query the OLS API endpoint
+  - query_access_clusterrole.yaml

--- a/config/user-access/query_access_clusterrole.yaml
+++ b/config/user-access/query_access_clusterrole.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: query-access
+    app.kubernetes.io/component: user-access
+    app.kubernetes.io/created-by: lightspeed-operator
+    app.kubernetes.io/part-of: lightspeed-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: query-access
+rules:
+  - nonResourceURLs:
+      - "/ols-access"
+    verbs:
+      - "get"


### PR DESCRIPTION
## Description

This PR adds a clusterrole to allow non-admin user access OLS API endpoint.
This PR resolves half of the ticket [OLS-444](https://issues.redhat.com/browse/OLS-444). The other half of the ticket is resoved by [PR#75](https://github.com/openshift/lightspeed-operator/pull/75), by granting the service account running OLS app server the permission to create token reviews and subjectaccess reviews. 

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # [OLS-444](https://issues.redhat.com//browse/OLS-444)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
