### PR TITLE
OLS-500: disable data collection when telemetry is off

### DIFF
--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-06-19T16:13:18Z"
+    createdAt: "2024-06-21T10:00:37Z"
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-lightspeed
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
@@ -256,6 +256,16 @@ spec:
           - ""
           resources:
           - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resourceNames:
+          - pull-secret
+          resources:
+          - secrets
           verbs:
           - get
           - list

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -198,7 +198,17 @@ func main() {
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "0ca034e3.openshift.io",
 		Cache: cache.Options{
-			DefaultNamespaces: map[string]cache.Config{controller.OLSNamespaceDefault: {}},
+			DefaultNamespaces: map[string]cache.Config{
+				controller.OLSNamespaceDefault: {},
+			},
+			ByObject: map[client.Object]cache.ByObject{
+				&corev1.Secret{}: {
+					Namespaces: map[string]cache.Config{
+						controller.OLSNamespaceDefault:          {},
+						controller.TelemetryPullSecretNamespace: {},
+					},
+				},
+			},
 		},
 	})
 	if err != nil {

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -9,10 +9,11 @@ metadata:
     app.kubernetes.io/part-of: lightspeed-operator
     app.kubernetes.io/managed-by: kustomize
   name: leader-election-rolebinding
+  namespace: system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: leader-election-role
 subjects:
-  - kind: ServiceAccount
-    name: controller-manager
+- kind: ServiceAccount
+  name: controller-manager

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -44,6 +44,16 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resourceNames:
+  - pull-secret
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ols.openshift.io
   resources:
   - olsconfigs

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -111,4 +111,9 @@ const (
 
 	/*** watchers ***/
 	WatcherAnnotationKey = "ols.openshift.io/watcher"
+	// TelemetryPullSecretNamespace "openshift-config" contains the telemetry pull secret to determine the enablement of telemetry
+	// #nosec G101
+	TelemetryPullSecretNamespace = "openshift-config"
+	// TelemetryPullSecretName is the name of the secret containing the telemetry pull secret
+	TelemetryPullSecretName = "pull-secret"
 )

--- a/internal/controller/olsconfig_controller.go
+++ b/internal/controller/olsconfig_controller.go
@@ -84,6 +84,8 @@ type OLSConfigReconcilerOptions struct {
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch
 // Secret access for redis server configuration
 // +kubebuilder:rbac:groups=core,namespace=openshift-lightspeed,resources=secrets,verbs=get;list;watch;create;update;patch;delete
+// Secret access for telemetry pull secret, must be a cluster role due to OLM limitations in managing roles in operator namespace
+// +kubebuilder:rbac:groups=core,resources=secrets,resourceNames=pull-secret,verbs=get;list;watch
 // ConsolePlugin for install console plugin
 // +kubebuilder:rbac:groups=console.openshift.io,resources=consolelinks;consoleexternalloglinks;consoleplugins;consoleplugins/finalizers,verbs=get;create;update;delete
 // Modify console CR to activate console plugin
@@ -221,6 +223,7 @@ func (r *OLSConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Secret{}).
 		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(secretWatcherFilter)).
+		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(telemetryPullSecretWatcherFilter)).
 		Owns(&consolev1.ConsolePlugin{}).
 		Owns(&monv1.ServiceMonitor{}).
 		Owns(&monv1.PrometheusRule{}).

--- a/internal/controller/resource_watchers.go
+++ b/internal/controller/resource_watchers.go
@@ -33,3 +33,14 @@ func annotateSecretWatcher(secret *corev1.Secret) {
 	annotations[WatcherAnnotationKey] = OLSConfigName
 	secret.SetAnnotations(annotations)
 }
+
+func telemetryPullSecretWatcherFilter(ctx context.Context, obj client.Object) []reconcile.Request {
+	if obj.GetNamespace() != TelemetryPullSecretNamespace || obj.GetName() != TelemetryPullSecretName {
+		return nil
+	}
+	return []reconcile.Request{
+		{NamespacedName: types.NamespacedName{
+			Name: OLSConfigName,
+		}},
+	}
+}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -129,6 +129,15 @@ var _ = BeforeSuite(func() {
 	err = k8sClient.Create(ctx, ns)
 	Expect(err).NotTo(HaveOccurred())
 
+	By("Create the namespace openshift-config")
+	ns = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "openshift-config",
+		},
+	}
+	err = k8sClient.Create(ctx, ns)
+	Expect(err).NotTo(HaveOccurred())
+
 	reconciler = &OLSConfigReconciler{
 		Options: OLSConfigReconcilerOptions{
 			LightspeedServiceImage:      "lightspeed-service-api:latest",

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -234,16 +234,20 @@ func deploymentSpecEqual(a, b *appsv1.DeploymentSpec) bool {
 		return false
 	}
 
+	return containersEqual(a.Template.Spec.Containers, b.Template.Spec.Containers)
+}
+
+// containerEqual compares two container arrays and returns true if they are equal.
+func containersEqual(a, b []corev1.Container) bool {
 	// check containers
-	if len(a.Template.Spec.Containers) != len(b.Template.Spec.Containers) {
+	if len(a) != len(b) {
 		return false
 	}
-	for i := range a.Template.Spec.Containers {
-		if !containerSpecEqual(&a.Template.Spec.Containers[i], &b.Template.Spec.Containers[i]) {
+	for i := range a {
+		if !containerSpecEqual(&a[i], &b[i]) {
 			return false
 		}
 	}
-
 	return true
 }
 

--- a/lightspeed-catalog/index.yaml
+++ b/lightspeed-catalog/index.yaml
@@ -57,7 +57,7 @@ properties:
           }
         ]
       capabilities: Basic Install
-      createdAt: "2024-05-21T10:01:38Z"
+      createdAt: "2024-06-19T11:24:23Z"
       operatorframework.io/cluster-monitoring: "true"
       operatorframework.io/suggested-namespace: openshift-lightspeed
       operators.operatorframework.io/builder: operator-sdk-v1.33.0
@@ -255,8 +255,6 @@ relatedImages:
   name: lightspeed-operator
 - image: quay.io/openshift-lightspeed/lightspeed-service-api:latest
   name: lightspeed-service-api
-- image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:latest
-  name: ose-kube-rbac-proxy
 schema: olm.bundle
 ---
 schema: olm.channel


### PR DESCRIPTION
## Description
disable data collection when telemetry is off. 

Telemetry enablement is determined by the presence of the telemetry pull secret: the presence of the field '.auths."cloud.openshift.com"' indicates that telemetry is enabled.
Use this command to check in an Openshift cluster
```oc get secret/pull-secret -n openshift-config --template='{{index .data ".dockerconfigjson" | base64decode}}' | jq '.auths."cloud.openshift.com"'```

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # 
- Closes # OLS-500

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
