### PR TITLE
Adding reconcile logic for TLS and CA certs for App & Console

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ metadata:
   namespace: openshift-lightspeed
 type: Opaque
 ```
-These `apitoken` values can be updated if user wishes to change them later. They get reflected automatically into the system.
+These `apitoken` values can be updated if the user wishes to change them later. The same applies to all the TLS and CA certs related to individual components. They get reflected automatically across the system.
 
 3. Create an `OLSConfig` custom resource
 

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -10,10 +10,6 @@ const (
 	/*** application server configuration file ***/
 	// OLSConfigName is the name of the OLSConfig configmap
 	OLSConfigCmName = "olsconfig"
-	// RedisCAConfigMap is the name of the OLS redis server TLS ca certificate configmap
-	RedisCAConfigMap = "openshift-service-ca.crt"
-	// RedisCAVolume is the name of the OLS redis TLS ca certificate volume name
-	RedisCAVolume = "cm-olsredisca"
 	// OLSNamespaceDefault is the default namespace for OLS
 	OLSNamespaceDefault = "openshift-lightspeed"
 	// OLSAppServerServiceAccountName is the name of service account running the application server
@@ -24,8 +20,6 @@ const (
 	OLSAppServerSARRoleBindingName = OLSAppServerSARRoleName + "-binding"
 	// OLSAppServerDeploymentName is the name of the OLS application server deployment
 	OLSAppServerDeploymentName = "lightspeed-app-server"
-	// RedisDeploymentName is the name of OLS application redis deployment
-	RedisDeploymentName = "lightspeed-redis-server"
 	// APIKeyMountRoot is the directory hosting the API key file in the container
 	APIKeyMountRoot = "/etc/apikeys" // #nosec G101
 	// CredentialsMountRoot is the directory hosting the credential files in the container
@@ -38,8 +32,6 @@ const (
 	OLSComponentPasswordFileName = "password"
 	// OLSConfigFilename is the name of the application server configuration file
 	OLSConfigFilename = "olsconfig.yaml"
-	// RedisSecretKeyName is the name of the key holding redis server secret
-	RedisSecretKeyName = "password"
 	// Image of the OLS application server
 	// todo: image vesion should synchronize with the release version of the lightspeed-service-api image.
 	OLSAppServerImageDefault = "quay.io/openshift-lightspeed/lightspeed-service-api:latest"
@@ -51,23 +43,15 @@ const (
 	AppServerMetricsPath = "/metrics"
 
 	// Image of the OLS application redis server
-	//RedisServerImageDefault = "quay.io/openshift/lightspeed-service-redis:latest"
 	// OLSConfigHashKey is the key of the hash value of the OLSConfig configmap
 	OLSConfigHashKey = "hash/olsconfig"
 	// LLMProviderHashKey is the key of the hash value of OLS LLM provider credentials consolidated
 	// #nosec G101
 	LLMProviderHashKey = "hash/llmprovider"
-	// RedisConfigHashKey is the key of the hash value of the OLS's redis config
-	RedisConfigHashKey = "hash/olsredisconfig"
-	// RedisSecretHashKey is the key of the hash value of OLS Redis secret
-	// #nosec G101
-	RedisSecretHashKey = "hash/redis-secret"
-	// RedisServiceName is the name of OLS application redis server service
-	RedisServiceName = "lightspeed-redis-server"
-	// RedisSecretName is the name of OLS application redis secret
-	RedisSecretName = "lightspeed-redis-secret"
-	// OLSAppRedisCertsName is the name of the OLS application redis certs secret
-	RedisCertsSecretName = "lightspeed-redis-certs"
+	// OLSAppTLSHashKey is the key of the hash value of the OLS App TLS certificates
+	OLSAppTLSHashKey = "hash/olstls"
+	// OLSConsoleTLSHashKey is the key of the hash value of the OLS Console TLS certificates
+	OLSConsoleTLSHashKey = "hash/olsconsoletls"
 	// OLSAppServerContainerPort is the port number of the lightspeed-service-api container exposes
 	OLSAppServerContainerPort = 8443
 	// OLSAppServerServicePort is the port number for OLS application server service.
@@ -76,23 +60,18 @@ const (
 	OLSAppServerServiceName = "lightspeed-app-server"
 	// OLSCertsSecretName is the name of the TLS secret for OLS.
 	OLSCertsSecretName = "lightspeed-tls" // #nosec G101
-	// RedisServicePort is the port number of the OLS redis server service
-	RedisServicePort = 6379
-	// RedisMaxMemory is the max memory of the OLS redis cache
-	RedisMaxMemory = "1024mb"
-	// RedisMaxMemoryPolicy is the max memory policy of the OLS redis cache
-	RedisMaxMemoryPolicy = "allkeys-lru"
-	// OLSDefaultCacheType is the default cache type for OLS
-	OLSDefaultCacheType = "redis"
 	// Annotation key for serving certificate secret name
 	// #nosec G101
 	ServingCertSecretAnnotationKey = "service.beta.openshift.io/serving-cert-secret-name"
 	/*** state cache keys ***/
-	OLSConfigHashStateCacheKey   = "olsconfigmap-hash"
+	// OLSAppTLSHashStateCacheKey is the key of the hash value of the OLS App TLS certificates
+	OLSAppTLSHashStateCacheKey = "olsapptls-hash"
+	// OLSConfigHashStateCacheKey is the key of the hash value of the OLSConfig configmap
+	OLSConfigHashStateCacheKey = "olsconfigmap-hash"
+	// OLSConsoleTLSHashStateCacheKey is the key of the hash value of the OLS Console TLS certificates
+	OLSConsoleTLSHashStateCacheKey = "olsconsoletls-hash"
+	// LLMProviderHashStateCacheKey is the key of the hash value of OLS LLM provider credentials consolidated
 	LLMProviderHashStateCacheKey = "llmprovider-hash"
-	RedisConfigHashStateCacheKey = "olsredisconfig-hash"
-	// #nosec G101
-	RedisSecretHashStateCacheKey = "olsredissecret-hash"
 
 	/*** console UI plugin ***/
 	// ConsoleUIConfigMapName is the name of the console UI nginx configmap

--- a/internal/controller/ols_app_server_assets_test.go
+++ b/internal/controller/ols_app_server_assets_test.go
@@ -542,18 +542,31 @@ func generateRandomSecret() (*corev1.Secret, error) {
 	passwordHash, _ := hashBytes([]byte(encodedPassword))
 	secret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-secret",
-			Namespace: "openshift-lightspeed",
-			Labels:    generateAppServerSelectorLabels(),
-			Annotations: map[string]string{
-				RedisSecretHashKey: "test-hash",
-			},
+			Name:        "test-secret",
+			Namespace:   "openshift-lightspeed",
+			Labels:      generateAppServerSelectorLabels(),
+			Annotations: map[string]string{},
 		},
 		Data: map[string][]byte{
 			LLMApiTokenFileName: []byte(passwordHash),
+			"tls.key":           []byte("test tls key"),
+			"tls.crt":           []byte("test tls crt"),
 		},
 	}
 	return &secret, nil
+}
+
+func generateRandomConfigMap() (*corev1.ConfigMap, error) {
+	configMap := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-configmap",
+			Namespace: "openshift-lightspeed",
+		},
+		Data: map[string]string{
+			"service-ca.crt": "random ca cert content",
+		},
+	}
+	return &configMap, nil
 }
 
 func getDefaultOLSConfigCR() *olsv1alpha1.OLSConfig {

--- a/internal/controller/ols_app_server_deployment.go
+++ b/internal/controller/ols_app_server_deployment.go
@@ -63,7 +63,7 @@ func (r *OLSConfigReconciler) generateOLSDeployment(cr *olsv1alpha1.OLSConfig) (
 	// map from secret name to secret mount path
 	secretMounts := map[string]string{}
 	for _, provider := range cr.Spec.LLMConfig.Providers {
-		_, err := getSecretContent(r.Client, provider.CredentialsSecretRef.Name, r.Options.Namespace, LLMApiTokenFileName, &corev1.Secret{})
+		_, err := getSecretContent(r.Client, provider.CredentialsSecretRef.Name, r.Options.Namespace, []string{LLMApiTokenFileName}, &corev1.Secret{})
 		if err != nil {
 			return nil, err
 		}
@@ -248,9 +248,11 @@ func (r *OLSConfigReconciler) updateOLSDeployment(ctx context.Context, existingD
 	// Validate deployment annotations.
 	if existingDeployment.Annotations == nil ||
 		existingDeployment.Annotations[OLSConfigHashKey] != r.stateCache[OLSConfigHashStateCacheKey] ||
+		existingDeployment.Annotations[OLSAppTLSHashKey] != r.stateCache[OLSAppTLSHashStateCacheKey] ||
 		existingDeployment.Annotations[LLMProviderHashKey] != r.stateCache[LLMProviderHashStateCacheKey] {
 		updateDeploymentAnnotations(existingDeployment, map[string]string{
 			OLSConfigHashKey:   r.stateCache[OLSConfigHashStateCacheKey],
+			OLSAppTLSHashKey:   r.stateCache[OLSAppTLSHashStateCacheKey],
 			LLMProviderHashKey: r.stateCache[LLMProviderHashStateCacheKey],
 			// TODO: Update DB
 			//RedisSecretHashKey: r.stateCache[RedisSecretHashStateCacheKey],
@@ -258,6 +260,7 @@ func (r *OLSConfigReconciler) updateOLSDeployment(ctx context.Context, existingD
 		// update the deployment template annotation triggers the rolling update
 		updateDeploymentTemplateAnnotations(existingDeployment, map[string]string{
 			OLSConfigHashKey:   r.stateCache[OLSConfigHashStateCacheKey],
+			OLSAppTLSHashKey:   r.stateCache[OLSAppTLSHashStateCacheKey],
 			LLMProviderHashKey: r.stateCache[LLMProviderHashStateCacheKey],
 			// TODO: Update DB
 			//RedisSecretHashKey: r.stateCache[RedisSecretHashStateCacheKey],

--- a/internal/controller/ols_console_reconciliator_test.go
+++ b/internal/controller/ols_console_reconciliator_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/gomega"
 	consolev1 "github.com/openshift/api/console/v1"
 	openshiftv1 "github.com/openshift/api/operator/v1"
+	olsv1alpha1 "github.com/openshift/lightspeed-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -15,6 +16,7 @@ import (
 var _ = Describe("Console UI reconciliator", Ordered, func() {
 
 	Context("Creation logic", Ordered, func() {
+		var tlsSecret *corev1.Secret
 		BeforeAll(func() {
 			console := openshiftv1.Console{
 				ObjectMeta: metav1.ObjectMeta{
@@ -29,7 +31,19 @@ var _ = Describe("Console UI reconciliator", Ordered, func() {
 			}
 			err := k8sClient.Create(ctx, &console)
 			Expect(err).NotTo(HaveOccurred())
-
+			By("create the console tls secret")
+			tlsSecret, _ = generateRandomSecret()
+			tlsSecret.Name = ConsoleUIServiceCertSecretName
+			tlsSecret.SetOwnerReferences([]metav1.OwnerReference{
+				{
+					Kind:       "Secret",
+					APIVersion: "v1",
+					UID:        "ownerUID",
+					Name:       ConsoleUIServiceCertSecretName,
+				},
+			})
+			secretCreationErr := reconciler.Create(ctx, tlsSecret)
+			Expect(secretCreationErr).NotTo(HaveOccurred())
 		})
 
 		AfterAll(func() {
@@ -43,7 +57,9 @@ var _ = Describe("Console UI reconciliator", Ordered, func() {
 				return
 			}
 			Expect(err).NotTo(HaveOccurred())
-
+			By("Delete the console tls secret")
+			secretDeletionErr := reconciler.Delete(ctx, tlsSecret)
+			Expect(secretDeletionErr).NotTo(HaveOccurred())
 		})
 
 		It("should reconcile from OLSConfig custom resource", func() {
@@ -95,9 +111,96 @@ var _ = Describe("Console UI reconciliator", Ordered, func() {
 			Expect(console.Spec.Plugins).To(ContainElement(ConsoleUIPluginName))
 		})
 
+		It("should trigger rolling update of the console deployment when changing tls secret content", func() {
+
+			By("Get the deployment")
+			dep := &appsv1.Deployment{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: ConsoleUIDeploymentName, Namespace: OLSNamespaceDefault}, dep)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dep.Spec.Template.Annotations).NotTo(BeNil())
+			oldHash := dep.Spec.Template.Annotations[OLSConsoleTLSHashKey]
+			Expect(oldHash).NotTo(BeEmpty())
+
+			foundSecret := &corev1.Secret{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: ConsoleUIServiceCertSecretName, Namespace: OLSNamespaceDefault}, foundSecret)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Update the console tls secret content")
+			foundSecret.Data["tls.key"] = []byte("new-value")
+			err = k8sClient.Update(ctx, foundSecret)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Reconcile the console
+			olsConfig := &olsv1alpha1.OLSConfig{}
+			err = k8sClient.Get(ctx, crNamespacedName, olsConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Reconcile the console")
+			err = reconciler.reconcileConsoleUI(ctx, cr)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Get the updated deployment")
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: ConsoleUIDeploymentName, Namespace: OLSNamespaceDefault}, dep)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dep.Spec.Template.Annotations).NotTo(BeNil())
+
+			// Verify that the hash in deployment annotations has been updated
+			Expect(dep.Annotations[OLSConsoleTLSHashKey]).NotTo(Equal(oldHash))
+		})
+
+		It("should trigger rolling update of the console deployment when recreating tls secret", func() {
+
+			By("Get the deployment")
+			dep := &appsv1.Deployment{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: ConsoleUIDeploymentName, Namespace: OLSNamespaceDefault}, dep)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dep.Spec.Template.Annotations).NotTo(BeNil())
+			oldHash := dep.Spec.Template.Annotations[OLSConsoleTLSHashKey]
+			Expect(oldHash).NotTo(BeEmpty())
+
+			By("Delete the console tls secret")
+			secretDeletionErr := reconciler.Delete(ctx, tlsSecret)
+			Expect(secretDeletionErr).NotTo(HaveOccurred())
+
+			By("Recreate the provider secret")
+			tlsSecret, _ = generateRandomSecret()
+			tlsSecret.Name = ConsoleUIServiceCertSecretName
+			tlsSecret.SetOwnerReferences([]metav1.OwnerReference{
+				{
+					Kind:       "Secret",
+					APIVersion: "v1",
+					UID:        "ownerUID",
+					Name:       ConsoleUIServiceCertSecretName,
+				},
+			})
+			secretCreationErr := reconciler.Create(ctx, tlsSecret)
+			Expect(secretCreationErr).NotTo(HaveOccurred())
+
+			// Reconcile the console
+			olsConfig := &olsv1alpha1.OLSConfig{}
+			err = k8sClient.Get(ctx, crNamespacedName, olsConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Reconcile the console")
+			err = reconciler.reconcileConsoleUI(ctx, cr)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Get the updated deployment")
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: ConsoleUIDeploymentName, Namespace: OLSNamespaceDefault}, dep)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dep.Spec.Template.Annotations).NotTo(BeNil())
+
+			// Verify that the hash in deployment annotations has been updated
+			Expect(dep.Annotations[OLSConsoleTLSHashKey]).NotTo(Equal(oldHash))
+			By("Delete the console tls secret")
+			secretDeletionErr = reconciler.Delete(ctx, tlsSecret)
+			Expect(secretDeletionErr).NotTo(HaveOccurred())
+		})
+
 	})
 
 	Context("Deleting logic", Ordered, func() {
+		var tlsSecret *corev1.Secret
 		BeforeAll(func() {
 			console := openshiftv1.Console{
 				ObjectMeta: metav1.ObjectMeta{
@@ -112,6 +215,19 @@ var _ = Describe("Console UI reconciliator", Ordered, func() {
 			}
 			err := k8sClient.Create(ctx, &console)
 			Expect(err).NotTo(HaveOccurred())
+			By("create the console tls secret")
+			tlsSecret, _ = generateRandomSecret()
+			tlsSecret.Name = ConsoleUIServiceCertSecretName
+			tlsSecret.SetOwnerReferences([]metav1.OwnerReference{
+				{
+					Kind:       "Secret",
+					APIVersion: "v1",
+					UID:        "ownerUID",
+					Name:       ConsoleUIServiceCertSecretName,
+				},
+			})
+			secretCreationErr := reconciler.Create(ctx, tlsSecret)
+			Expect(secretCreationErr).NotTo(HaveOccurred())
 		})
 
 		AfterAll(func() {
@@ -125,6 +241,9 @@ var _ = Describe("Console UI reconciliator", Ordered, func() {
 				return
 			}
 			Expect(err).NotTo(HaveOccurred())
+			By("Delete the console tls secret")
+			secretDeletionErr := reconciler.Delete(ctx, tlsSecret)
+			Expect(secretDeletionErr).NotTo(HaveOccurred())
 		})
 
 		It("should reconcile from OLSConfig custom resource", func() {


### PR DESCRIPTION
## Description

This PR add a fix removing logic around CA secrets to  https://github.com/openshift/lightspeed-operator/pull/62
It reconciles for TLS secrets only.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
