### PR TITLE
fix: increase timeout per test case to 120m for E2E test.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ endif
 ifndef LLM_TOKEN
 	$(error LLM_TOKEN  environment variable is not set)
 endif
-	go test ./test/e2e  -ginkgo.v -ginkgo.progress -test.v
+	go test ./test/e2e -timeout=120m -ginkgo.v -test.v -ginkgo.show-node-events
 
 .PHONY: lint
 lint: ## Run golangci-lint against code.


### PR DESCRIPTION
## Description

Increase timeout per test case for the E2E test. Because it takes long time to reconcile the OLS app server deployment.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # [OLS-249](https://issues.redhat.com//browse/OLS-249)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

