### PR TITLE
OLS-346: E2e tests for console reconciliaiton

### DIFF
--- a/test/e2e/autocorrection_test.go
+++ b/test/e2e/autocorrection_test.go
@@ -1,0 +1,148 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	consolev1 "github.com/openshift/api/console/v1"
+	olsv1alpha1 "github.com/openshift/lightspeed-operator/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+var _ = Describe("Automatic correction against modifications on managed resources", Ordered, func() {
+	var cr *olsv1alpha1.OLSConfig
+	var client *Client
+
+	BeforeAll(func() {
+		var err error
+		client, err = GetClient()
+		Expect(err).NotTo(HaveOccurred())
+		By("Creating a OLSConfig CR")
+		cr, err = generateOLSConfig()
+		Expect(err).NotTo(HaveOccurred())
+		err = client.Create(cr)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterAll(func() {
+		var err error
+		client, err = GetClient()
+		Expect(err).NotTo(HaveOccurred())
+		By("Deleting the OLSConfig CR")
+		Expect(cr).NotTo(BeNil())
+		err = client.Delete(cr)
+		Expect(err).NotTo(HaveOccurred())
+
+	})
+
+	It("should restore console plugin resources", func() {
+		var err error
+		By("wait for all resources created")
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      ConsolePluginServiceName,
+				Namespace: OLSNameSpace,
+			},
+		}
+		err = client.WaitForObjectCreated(deployment)
+		Expect(err).NotTo(HaveOccurred())
+		service := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      ConsolePluginServiceName,
+				Namespace: OLSNameSpace,
+			},
+		}
+		Expect(err).NotTo(HaveOccurred())
+		consoleplugin := &consolev1.ConsolePlugin{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ConsoleUIPluginName,
+			},
+		}
+		err = client.WaitForObjectCreated(consoleplugin)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("restoring console plugin deployment")
+		err = client.Get(deployment)
+		Expect(err).NotTo(HaveOccurred())
+		originDeployment := deployment.DeepCopy()
+		deployment.Spec.Replicas = int32Ptr(1 + *deployment.Spec.Replicas)
+		err = client.Update(deployment)
+		Expect(err).NotTo(HaveOccurred())
+		var lastErr error
+		err = wait.PollUntilContextTimeout(client.ctx, DefaultPollInterval, DefaultPollTimeout, true, func(ctx context.Context) (bool, error) {
+			err := client.Get(deployment)
+			if err != nil {
+				lastErr = fmt.Errorf("failed to get Deployment: %w", err)
+				return false, nil
+			}
+			if *deployment.Spec.Replicas != *originDeployment.Spec.Replicas {
+				lastErr = fmt.Errorf("the number of replicas (%d) does not match the expected number (%d)",
+					*deployment.Spec.Replicas, *originDeployment.Spec.Replicas)
+				return false, nil
+			}
+			return true, nil
+		})
+		if err != nil {
+			Fail(fmt.Sprintf("failed to restore console plugin service: %v LastErr: %v", err, lastErr))
+		}
+
+		By("restoring console plugin service")
+		err = client.Get(service)
+		Expect(err).NotTo(HaveOccurred())
+		originService := service.DeepCopy()
+		service.Spec.Ports[0].Name = "wrong-port-name"
+		service.Spec.Selector = map[string]string{
+			"wrong": "label",
+		}
+		err = client.Update(service)
+		Expect(err).NotTo(HaveOccurred())
+		err = wait.PollUntilContextTimeout(client.ctx, DefaultPollInterval, DefaultPollTimeout, true, func(ctx context.Context) (bool, error) {
+			err := client.Get(service)
+			if err != nil {
+				lastErr = fmt.Errorf("failed to get Service: %w", err)
+				return false, nil
+			}
+			if !apiequality.Semantic.DeepEqual(service.Spec, originService.Spec) {
+				lastErr = fmt.Errorf("the specs are not equal")
+				return false, nil
+			}
+
+			return true, nil
+		})
+		if err != nil {
+			Fail(fmt.Sprintf("failed to restore console plugin service: %v LastErr: %v", err, lastErr))
+		}
+
+		By("restoring console plugin CR")
+		err = client.Get(consoleplugin)
+		Expect(err).NotTo(HaveOccurred())
+		originConsolePlugin := consoleplugin.DeepCopy()
+		consoleplugin.Spec.DisplayName = "New Console Plugin Name"
+		err = client.Update(consoleplugin)
+		Expect(err).NotTo(HaveOccurred())
+		err = wait.PollUntilContextTimeout(client.ctx, DefaultPollInterval, DefaultPollTimeout, true, func(ctx context.Context) (bool, error) {
+			err := client.Get(consoleplugin)
+			if err != nil {
+				lastErr = fmt.Errorf("failed to get ConsolePlugin: %w", err)
+				return false, nil
+			}
+			if !apiequality.Semantic.DeepEqual(consoleplugin.Spec, originConsolePlugin.Spec) {
+				lastErr = fmt.Errorf("the actual consoleplugin (%v) does not match the original (%v)",
+					consoleplugin.Spec, originConsolePlugin.Spec)
+				return false, nil
+			}
+			return true, nil
+		})
+		if err != nil {
+			Fail(fmt.Sprintf("failed to restore console plugin CR: %v LastErr: %v", err, lastErr))
+		}
+
+	})
+
+})

--- a/test/e2e/autocorrection_test.go
+++ b/test/e2e/autocorrection_test.go
@@ -21,7 +21,7 @@ var _ = Describe("Automatic correction against modifications on managed resource
 
 	BeforeAll(func() {
 		var err error
-		client, err = GetClient()
+		client, err = GetClient(nil)
 		Expect(err).NotTo(HaveOccurred())
 		By("Creating a OLSConfig CR")
 		cr, err = generateOLSConfig()
@@ -32,7 +32,7 @@ var _ = Describe("Automatic correction against modifications on managed resource
 
 	AfterAll(func() {
 		var err error
-		client, err = GetClient()
+		client, err = GetClient(nil)
 		Expect(err).NotTo(HaveOccurred())
 		By("Deleting the OLSConfig CR")
 		Expect(cr).NotTo(BeNil())

--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -41,6 +41,8 @@ const (
 	ConsolePluginServiceName = "lightspeed-console-plugin"
 	// ConsoleUIPluginName is the name of the OLS console plugin
 	ConsoleUIPluginName = "lightspeed-console-plugin"
+	// ConsoleUIConfigMapName is the name of the console UI nginx configmap
+	ConsoleUIConfigMapName = "lightspeed-console-plugin"
 
 	// OLSConsolePluginServiceHTTPSPort is the port number of the OLS console plugin service
 	OLSConsolePluginServiceHTTPSPort = 9443

--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -35,10 +35,13 @@ const (
 	AppServerServiceName = "lightspeed-app-server"
 	// AppServerServiceHTTPSPort is the port number of the OLS application server service
 	AppServerServiceHTTPSPort = 8443
-	// OLSConsolePluginDeploymentName is the name of the OLS console plugin deployment
-	OLSConsolePluginDeploymentName = "lightspeed-console-plugin"
-	// OLSConsolePluginServiceName is the name of the OLS console plugin service
-	OLSConsolePluginServiceName = "lightspeed-console-plugin"
+	// ConsolePluginServiceName is the name of the OLS console plugin deployment
+	ConsolePluginDeploymentName = "lightspeed-console-plugin"
+	// ConsolePluginServiceName is the name of the OLS console plugin service
+	ConsolePluginServiceName = "lightspeed-console-plugin"
+	// ConsoleUIPluginName is the name of the OLS console plugin
+	ConsoleUIPluginName = "lightspeed-console-plugin"
+
 	// OLSConsolePluginServiceHTTPSPort is the port number of the OLS console plugin service
 	OLSConsolePluginServiceHTTPSPort = 9443
 	// AppServerConfigMapName is the name of the OLS application server config map

--- a/test/e2e/reconciliation_test.go
+++ b/test/e2e/reconciliation_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Reconciliation From OLSConfig CR", Ordered, func() {
 		By("make console plugin deployment running")
 		deployment := &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      OLSConsolePluginDeploymentName,
+				Name:      ConsolePluginDeploymentName,
 				Namespace: OLSNameSpace,
 			},
 		}
@@ -83,7 +83,7 @@ var _ = Describe("Reconciliation From OLSConfig CR", Ordered, func() {
 		By("exposing its HTTPS port in a service")
 		service := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      OLSConsolePluginServiceName,
+				Name:      ConsolePluginServiceName,
 				Namespace: OLSNameSpace,
 			},
 		}

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -1,0 +1,3 @@
+package e2e
+
+func int32Ptr(i int32) *int32 { return &i } // nolint:unused


### PR DESCRIPTION
## Description

This PR adds E2E tests about reconcile console related resources after unintended modification.
Rebased original PR https://github.com/openshift/lightspeed-operator/pull/89
Added a verification for restoring ConsoleUI configmap. 

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

Related Issue # [OLS-346](https://issues.redhat.com//browse/OLS-346)
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
