### PR TITLE
Add spec.llm.providers.type to example OLSConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,14 @@ spec:
       - name: gpt-3.5-turbo
       name: openai
       url: https://api.openai.com/v1
+      type: openai
     - credentialsSecretRef:
         name: bam-api-keys
       models:
       - name: ibm/granite-13b-chat-v2
       name: bam
       url: https://bam-api.res.ibm.com
+      type: bam
   ols:
     conversationCache:
       redis:

--- a/internal/controller/ols_app_server_deployment.go
+++ b/internal/controller/ols_app_server_deployment.go
@@ -200,7 +200,7 @@ func (r *OLSConfigReconciler) generateOLSDeployment(cr *olsv1alpha1.OLSConfig) (
 										Scheme: corev1.URISchemeHTTPS,
 									},
 								},
-								InitialDelaySeconds: 60,
+								InitialDelaySeconds: 120,
 								PeriodSeconds:       10,
 							},
 						},


### PR DESCRIPTION
## Pull Request Description

### Add `spec.llm.providers.type`

This PR addresses an issue where the `OLSConfig` becomes invalid due to the absence of the `type` field in `spec.llm.providers`. Specifically, the following validation errors are encountered:

- `spec.llm.providers[0].type`: Required value
- `spec.llm.providers[1].type`: Required value

### Changes Made

- Added the `type` field to `spec.llm.providers`.

### Validation

This change ensures that the `OLSConfig` is valid by providing the necessary `type` field for each provider in the `spec.llm.providers` list.

Please review and merge to ensure proper configuration validation.

### Testing

- Verified that the `OLSConfig` is valid with the added `type` field.
- Ensured that no other parts of the configuration are affected by this change.
