### PR TITLE
OLS-644: Use version-aligned OCP docs for RAG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,14 +119,16 @@ test: manifests generate fmt vet envtest test-crds ## Run local tests.
 
 OS_CONSOLE_CRD_URL = https://raw.githubusercontent.com/openshift/api/master/operator/v1/zz_generated.crd-manifests/0000_50_console_01_consoles.crd.yaml
 OS_CONSOLE_PLUGIN_CRD_URL = https://raw.githubusercontent.com/openshift/api/master/console/v1/zz_generated.crd-manifests/90_consoleplugins.crd.yaml
+OCP_CLUSTER_VERSION_CRD_URL = https://raw.githubusercontent.com/openshift/api/master/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversions-Default.crd.yaml
 MONITORING_CRD_URL = https://raw.githubusercontent.com/openshift/prometheus-operator/master/bundle.yaml
 TEST_CRD_DIR = .testcrds
 OS_CONSOLE_CRD_FILE = $(TEST_CRD_DIR)/openshift-console-crd.yaml
 OS_CONSOLE_PLUGIN_CRD_FILE = $(TEST_CRD_DIR)/openshift-console-plugin-crd.yaml
+OCP_CLUSTER_VERSION_CRD_FILE = $(TEST_CRD_DIR)/openshift-config-clusterversion-crd.yaml
 MONITORING_CRD_FILE = $(TEST_CRD_DIR)/monitoring-crd.yaml
 
 .PHONY: test-crds
-test-crds: $(TEST_CRD_DIR) $(OS_CONSOLE_CRD_FILE) $(OS_CONSOLE_PLUGIN_CRD_FILE) $(MONITORING_CRD_FILE) ## Test Dependencies CRDs
+test-crds: $(TEST_CRD_DIR) $(OS_CONSOLE_CRD_FILE) $(OS_CONSOLE_PLUGIN_CRD_FILE) $(MONITORING_CRD_FILE) $(OCP_CLUSTER_VERSION_CRD_FILE) ## Test Dependencies CRDs
 
 $(TEST_CRD_DIR):
 	mkdir -p $(TEST_CRD_DIR)
@@ -139,6 +141,9 @@ $(OS_CONSOLE_PLUGIN_CRD_FILE): $(TEST_CRD_DIR)
 
 $(MONITORING_CRD_FILE): $(TEST_CRD_DIR)
 	wget -O $(MONITORING_CRD_FILE) $(MONITORING_CRD_URL)
+
+$(OCP_CLUSTER_VERSION_CRD_FILE): $(TEST_CRD_DIR)
+	wget -O $(OCP_CLUSTER_VERSION_CRD_FILE) $(OCP_CLUSTER_VERSION_CRD_URL)
 
 
 .PHONY: test-e2e

--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -232,6 +232,7 @@ spec:
           - clusterversions
           verbs:
           - get
+          - list
         - apiGroups:
           - console.openshift.io
           resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -22,6 +22,7 @@ rules:
   - clusterversions
   verbs:
   - get
+  - list
 - apiGroups:
   - console.openshift.io
   resources:

--- a/internal/controller/ols_app_server_reconciliator.go
+++ b/internal/controller/ols_app_server_reconciliator.go
@@ -71,7 +71,7 @@ func (r *OLSConfigReconciler) reconcileAppServer(ctx context.Context, olsconfig 
 }
 
 func (r *OLSConfigReconciler) reconcileOLSConfigMap(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
-	cm, err := r.generateOLSConfigMap(cr)
+	cm, err := r.generateOLSConfigMap(ctx, cr)
 	if err != nil {
 		return fmt.Errorf("%s: %w", ErrGenerateAPIConfigmap, err)
 	}

--- a/internal/controller/olsconfig_controller.go
+++ b/internal/controller/olsconfig_controller.go
@@ -97,7 +97,7 @@ type OLSConfigReconcilerOptions struct {
 // +kubebuilder:rbac:groups=monitoring.coreos.com,namespace=openshift-lightspeed,resources=prometheusrules,verbs=get;list;watch;create;update;patch;delete
 
 // clusterversion for checking the openshift cluster version
-// +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get
+// +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list
 
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.17.3/pkg/reconcile

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	configv1 "github.com/openshift/api/config/v1"
 	consolev1 "github.com/openshift/api/console/v1"
 	openshiftv1 "github.com/openshift/api/operator/v1"
 	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -98,6 +99,26 @@ var _ = BeforeSuite(func() {
 	Expect(k8sClient).NotTo(BeNil())
 
 	ctx = context.Background()
+
+	By("Create the ClusterVersion object")
+	clusterVersion := &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "version",
+		},
+		Spec: configv1.ClusterVersionSpec{
+			ClusterID: "foobar",
+		},
+	}
+	err = k8sClient.Create(context.TODO(), clusterVersion)
+	Expect(err).NotTo(HaveOccurred())
+
+	clusterVersion.Status = configv1.ClusterVersionStatus{
+		Desired: configv1.Release{
+			Version: "123.456.789",
+		},
+	}
+	err = k8sClient.Status().Update(context.TODO(), clusterVersion)
+	Expect(err).NotTo(HaveOccurred())
 
 	By("Create the namespace openshift-lightspeed")
 	ns := &corev1.Namespace{


### PR DESCRIPTION
## Description

Get OLS to retrieve rag content specific to the OCP version the customer is using

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes # https://issues.redhat.com/browse/OLS-644

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
