### PR TITLE
[OLS-620] Use all fields from provider secret from the user

### DIFF
--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -26,8 +26,6 @@ const (
 	CredentialsMountRoot = "/etc/credentials"
 	// OLSAppCertsMountRoot is the directory hosting the cert files in the container
 	OLSAppCertsMountRoot = "/etc/certs"
-	// LLMApiTokenFileName is the name of the file containing the API token to access LLM in the secret referenced by the OLSConfig
-	LLMApiTokenFileName = "apitoken"
 	// OLSComponentPasswordFileName is the generic name of the password file for each of its components
 	OLSComponentPasswordFileName = "password"
 	// OLSConfigFilename is the name of the application server configuration file

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -70,7 +70,8 @@ const (
 	OLSConsoleTLSHashStateCacheKey = "olsconsoletls-hash"
 	// LLMProviderHashStateCacheKey is the key of the hash value of OLS LLM provider credentials consolidated
 	LLMProviderHashStateCacheKey = "llmprovider-hash"
-
+	// AzureOpenAIType is the name of the Azure OpenAI provider type
+	AzureOpenAIType = "azure_openai"
 	/*** console UI plugin ***/
 	// ConsoleUIConfigMapName is the name of the console UI nginx configmap
 	ConsoleUIConfigMapName = "lightspeed-console-plugin"

--- a/internal/controller/ols_app_server_assets.go
+++ b/internal/controller/ols_app_server_assets.go
@@ -115,15 +115,26 @@ func (r *OLSConfigReconciler) generateOLSConfigMap(cr *olsv1alpha1.OLSConfig) (*
 			}
 			modelConfigs = append(modelConfigs, modelConfig)
 		}
-
-		providerConfig := ProviderConfig{
-			Name:                provider.Name,
-			Type:                provider.Type,
-			URL:                 provider.URL,
-			CredentialsPath:     credentialPath,
-			Models:              modelConfigs,
-			AzureDeploymentName: provider.AzureDeploymentName,
-			WatsonProjectID:     provider.WatsonProjectID,
+		providerConfig := ProviderConfig{}
+		if provider.Type == AzureOpenAIType {
+			providerConfig = ProviderConfig{
+				Name: provider.Name,
+				Type: provider.Type,
+				AzureOpenAIConfig: &AzureOpenAIConfig{
+					URL:                 provider.URL,
+					CredentialsPath:     credentialPath,
+					AzureDeploymentName: provider.AzureDeploymentName,
+				},
+			}
+		} else {
+			providerConfig = ProviderConfig{
+				Name:            provider.Name,
+				Type:            provider.Type,
+				URL:             provider.URL,
+				CredentialsPath: credentialPath,
+				Models:          modelConfigs,
+				WatsonProjectID: provider.WatsonProjectID,
+			}
 		}
 		providerConfigs = append(providerConfigs, providerConfig)
 	}

--- a/internal/controller/ols_app_server_assets.go
+++ b/internal/controller/ols_app_server_assets.go
@@ -115,7 +115,7 @@ func (r *OLSConfigReconciler) generateOLSConfigMap(cr *olsv1alpha1.OLSConfig) (*
 			}
 			modelConfigs = append(modelConfigs, modelConfig)
 		}
-		providerConfig := ProviderConfig{}
+		var providerConfig ProviderConfig
 		if provider.Type == AzureOpenAIType {
 			providerConfig = ProviderConfig{
 				Name: provider.Name,

--- a/internal/controller/ols_app_server_assets.go
+++ b/internal/controller/ols_app_server_assets.go
@@ -106,7 +106,7 @@ func (r *OLSConfigReconciler) generateSARClusterRoleBinding(cr *olsv1alpha1.OLSC
 func (r *OLSConfigReconciler) generateOLSConfigMap(cr *olsv1alpha1.OLSConfig) (*corev1.ConfigMap, error) {
 	providerConfigs := []ProviderConfig{}
 	for _, provider := range cr.Spec.LLMConfig.Providers {
-		credentialPath := path.Join(APIKeyMountRoot, provider.CredentialsSecretRef.Name, LLMApiTokenFileName)
+		credentialPath := path.Join(APIKeyMountRoot, provider.CredentialsSecretRef.Name)
 		modelConfigs := []ModelConfig{}
 		for _, model := range provider.Models {
 			modelConfig := ModelConfig{

--- a/internal/controller/ols_app_server_assets.go
+++ b/internal/controller/ols_app_server_assets.go
@@ -118,8 +118,9 @@ func (r *OLSConfigReconciler) generateOLSConfigMap(cr *olsv1alpha1.OLSConfig) (*
 		var providerConfig ProviderConfig
 		if provider.Type == AzureOpenAIType {
 			providerConfig = ProviderConfig{
-				Name: provider.Name,
-				Type: provider.Type,
+				Name:   provider.Name,
+				Type:   provider.Type,
+				Models: modelConfigs,
 				AzureOpenAIConfig: &AzureOpenAIConfig{
 					URL:                 provider.URL,
 					CredentialsPath:     credentialPath,

--- a/internal/controller/ols_app_server_assets_test.go
+++ b/internal/controller/ols_app_server_assets_test.go
@@ -171,9 +171,13 @@ var _ = Describe("App server assets", func() {
 			err = yaml.Unmarshal([]byte(cm.Data[OLSConfigFilename]), &olsConfigMap)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(olsConfigMap).To(HaveKeyWithValue("llm_providers", ContainElement(MatchKeys(Options(IgnoreExtras), Keys{
-				"name":            Equal("openai"),
-				"type":            Equal("azure_openai"),
-				"deployment_name": Equal("testDeployment"),
+				"name": Equal("openai"),
+				"type": Equal("azure_openai"),
+				"azure_openai_config": MatchKeys(Options(IgnoreExtras), Keys{
+					"url":              Equal(testURL),
+					"credentials_path": Equal("/etc/apikeys/test-secret"),
+					"deployment_name":  Equal("testDeployment"),
+				}),
 			}))))
 		})
 

--- a/internal/controller/ols_app_server_assets_test.go
+++ b/internal/controller/ols_app_server_assets_test.go
@@ -127,7 +127,7 @@ var _ = Describe("App server assets", func() {
 					{
 						Name:            "testProvider",
 						URL:             testURL,
-						CredentialsPath: "/etc/apikeys/test-secret/apitoken",
+						CredentialsPath: "/etc/apikeys/test-secret",
 						Type:            "bam",
 						Models: []ModelConfig{
 							{
@@ -545,9 +545,9 @@ func generateRandomSecret() (*corev1.Secret, error) {
 			Annotations: map[string]string{},
 		},
 		Data: map[string][]byte{
-			LLMApiTokenFileName: []byte(passwordHash),
-			"tls.key":           []byte("test tls key"),
-			"tls.crt":           []byte("test tls crt"),
+			"client_secret": []byte(passwordHash),
+			"tls.key":       []byte("test tls key"),
+			"tls.crt":       []byte("test tls crt"),
 		},
 	}
 	return &secret, nil

--- a/internal/controller/ols_app_server_deployment.go
+++ b/internal/controller/ols_app_server_deployment.go
@@ -63,10 +63,6 @@ func (r *OLSConfigReconciler) generateOLSDeployment(cr *olsv1alpha1.OLSConfig) (
 	// map from secret name to secret mount path
 	secretMounts := map[string]string{}
 	for _, provider := range cr.Spec.LLMConfig.Providers {
-		_, err := getSecretContent(r.Client, provider.CredentialsSecretRef.Name, r.Options.Namespace, []string{LLMApiTokenFileName}, &corev1.Secret{})
-		if err != nil {
-			return nil, err
-		}
 		credentialMountPath := path.Join(APIKeyMountRoot, provider.CredentialsSecretRef.Name)
 		secretMounts[provider.CredentialsSecretRef.Name] = credentialMountPath
 	}

--- a/internal/controller/ols_app_server_reconciliator.go
+++ b/internal/controller/ols_app_server_reconciliator.go
@@ -273,11 +273,13 @@ func (r *OLSConfigReconciler) reconcileLLMSecrets(ctx context.Context, cr *olsv1
 	providerCredentials := ""
 	for _, provider := range cr.Spec.LLMConfig.Providers {
 		foundSecret := &corev1.Secret{}
-		secretValues, err := getSecretContent(r.Client, provider.CredentialsSecretRef.Name, r.Options.Namespace, []string{LLMApiTokenFileName}, foundSecret)
+		secretValues, err := getAllSecretContent(r.Client, provider.CredentialsSecretRef.Name, r.Options.Namespace, foundSecret)
 		if err != nil {
 			return fmt.Errorf("Secret token not found for provider: %s. error: %w", provider.Name, err)
 		}
-		providerCredentials += secretValues[LLMApiTokenFileName]
+		for key, value := range secretValues {
+			providerCredentials += key + "=" + value + "\n"
+		}
 		annotateSecretWatcher(foundSecret)
 		err = r.Update(ctx, foundSecret)
 		if err != nil {

--- a/internal/controller/ols_app_server_reconciliator_test.go
+++ b/internal/controller/ols_app_server_reconciliator_test.go
@@ -230,7 +230,7 @@ var _ = Describe("App server reconciliator", Ordered, func() {
 			Expect(dep.Spec.Template.Annotations).NotTo(BeNil())
 			oldHash := dep.Spec.Template.Annotations[LLMProviderHashKey]
 			By("Update the provider secret content")
-			secret.Data[LLMApiTokenFileName] = []byte("new-value")
+			secret.Data["apitoken2"] = []byte("new-value")
 			err = k8sClient.Update(ctx, secret)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/internal/controller/types.go
+++ b/internal/controller/types.go
@@ -49,7 +49,7 @@ type ProviderConfig struct {
 type AzureOpenAIConfig struct {
 	// Azure OpenAI API URL
 	URL string `json:"url,omitempty"`
-	// Azure OpenAI API Key
+	// Path where Azure OpenAI accesstoken or credentials are stored
 	CredentialsPath string `json:"credentials_path"`
 	// Azure deployment name
 	AzureDeploymentName string `json:"deployment_name,omitempty"`

--- a/internal/controller/types.go
+++ b/internal/controller/types.go
@@ -35,15 +35,24 @@ type ProviderConfig struct {
 	URL string `json:"url,omitempty"`
 	// Path to the file containing API provider credentials in the app server container.
 	// default to "bam_api_key.txt"
-	CredentialsPath string `json:"credentials_path" default:"bam_api_key.txt"`
+	CredentialsPath string `json:"credentials_path,omitempty" default:"bam_api_key.txt"`
 	// List of models from the provider
 	Models []ModelConfig `json:"models,omitempty"`
 	// Provider type
 	Type string `json:"type,omitempty"`
-	// Azure deployment name
-	AzureDeploymentName string `json:"deployment_name,omitempty"`
 	// Watsonx Project ID
 	WatsonProjectID string `json:"project_id,omitempty"`
+	// Azure OpenAI Config
+	AzureOpenAIConfig *AzureOpenAIConfig `json:"azure_openai_config,omitempty"`
+}
+
+type AzureOpenAIConfig struct {
+	// Azure OpenAI API URL
+	URL string `json:"url,omitempty"`
+	// Azure OpenAI API Key
+	CredentialsPath string `json:"credentials_path"`
+	// Azure deployment name
+	AzureDeploymentName string `json:"deployment_name,omitempty"`
 }
 
 // ModelSpec defines the desired state of in-memory cache.

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -166,6 +166,21 @@ func getSecretContent(rclient client.Client, secretName string, namespace string
 	return secretValues, nil
 }
 
+func getAllSecretContent(rclient client.Client, secretName string, namespace string, foundSecret *corev1.Secret) (map[string]string, error) {
+	ctx := context.Background()
+	err := rclient.Get(ctx, client.ObjectKey{Name: secretName, Namespace: namespace}, foundSecret)
+	if err != nil {
+		return nil, fmt.Errorf("secret not found: %s. error: %w", secretName, err)
+	}
+
+	secretValues := make(map[string]string)
+	for key, value := range foundSecret.Data {
+		secretValues[key] = string(value)
+	}
+
+	return secretValues, nil
+}
+
 // podVolumEqual compares two slices of corev1.Volume and returns true if they are equal.
 // covers 3 volume types: Secret, ConfigMap, EmptyDir
 func podVolumeEqual(a, b []corev1.Volume) bool {


### PR DESCRIPTION
## Description
Updated the secret mount path  not to include the filename , so that we can support all secret configurations.
Added azure_openai_config specific confing .


## Type of change

- [] Refactor
- [] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue [OLS-620](https://issues.redhat.com/browse/OLS-620)


## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
