### PR TITLE
fix: OLSConfig CR watches the LLM token secret without owning the secret

### DIFF
--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -112,4 +112,7 @@ const (
 	// ConsoleProxyAlias is the alias of the console proxy
 	// The console backend exposes following proxy endpoint: /api/proxy/plugin/<plugin-name>/<proxy-alias>/<request-path>?<optional-query-parameters>
 	ConsoleProxyAlias = "ols"
+
+	/*** watchers ***/
+	WatcherAnnotationKey = "ols.openshift.io/watcher"
 )

--- a/internal/controller/ols_app_server_reconciliator.go
+++ b/internal/controller/ols_app_server_reconciliator.go
@@ -8,7 +8,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -269,9 +268,7 @@ func (r *OLSConfigReconciler) reconcileLLMSecrets(ctx context.Context, cr *olsv1
 			return fmt.Errorf("Secret token not found for provider: %s. error: %w", provider.Name, err)
 		}
 		providerCredentials += providerApiToken
-		if err = controllerutil.SetControllerReference(cr, foundSecret, r.Scheme); err != nil {
-			return fmt.Errorf("failed to set controller reference to secret: %s. error: %w", foundSecret.Name, err)
-		}
+		annotateSecretWatcher(foundSecret)
 		err = r.Update(ctx, foundSecret)
 		if err != nil {
 			return fmt.Errorf("failed to update secret:%s. error: %w", foundSecret.Name, err)

--- a/internal/controller/olsconfig_controller.go
+++ b/internal/controller/olsconfig_controller.go
@@ -32,6 +32,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	olsv1alpha1 "github.com/openshift/lightspeed-operator/api/v1alpha1"
@@ -200,6 +201,7 @@ func (r *OLSConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.Service{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Secret{}).
+		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(secretWatcherFilter)).
 		Owns(&monv1.ServiceMonitor{}).
 		Complete(r)
 }

--- a/internal/controller/resource_watchers.go
+++ b/internal/controller/resource_watchers.go
@@ -1,0 +1,35 @@
+package controller
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func secretWatcherFilter(ctx context.Context, obj client.Object) []reconcile.Request {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return nil
+	}
+	crName, exist := annotations[WatcherAnnotationKey]
+	if !exist {
+		return nil
+	}
+	return []reconcile.Request{
+		{NamespacedName: types.NamespacedName{
+			Name: crName,
+		}},
+	}
+}
+
+func annotateSecretWatcher(secret *corev1.Secret) {
+	annotations := secret.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[WatcherAnnotationKey] = OLSConfigName
+	secret.SetAnnotations(annotations)
+}

--- a/internal/controller/resource_watchers_test.go
+++ b/internal/controller/resource_watchers_test.go
@@ -1,0 +1,30 @@
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Watchers", func() {
+
+	Context("secret", Ordered, func() {
+		ctx := context.Background()
+		It("should identify watched secret by annotations", func() {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "test-secret"},
+			}
+			requests := secretWatcherFilter(ctx, secret)
+			Expect(requests).To(BeEmpty())
+
+			annotateSecretWatcher(secret)
+			requests = secretWatcherFilter(ctx, secret)
+			Expect(requests).To(HaveLen(1))
+			Expect(requests[0].Name).To(Equal(OLSConfigName))
+		})
+	})
+
+})


### PR DESCRIPTION
## Description

This PR fix a bug that the LLM token secret referenced by an OLSConfig CR is deleted when the OLSConfig CR is deleted. 
The operator will watch the refertenced secret without owning the secret, reconcile if any changes applied to that LLM token secret. 

This PR replaces https://github.com/openshift/lightspeed-operator/pull/101

This PR makes the operator passes the E2E test. 

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

