### PR TITLE
Refactor catalog publish script with args

### DIFF
--- a/hack/publish_build_from_tag.sh
+++ b/hack/publish_build_from_tag.sh
@@ -7,6 +7,53 @@
 
 #!/bin/bash
 
+usage() {
+  echo "Usage:
+  -o, --org:
+    Specify the quay org the bundle+catalog images will be pushed to (default: openshift)
+  -t, --target-tag:
+    Specify the image tag for the bundle+catalog images (default: internal-preview) 
+  --ols-image: 
+    The full pull spec of the ols api server image (default: quay.io/openshift/lightspeed-service-api:internal-preview)
+  --console-image:
+    The full pull spec of the console image (default: quay.io/openshift/lightspeed-console-plugin:internal-preview)
+  --operator-image:
+    The full pull spec of the operator image (default: quay.io/openshift/lightspeed-operator:internal-preview)
+  -p, --publish:
+    If set, the bundle+catalog images will be pushed to quay (default: false)
+  -v, --version:
+    The version identifier to use for the bundle (default: 0.0.1)
+
+"
+}
+while [ "$1" != "" ]; do
+    case $1 in
+        -o | --org )            shift
+                                QUAY_ORG="$1"
+                                ;;
+        -t | --target-tag )     shift
+                                TARGET_TAG="$1"
+                                ;;
+        --ols-image )           shift
+                                OLS_IMAGE="$1"
+                                ;;
+        --console-image )       shift
+                                CONSOLE_IMAGE="$1"
+                                ;;
+        --operator-image )      shift
+                                OPERATOR_IMAGE="$1"
+                                ;;
+        -p | --publish )        PUBLISH="true"
+                                ;;
+        -v | --version )        shift
+                                VERSION="$1"
+                                ;;
+        * )                     usage
+                                exit 1
+    esac
+    shift
+done
+
 # Backup files before running script
 backup() {
   echo "Backing up files"
@@ -14,7 +61,6 @@ backup() {
   cp "${CSV_FILE}" backup/lightspeed-operator.clusterserviceversion.yaml.bak
   cp "${CATALOG_FILE}" backup/operator.yaml.bak
 }
-
 
 # Reverse backup files
 restore() {
@@ -24,34 +70,38 @@ restore() {
   rm -rf backup
 }
 
-trap restore EXIT
-
 set -euo pipefail
 
 # Begin configuration
-export QUAY_USER=""  # Set quay user for personal builds
-VERSION="0.0.1"    # Set the bundle version - currently 0.0.1
-QUAY_USER="${QUAY_USER:-openshift}"
-TARGET_TAG="internal-preview"  # Set the target tag for the bundle and catalog image
+VERSION=${VERSION:-"0.0.1"}    # Set the bundle version - currently 0.0.1
+QUAY_ORG=${QUAY_ORG:-"openshift"}
+TARGET_TAG=${TARGET_TAG:-"internal-preview"}  # Set the target tag for the bundle and catalog image
 
 # Set the images for the operator and operands
-OLS_IMAGE="quay.io/openshift/lightspeed-service-api:internal-preview"
-CONSOLE_IMAGE="quay.io/openshift/lightspeed-console-plugin:internal-preview"
-OPERATOR_IMAGE="quay.io/openshift/lightspeed-operator:internal-preview"
+OLS_IMAGE=${OLS_IMAGE:-"quay.io/openshift/lightspeed-service-api:internal-preview"}
+CONSOLE_IMAGE=${CONSOLE_IMAGE:-"quay.io/openshift/lightspeed-console-plugin:internal-preview"}
+OPERATOR_IMAGE=${OPERATOR_IMAGE:-"quay.io/openshift/lightspeed-operator:internal-preview"}
+PUBLISH=${PUBLISH:-"false"}
+
+echo "====== inputs ======="
+echo "OLS_IMAGE=${OLS_IMAGE}"
+echo "CONSOLE_IMAGE=${OLS_IMAGE}"
+echo "OPERATOR_IMAGE=${OLS_IMAGE}"
+echo ""
+echo "====== outputs ======="
+echo "VERSION=${VERSION}"
+echo "QUAY_ORG=${QUAY_ORG}"
+echo "TARGET_TAG=${TARGET_TAG}"
+echo "PUBLISH=${PUBLISH}"
 
 # End configuration
 
 
 # If first arg --publish is set ,then the script pushes the images to the quay.io registry
-PUBLISH="false"
-if [ "$#" -eq 1 ] && [ "$1" == "--publish" ]; then
-  PUBLISH="true"
-fi
-echo "PUBLISH=${PUBLISH}"
 
 DEFAULT_PLATFORM="linux/amd64"
-BUNDLE_BASE="quay.io/${QUAY_USER}/lightspeed-operator-bundle"
-CATALOG_BASE="quay.io/${QUAY_USER}/lightspeed-catalog"
+BUNDLE_BASE="quay.io/${QUAY_ORG}/lightspeed-operator-bundle"
+CATALOG_BASE="quay.io/${QUAY_ORG}/lightspeed-catalog"
 TARGET_BUNDLE_IMAGE="${BUNDLE_BASE}:${TARGET_TAG}"
 TARGET_CATALOG_IMAGE="${CATALOG_BASE}:${TARGET_TAG}"
 
@@ -61,17 +111,20 @@ CATALOG_DOCKER_FILE="lightspeed-catalog.Dockerfile"
 
 echo "Backup files before running the script"
 backup
+trap restore EXIT
 
 
 OPERANDS="lightspeed-service=${OLS_IMAGE},console-plugin=${CONSOLE_IMAGE}"
 #replace the operand images in the CSV file
-sed -i.bak "s|--images=lightspeed-service=quay.io/openshift/lightspeed-service-api:latest|--images=${OPERANDS}|g" "${CSV_FILE}"
+sed -i "s|--images=.*|--images=${OPERANDS}|g" "${CSV_FILE}"
 
-#Replace operator  in CSV file
-sed -i.bak "s|image: quay.io/openshift/lightspeed-operator:latest|image: ${OPERATOR_IMAGE}|g" "${CSV_FILE}"
-rm bundle/manifests/lightspeed-operator.clusterserviceversion.yaml.bak
+#Replace operator in CSV file
+sed -i "s|image: quay.io/openshift/lightspeed-operator:latest|image: ${OPERATOR_IMAGE}|g" "${CSV_FILE}"
 
-make bundle-build   VERSION="${VERSION}" BUNDLE_IMG="${TARGET_BUNDLE_IMAGE}"
+#Replace version in CSV file
+sed -i "s|0.0.1|${VERSION}|g" "${CSV_FILE}"
+
+make bundle-build VERSION="${VERSION}" BUNDLE_IMG="${TARGET_BUNDLE_IMAGE}"
 
 if [[ ${PUBLISH} == "false" ]] ; then
   echo "Bundle image ${TARGET_BUNDLE_IMAGE} built successfully , skipping the push to quay.io"
@@ -99,7 +152,7 @@ schema: olm.channel
 package: lightspeed-operator
 name: preview
 entries:
-  - name: lightspeed-operator.v$VERSION
+  - name: lightspeed-operator.v${VERSION}
 EOF
 
 echo "Building catalog image ${TARGET_CATALOG_IMAGE}"


### PR DESCRIPTION
* Takes arguments for most inputs
* Sets the specified bundle version in the csv(was not being set previously)
* Makes the CSV regexes a bit less fragile(hopefully)
* Removed the ".bak" logic in the sed invocations which didn't seem to serve any purpose because the .bak file was being removed immediately after the sed invocations
* Sets up the restore exit trap only after backup is invoked(there is nothing to restore until backup is invoked)

There's more to do here to collapse the 3 scripts into one (publish, rebuild, update) and create some utility functions, but for now i think this makes it easier to execute a flow like:

1) tag the latest operand images as "candidate"
2) build a new bundle+catalog image from the "candidate" operand images and push the bundle/catalog to your own quay org, or to a candidate tag in the openshift org
3) go test the catalog on a cluster
4) retag the candidate operand images as internal-preview
5) build a new bundle/catalog from the internal-preview operands and push the bundle/catalog to the openshift org under the internal-preview tag

Not ideal, but it gives us a workflow where we can sanity check things before putting them out there, at least, while we work to improve our CI processes.


## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.