### PR TITLE
fix: console UI image is configurable

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -148,6 +148,7 @@ func main() {
 		Scheme: mgr.GetScheme(),
 		Options: controller.OLSConfigReconcilerOptions{
 			LightspeedServiceImage: imagesMap["lightspeed-service"],
+			ConsoleUIImage:         imagesMap["console-plugin"],
 			// TODO: Update DB
 			//LightspeedServiceRedisImage: imagesMap["lightspeed-service-redis"],
 			Namespace: controller.OLSNamespaceDefault,

--- a/internal/controller/ols_console_ui_assets.go
+++ b/internal/controller/ols_console_ui_assets.go
@@ -109,7 +109,7 @@ func (r *OLSConfigReconciler) generateConsoleUIDeployment(cr *olsv1alpha1.OLSCon
 					Containers: []corev1.Container{
 						{
 							Name:  "lightspeed-console-plugin",
-							Image: ConsoleUIImageDefault,
+							Image: r.Options.ConsoleUIImage,
 							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: ConsoleUIHTTPSPort,

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -108,6 +108,7 @@ var _ = BeforeSuite(func() {
 		Options: OLSConfigReconcilerOptions{
 			LightspeedServiceImage:      "lightspeed-service-api:latest",
 			LightspeedServiceRedisImage: "lightspeed-service-redis:latest",
+			ConsoleUIImage:              ConsoleUIImageDefault,
 			Namespace:                   OLSNamespaceDefault,
 		},
 		logger:     logf.Log.WithName("olsconfig.reconciler"),


### PR DESCRIPTION
## Description

fix the bug that console UI deployment always use the default image.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

