### PR TITLE
OLS-249 fix for E2E test - create LLM token secrets for each sub test suite

### DIFF
--- a/test/e2e/reconciliation_test.go
+++ b/test/e2e/reconciliation_test.go
@@ -9,6 +9,7 @@ import (
 	olsv1alpha1 "github.com/openshift/lightspeed-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -21,6 +22,23 @@ var _ = Describe("Reconciliation From OLSConfig CR", Ordered, func() {
 	BeforeAll(func() {
 		client, err = GetClient()
 		Expect(err).NotTo(HaveOccurred())
+		By("Create 2 LLM token secrets")
+		secret, err := generateLLMTokenSecret(LLMTokenFirstSecretName)
+		Expect(err).NotTo(HaveOccurred())
+		err = client.Create(secret)
+		if errors.IsAlreadyExists(err) {
+			err = client.Update(secret)
+		}
+		Expect(err).NotTo(HaveOccurred())
+
+		secret, err = generateLLMTokenSecret(LLMTokenSecondSecretName)
+		Expect(err).NotTo(HaveOccurred())
+		err = client.Create(secret)
+		if errors.IsAlreadyExists(err) {
+			err = client.Update(secret)
+		}
+		Expect(err).NotTo(HaveOccurred())
+
 		By("Creating a OLSConfig CR")
 		cr, err = generateOLSConfig()
 		Expect(err).NotTo(HaveOccurred())
@@ -35,6 +53,29 @@ var _ = Describe("Reconciliation From OLSConfig CR", Ordered, func() {
 		Expect(cr).NotTo(BeNil())
 		err = client.Delete(cr)
 		Expect(err).NotTo(HaveOccurred())
+
+		By("Delete the 2 LLM token Secrets")
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      LLMTokenFirstSecretName,
+				Namespace: OLSNameSpace,
+			},
+		}
+		err = client.Delete(secret)
+		if !errors.IsNotFound(err) {
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      LLMTokenSecondSecretName,
+				Namespace: OLSNameSpace,
+			},
+		}
+		err = client.Delete(secret)
+		if !errors.IsNotFound(err) {
+			Expect(err).NotTo(HaveOccurred())
+		}
 
 	})
 

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -10,7 +10,6 @@ import (
 
 	olsv1alpha1 "github.com/openshift/lightspeed-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -46,51 +45,8 @@ var _ = BeforeSuite(func() {
 		Expect(err).NotTo(HaveOccurred())
 	}
 
-	By("Create 2 LLM token secrets")
-	secret, err := generateLLMTokenSecret(LLMTokenFirstSecretName)
-	Expect(err).NotTo(HaveOccurred())
-	err = client.Create(secret)
-	if errors.IsAlreadyExists(err) {
-		err = client.Update(secret)
-	}
-	Expect(err).NotTo(HaveOccurred())
-
-	secret, err = generateLLMTokenSecret(LLMTokenSecondSecretName)
-	Expect(err).NotTo(HaveOccurred())
-	err = client.Create(secret)
-	if errors.IsAlreadyExists(err) {
-		err = client.Update(secret)
-	}
-	Expect(err).NotTo(HaveOccurred())
-
 })
 
 var _ = AfterSuite(func() {
-	client, err := GetClient()
-	if err != nil {
-		Fail("Failed to create client")
-	}
 
-	By("Delete the 2 LLM token Secrets")
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      LLMTokenFirstSecretName,
-			Namespace: OLSNameSpace,
-		},
-	}
-	err = client.Delete(secret)
-	if !errors.IsNotFound(err) {
-		Expect(err).NotTo(HaveOccurred())
-	}
-
-	secret = &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      LLMTokenSecondSecretName,
-			Namespace: OLSNameSpace,
-		},
-	}
-	err = client.Delete(secret)
-	if !errors.IsNotFound(err) {
-		Expect(err).NotTo(HaveOccurred())
-	}
 })

--- a/test/e2e/tls_test.go
+++ b/test/e2e/tls_test.go
@@ -9,6 +9,7 @@ import (
 	olsv1alpha1 "github.com/openshift/lightspeed-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -23,6 +24,15 @@ var _ = Describe("TLS activation", Ordered, func() {
 	BeforeAll(func() {
 		client, err = GetClient()
 		Expect(err).NotTo(HaveOccurred())
+		By("Create 1 LLM token secrets")
+		secret, err := generateLLMTokenSecret(LLMTokenFirstSecretName)
+		Expect(err).NotTo(HaveOccurred())
+		err = client.Create(secret)
+		if errors.IsAlreadyExists(err) {
+			err = client.Update(secret)
+		}
+		Expect(err).NotTo(HaveOccurred())
+
 		By("Creating a OLSConfig CR")
 		cr, err = generateOLSConfig()
 		Expect(err).NotTo(HaveOccurred())
@@ -58,6 +68,18 @@ var _ = Describe("TLS activation", Ordered, func() {
 		Expect(cr).NotTo(BeNil())
 		err = client.Delete(cr)
 		Expect(err).NotTo(HaveOccurred())
+
+		By("Delete the 1 LLM token Secret")
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      LLMTokenFirstSecretName,
+				Namespace: OLSNameSpace,
+			},
+		}
+		err = client.Delete(secret)
+		if !errors.IsNotFound(err) {
+			Expect(err).NotTo(HaveOccurred())
+		}
 
 	})
 


### PR DESCRIPTION
## Description
we need to create LLM token secrets for each sub test suite. because the LLM token secret is deleted when deleting the CR that is registered as the owner of the secret. This behavior is introduced by [this commit](https://github.com/openshift/lightspeed-operator/commit/3071dca4b6798339d7d1bf8dcb3498fa452af4fb#diff-05e39d12ec72b18f2278025c8d6f936f38c066507a33f5531291e6d604f7d3a3R261), which sets the owner of the LLM token secret to the OLSConfig CR being reconciled.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # [OLS-249](https://issues.redhat.com//browse/OLS-249)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

