### PR TITLE
fix: mark defaultProvider as a required field

### DIFF
--- a/api/v1alpha1/olsconfig_types.go
+++ b/api/v1alpha1/olsconfig_types.go
@@ -30,7 +30,9 @@ type OLSConfigSpec struct {
 	// +kubebuilder:validation:Required
 	// +required
 	LLMConfig LLMSpec `json:"llm"`
-	OLSConfig OLSSpec `json:"ols,omitempty"`
+	// +kubebuilder:validation:Required
+	// +required
+	OLSConfig OLSSpec `json:"ols"`
 }
 
 // OLSConfigStatus defines the observed state of OLS deployment.
@@ -60,7 +62,9 @@ type OLSSpec struct {
 	// +kubebuilder:default=false
 	DisableAuth bool `json:"disableAuth,omitempty"`
 	// Default model for usage
-	DefaultModel string `json:"defaultModel,omitempty"`
+	// +kubebuilder:validation:Required
+	// +required
+	DefaultModel string `json:"defaultModel"`
 	// Default provider for usage
 	DefaultProvider string `json:"defaultProvider,omitempty"`
 	// Classifier provider name

--- a/config/crd/bases/ols.openshift.io_olsconfigs.yaml
+++ b/config/crd/bases/ols.openshift.io_olsconfigs.yaml
@@ -245,9 +245,12 @@ spec:
                   yamlProvider:
                     description: YAML provider name
                     type: string
+                required:
+                - defaultModel
                 type: object
             required:
             - llm
+            - ols
             type: object
           status:
             description: OLSConfigStatus defines the observed state of OLS deployment.


### PR DESCRIPTION
## Description

Fix the error

```
Failed to load config file /etc/ols/olsconfig.yaml: default_provider is missing
```

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
