### PR TITLE
fix: add "type" field to the OLSConfig CR used in E2E tests

### DIFF
--- a/test/e2e/assets.go
+++ b/test/e2e/assets.go
@@ -36,6 +36,10 @@ func generateOLSConfig() (*olsv1alpha1.OLSConfig, error) { // nolint:unused
 	if llmModel == "" {
 		llmModel = OpenAIDefaultModel
 	}
+	llmType := os.Getenv(LLMTypeEnvVar)
+	if llmType == "" {
+		llmType = LLMDefaultType
+	}
 	replicas := int32(1)
 	maxMemory := intstr.Parse("100mb")
 	return &olsv1alpha1.OLSConfig{
@@ -55,6 +59,7 @@ func generateOLSConfig() (*olsv1alpha1.OLSConfig, error) { // nolint:unused
 						CredentialsSecretRef: corev1.LocalObjectReference{
 							Name: LLMTokenFirstSecretName,
 						},
+						Type: llmType,
 					},
 				},
 			},

--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -17,6 +17,10 @@ const (
 	LLMDefaultProvider = "openai"
 	// LLMProviderEnvVar is the environment variable containing the LLM provider
 	LLMProviderEnvVar = "LLM_PROVIDER"
+	// LLMTypeEnvVar is the environment variable containing the LLM type
+	LLMTypeEnvVar = "LLM_TYPE"
+	// LLMDefaultType is the default LLM type
+	LLMDefaultType = "openai"
 	// OpenAIDefaultModel is the default model to use
 	OpenAIDefaultModel = "gpt-3.5-turbo"
 	// OpenAIAlternativeModel is the alternative model to test model change


### PR DESCRIPTION
## Description

A new field `type` is required in the provider spec of OLSConfig CR for validation rules. This PR add this missing field so that the E2E test can execute.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

