### PR TITLE
OLS-249: make poll timeout configurable in E2E test

### DIFF
--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -47,4 +47,6 @@ const (
 	AppServerConfigMapKey = "olsconfig.yaml"
 	// AppServerTLSSecretName is the name of the OLS application server TLS secret
 	AppServerTLSSecretName = "lightspeed-tls" // #nosec G101
+	// ConditionTimeoutEnvVar is the environment variable containing the condition check timeout in seconds
+	ConditionTimeoutEnvVar = "CONDITION_TIMEOUT"
 )

--- a/test/e2e/reconciliation_test.go
+++ b/test/e2e/reconciliation_test.go
@@ -19,7 +19,7 @@ var _ = Describe("Reconciliation From OLSConfig CR", Ordered, func() {
 	var client *Client
 
 	BeforeAll(func() {
-		client, err = GetClient()
+		client, err = GetClient(nil)
 		Expect(err).NotTo(HaveOccurred())
 		By("Creating a OLSConfig CR")
 		cr, err = generateOLSConfig()
@@ -29,7 +29,7 @@ var _ = Describe("Reconciliation From OLSConfig CR", Ordered, func() {
 	})
 
 	AfterAll(func() {
-		client, err = GetClient()
+		client, err = GetClient(nil)
 		Expect(err).NotTo(HaveOccurred())
 		By("Deleting the OLSConfig CR")
 		Expect(cr).NotTo(BeNil())

--- a/test/e2e/tls_test.go
+++ b/test/e2e/tls_test.go
@@ -21,7 +21,7 @@ var _ = Describe("TLS activation", Ordered, func() {
 	var forwardHost string
 
 	BeforeAll(func() {
-		client, err = GetClient()
+		client, err = GetClient(nil)
 		Expect(err).NotTo(HaveOccurred())
 		By("Creating a OLSConfig CR")
 		cr, err = generateOLSConfig()
@@ -52,7 +52,7 @@ var _ = Describe("TLS activation", Ordered, func() {
 			cleanUp()
 		}
 
-		client, err = GetClient()
+		client, err = GetClient(nil)
 		Expect(err).NotTo(HaveOccurred())
 		By("Deleting the OLSConfig CR")
 		Expect(cr).NotTo(BeNil())


### PR DESCRIPTION
## Description

The polling timeout for condition checks in E2E test is configuration via env var `CONDITION_TIMEOUT`.
The default is increased to 10 minutes, too, adapting to the slow cluster in CI.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # [OLS-249](https://issues.redhat.com//browse/OLS-249)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

