### PR TITLE
fix: update reconcile logic to avoid repeated reconcile restarts

### DIFF
--- a/internal/controller/ols_app_server_assets_test.go
+++ b/internal/controller/ols_app_server_assets_test.go
@@ -23,6 +23,7 @@ var _ = Describe("App server assets", func() {
 	var r *OLSConfigReconciler
 	var rOptions *OLSConfigReconcilerOptions
 	var secret *corev1.Secret
+	defaultVolumeMode := int32(420)
 	Context("complete custom resource", func() {
 		BeforeEach(func() {
 			rOptions = &OLSConfigReconcilerOptions{
@@ -199,7 +200,8 @@ var _ = Describe("App server assets", func() {
 					Name: "secret-test-secret",
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							SecretName: "test-secret",
+							SecretName:  "test-secret",
+							DefaultMode: &defaultVolumeMode,
 						},
 					},
 				},
@@ -207,7 +209,8 @@ var _ = Describe("App server assets", func() {
 					Name: "secret-lightspeed-tls",
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							SecretName: OLSCertsSecretName,
+							SecretName:  OLSCertsSecretName,
+							DefaultMode: &defaultVolumeMode,
 						},
 					},
 				},
@@ -216,6 +219,7 @@ var _ = Describe("App server assets", func() {
 					VolumeSource: corev1.VolumeSource{
 						ConfigMap: &corev1.ConfigMapVolumeSource{
 							LocalObjectReference: corev1.LocalObjectReference{Name: OLSConfigCmName},
+							DefaultMode:          &defaultVolumeMode,
 						},
 					},
 				},
@@ -358,7 +362,8 @@ ols_config:
 					Name: "secret-lightspeed-tls",
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							SecretName: OLSCertsSecretName,
+							SecretName:  OLSCertsSecretName,
+							DefaultMode: &defaultVolumeMode,
 						},
 					},
 				},
@@ -367,6 +372,7 @@ ols_config:
 					VolumeSource: corev1.VolumeSource{
 						ConfigMap: &corev1.ConfigMapVolumeSource{
 							LocalObjectReference: corev1.LocalObjectReference{Name: OLSConfigCmName},
+							DefaultMode:          &defaultVolumeMode,
 						},
 					},
 				},

--- a/internal/controller/ols_app_server_deployment.go
+++ b/internal/controller/ols_app_server_deployment.go
@@ -44,6 +44,7 @@ func (r *OLSConfigReconciler) generateOLSDeployment(cr *olsv1alpha1.OLSConfig) (
 	const OLSUserDataVolumeName = "ols-user-data"
 	const OLSUserDataMountPath = "/app-root/ols-user-data"
 	revisionHistoryLimit := int32(1)
+	volumeDefaultMode := int32(420)
 
 	// map from secret name to secret mount path
 	secretMounts := map[string]string{}
@@ -81,7 +82,8 @@ func (r *OLSConfigReconciler) generateOLSDeployment(cr *olsv1alpha1.OLSConfig) (
 			Name: "secret-" + secretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: secretName,
+					SecretName:  secretName,
+					DefaultMode: &volumeDefaultMode,
 				},
 			},
 		}
@@ -94,6 +96,7 @@ func (r *OLSConfigReconciler) generateOLSDeployment(cr *olsv1alpha1.OLSConfig) (
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: OLSConfigCmName,
 				},
+				DefaultMode: &volumeDefaultMode,
 			},
 		},
 	}
@@ -208,7 +211,8 @@ func (r *OLSConfigReconciler) updateOLSDeployment(ctx context.Context, existingD
 
 	// Validate deployment annotations.
 	if existingDeployment.Annotations == nil ||
-		existingDeployment.Annotations[OLSConfigHashKey] != r.stateCache[OLSConfigHashStateCacheKey] || existingDeployment.Annotations[LLMProviderHashKey] != r.stateCache[LLMProviderHashStateCacheKey] {
+		existingDeployment.Annotations[OLSConfigHashKey] != r.stateCache[OLSConfigHashStateCacheKey] ||
+		existingDeployment.Annotations[LLMProviderHashKey] != r.stateCache[LLMProviderHashStateCacheKey] {
 		updateDeploymentAnnotations(existingDeployment, map[string]string{
 			OLSConfigHashKey:   r.stateCache[OLSConfigHashStateCacheKey],
 			LLMProviderHashKey: r.stateCache[LLMProviderHashStateCacheKey],

--- a/internal/controller/olsconfig_controller.go
+++ b/internal/controller/olsconfig_controller.go
@@ -121,6 +121,12 @@ func (r *OLSConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Update status condition for Console Plugin
 	r.updateStatusCondition(ctx, olsconfig, typeConsolePluginReady, true, "All components are successfully deployed", nil)
 
+	err = r.reconcileLLMSecrets(ctx, olsconfig)
+	if err != nil {
+		r.logger.Error(err, "Failed to reconcile LLM Provider Secrets")
+		return ctrl.Result{}, err
+	}
+
 	err = r.reconcileAppServer(ctx, olsconfig)
 	if err != nil {
 		r.logger.Error(err, "Failed to reconcile application server")
@@ -130,11 +136,6 @@ func (r *OLSConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Update status condition for API server
 	r.updateStatusCondition(ctx, olsconfig, typeApiReady, true, "All components are successfully deployed", nil)
 
-	err = r.reconcileLLMSecrets(ctx, olsconfig)
-	if err != nil {
-		r.logger.Error(err, "Failed to reconcile LLM Provider Secrets")
-		return ctrl.Result{}, err
-	}
 	r.logger.Info("reconciliation done", "olsconfig generation", olsconfig.Generation)
 
 	// Update status condition for Custom Resource
@@ -169,7 +170,7 @@ func (r *OLSConfigReconciler) updateStatusCondition(ctx context.Context, olsconf
 	meta.SetStatusCondition(&olsconfig.Status.Conditions, condition)
 
 	if updateErr := r.Status().Update(ctx, olsconfig); updateErr != nil {
-		r.logger.Error(err, ErrUpdateCRStatusCondition)
+		r.logger.Error(updateErr, ErrUpdateCRStatusCondition)
 	}
 }
 


### PR DESCRIPTION
## Description

Fix the issues when the reconcile loop is triggered unnecessarily in multiple cases:

1. The `stateCache` does not contain the `LLMProviderHashStateCacheKey` key.
2. Added sorting of elements for `Volumes/set VolumeMounts` for the correct `Semantic.DeepEqual` comparison
3. Added default volume mode for the correct `Semantic.DeepEqual` comparison

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
