### PR TITLE
OLS-346: periodic reconciliation

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"slices"
+	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -101,6 +102,7 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
+	var reconcilerIntervalSeconds uint
 	images := k8sflag.NewMapStringString(ptr.To(make(map[string]string)))
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -108,6 +110,7 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.Var(images, "images", fmt.Sprintf("Full images refs to use for containers managed by the operator. E.g lightspeed-service=quay.io/openshift/lightspeed-service-api:latest. Images used are %v", listImages()))
+	flag.UintVar(&reconcilerIntervalSeconds, "reconcile-interval", controller.DefaultReconcileInterval, "The interval in seconds to reconcile the OLSConfig CR")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -156,7 +159,8 @@ func main() {
 			ConsoleUIImage:         imagesMap["console-plugin"],
 			// TODO: Update DB
 			//LightspeedServiceRedisImage: imagesMap["lightspeed-service-redis"],
-			Namespace: controller.OLSNamespaceDefault,
+			Namespace:         controller.OLSNamespaceDefault,
+			ReconcileInterval: time.Duration(reconcilerIntervalSeconds) * time.Second,
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OLSConfig")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -102,7 +102,7 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
-	var reconcilerIntervalSeconds uint
+	var reconcilerIntervalMinutes uint
 	images := k8sflag.NewMapStringString(ptr.To(make(map[string]string)))
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -110,7 +110,7 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.Var(images, "images", fmt.Sprintf("Full images refs to use for containers managed by the operator. E.g lightspeed-service=quay.io/openshift/lightspeed-service-api:latest. Images used are %v", listImages()))
-	flag.UintVar(&reconcilerIntervalSeconds, "reconcile-interval", controller.DefaultReconcileInterval, "The interval in seconds to reconcile the OLSConfig CR")
+	flag.UintVar(&reconcilerIntervalMinutes, "reconcile-interval", controller.DefaultReconcileInterval, "The interval in minutes to reconcile the OLSConfig CR")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -160,7 +160,7 @@ func main() {
 			// TODO: Update DB
 			//LightspeedServiceRedisImage: imagesMap["lightspeed-service-redis"],
 			Namespace:         controller.OLSNamespaceDefault,
-			ReconcileInterval: time.Duration(reconcilerIntervalSeconds) * time.Second,
+			ReconcileInterval: time.Duration(reconcilerIntervalMinutes) * time.Minute,
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OLSConfig")

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -5,7 +5,7 @@ const (
 	// OLSConfigName is the name of the OLSConfig Custom Resource
 	OLSConfigName = "cluster"
 	// DefaultReconcileInterval is the default interval for reconciliation
-	DefaultReconcileInterval = 300
+	DefaultReconcileInterval = 120
 
 	/*** application server configuration file ***/
 	// OLSConfigName is the name of the OLSConfig configmap

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -4,6 +4,8 @@ const (
 	/*** Operator Settings ***/
 	// OLSConfigName is the name of the OLSConfig Custom Resource
 	OLSConfigName = "cluster"
+	// DefaultReconcileInterval is the default interval for reconciliation
+	DefaultReconcileInterval = 300
 
 	/*** application server configuration file ***/
 	// OLSConfigName is the name of the OLSConfig configmap

--- a/internal/controller/olsconfig_controller.go
+++ b/internal/controller/olsconfig_controller.go
@@ -168,6 +168,7 @@ func (r *OLSConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, nil
 	}
 	r.NextReconcileTime = time.Now().Add(r.Options.ReconcileInterval)
+	r.logger.Info("Next automatic reconciliation scheduled at", "nextReconcileTime", r.NextReconcileTime)
 	return ctrl.Result{RequeueAfter: r.Options.ReconcileInterval}, nil
 }
 

--- a/internal/controller/olsconfig_controller.go
+++ b/internal/controller/olsconfig_controller.go
@@ -19,8 +19,10 @@ package controller
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
+	consolev1 "github.com/openshift/api/console/v1"
 	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -49,10 +51,11 @@ const (
 // OLSConfigReconciler reconciles a OLSConfig object
 type OLSConfigReconciler struct {
 	client.Client
-	Scheme     *runtime.Scheme
-	logger     logr.Logger
-	stateCache map[string]string
-	Options    OLSConfigReconcilerOptions
+	Scheme            *runtime.Scheme
+	logger            logr.Logger
+	stateCache        map[string]string
+	Options           OLSConfigReconcilerOptions
+	NextReconcileTime time.Time
 }
 
 type OLSConfigReconcilerOptions struct {
@@ -60,6 +63,7 @@ type OLSConfigReconcilerOptions struct {
 	LightspeedServiceRedisImage string
 	ConsoleUIImage              string
 	Namespace                   string
+	ReconcileInterval           time.Duration
 }
 
 // +kubebuilder:rbac:groups=ols.openshift.io,resources=olsconfigs,verbs=get;list;watch;create;update;patch;delete
@@ -121,7 +125,7 @@ func (r *OLSConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 		// Error reading the object - requeue the request.
 		r.logger.Error(err, "Failed to get olsconfig")
-		return ctrl.Result{}, err
+		return ctrl.Result{RequeueAfter: 1 * time.Second}, err
 	}
 	r.logger.Info("reconciliation starts", "olsconfig generation", olsconfig.Generation)
 	// TODO: Update DB
@@ -134,7 +138,7 @@ func (r *OLSConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if err != nil {
 		r.logger.Error(err, "Failed to reconcile console UI")
 		r.updateStatusCondition(ctx, olsconfig, typeCRReconciled, false, "Failed", nil)
-		return ctrl.Result{}, err
+		return ctrl.Result{RequeueAfter: 1 * time.Second}, err
 	}
 	// Update status condition for Console Plugin
 	r.updateStatusCondition(ctx, olsconfig, typeConsolePluginReady, true, "All components are successfully deployed", nil)
@@ -142,14 +146,14 @@ func (r *OLSConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	err = r.reconcileLLMSecrets(ctx, olsconfig)
 	if err != nil {
 		r.logger.Error(err, "Failed to reconcile LLM Provider Secrets")
-		return ctrl.Result{}, err
+		return ctrl.Result{RequeueAfter: 1 * time.Second}, err
 	}
 
 	err = r.reconcileAppServer(ctx, olsconfig)
 	if err != nil {
 		r.logger.Error(err, "Failed to reconcile application server")
 		r.updateStatusCondition(ctx, olsconfig, typeCRReconciled, false, "Failed", nil)
-		return ctrl.Result{}, err
+		return ctrl.Result{RequeueAfter: 1 * time.Second}, err
 	}
 	// Update status condition for API server
 	r.updateStatusCondition(ctx, olsconfig, typeApiReady, true, "All components are successfully deployed", nil)
@@ -159,7 +163,12 @@ func (r *OLSConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Update status condition for Custom Resource
 	r.updateStatusCondition(ctx, olsconfig, typeCRReconciled, true, "Custom resource successfully reconciled", nil)
 
-	return ctrl.Result{}, nil
+	// Requeue if no reconciliation is scheduled in future.
+	if r.NextReconcileTime.After(time.Now()) {
+		return ctrl.Result{}, nil
+	}
+	r.NextReconcileTime = time.Now().Add(r.Options.ReconcileInterval)
+	return ctrl.Result{RequeueAfter: r.Options.ReconcileInterval}, nil
 }
 
 // updateStatusCondition updates the status condition of the OLSConfig Custom Resource instance.
@@ -196,6 +205,7 @@ func (r *OLSConfigReconciler) updateStatusCondition(ctx context.Context, olsconf
 func (r *OLSConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.logger = ctrl.Log.WithName("Reconciler")
 	r.stateCache = make(map[string]string)
+	r.NextReconcileTime = time.Now()
 
 	generationChanged := builder.WithPredicates(predicate.GenerationChangedPredicate{})
 	return ctrl.NewControllerManagedBy(mgr).
@@ -208,6 +218,7 @@ func (r *OLSConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Secret{}).
 		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(secretWatcherFilter)).
+		Owns(&consolev1.ConsolePlugin{}).
 		Owns(&monv1.ServiceMonitor{}).
 		Owns(&monv1.PrometheusRule{}).
 		Complete(r)


### PR DESCRIPTION
## Description

This PR allows the operator to reconcile even when no event is received. This prevents missing reonciliation and leaves the OLS stack in an inconsistent state.

Rebased https://github.com/openshift/lightspeed-operator/pull/90 . 

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

Related Issue # [OLS-346](https://issues.redhat.com//browse/OLS-346)
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
