### PR TITLE
Add an allowlist for dummy secrets in the repo

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,10 @@
+# See https://source.redhat.com/departments/it/it-information-security/wiki/pattern_distribution_server for how to use this file
+[allowlist]
+  description = "Global Allowlist"
+
+        
+  # Ignore based on any subset of the line
+  regexes = [
+    # Ignore lines containing pickles
+    '''dummy-secret-''',
+  ]


### PR DESCRIPTION
## Description
follows directions from https://source.redhat.com/departments/it/it-information-security/wiki/pattern_distribution_server to allowlist some dummy secrets that exist in this repo's commit history


<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.