### PR TITLE
Added relatedImages for CSV to publish in catalog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ endif
 # To re-generate a bundle for any other default channel without changing the default setup, you can:
 # - use the DEFAULT_CHANNEL as arg of the bundle target (e.g make bundle DEFAULT_CHANNEL=stable)
 # - use environment variables to overwrite this value (e.g export DEFAULT_CHANNEL="stable")
+DEFAULT_CHANNEL = "preview"
 ifneq ($(origin DEFAULT_CHANNEL), undefined)
 BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
 endif
@@ -175,7 +176,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
-	$(CONTAINER_TOOL) build -t ${IMG} .
+	$(CONTAINER_TOOL) build --platform linux/amd64 -t ${IMG} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,6 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=lightspeed-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.bundle.channel.default.v1=preview
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.33.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4

--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-04-25T11:45:13Z"
+    createdAt: "2024-04-28T22:18:32Z"
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-lightspeed
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
@@ -537,3 +537,12 @@ spec:
     name: Red Hat, Inc
     url: https://github.com/openshift/lightspeed-service
   version: 0.0.1
+  relatedImages:
+    - name: lightspeed-service-api
+      image: quay.io/openshift/lightspeed-service-api:latest
+    - name: lightspeed-console-plugin
+      image: quay.io/openshift/lightspeed-console-plugin:latest
+    - name: lightspeed-operator
+      image: quay.io/openshift/lightspeed-operator:latest
+    - name: ose-kube-rbac-proxy
+      image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:latest

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,6 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: lightspeed-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channel.default.v1: preview
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.33.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4

--- a/hack/update_bundle_catalog.sh
+++ b/hack/update_bundle_catalog.sh
@@ -20,11 +20,24 @@ OPERATOR_IMAGE="quay.io/openshift/lightspeed-operator:${TAG}"
 BUNDLE_IMAGE="quay.io/openshift/lightspeed-operator-bundle:v${BUNDLE_TAG}"
 CATALOG_FILE="lightspeed-catalog/index.yaml"
 CATALOG_INTIAL_FILE="hack/operator.yaml"
+CSV_FILE="bundle/manifests/lightspeed-operator.clusterserviceversion.yaml"
 
 # Build the bundle image
 echo "Updating bundle artifcts for image ${OPERATOR_IMAGE}"
+rm -rf ./bundle
 make bundle VERSION="${BUNDLE_TAG}" IMG="${OPERATOR_IMAGE}"
-
+# Add related images to the CSV file
+cat << EOF >> "${CSV_FILE}"
+  relatedImages:
+    - name: lightspeed-service-api
+      image: quay.io/openshift/lightspeed-service-api:latest
+    - name: lightspeed-console-plugin
+      image: quay.io/openshift/lightspeed-console-plugin:latest
+    - name: lightspeed-operator
+      image: quay.io/openshift/lightspeed-operator:latest
+    - name: ose-kube-rbac-proxy
+      image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:latest
+EOF
 echo "Adding bundle image to FBC using image ${BUNDLE_IMAGE}" 
 
 #Initialize lightspeed-catalog/index.yaml from hack/operator.yaml


### PR DESCRIPTION
## Description
1. Made `preview` as the default channel in Makefile and annotations,bundle.Docker
2. Added related Images part of CSV file - in  make target `update-bundle-catalog` [ Adding in config did not reflect in CSV - made it manual]
3. Replaced relatedImages with SHA in - hack/publish_package_builds.sh
4. Introduced option -b to build operator image from source to developers in hack/publish_package_builds.sh

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
