### PR TITLE
fix: always update the latest version of CR in e2e reconciliation test

### DIFF
--- a/test/e2e/reconciliation_test.go
+++ b/test/e2e/reconciliation_test.go
@@ -171,6 +171,9 @@ var _ = Describe("Reconciliation From OLSConfig CR", Ordered, func() {
 		generation = deployment.Generation
 
 		By("update models in the OLSConfig CR")
+		err = client.Get(cr)
+		Expect(err).NotTo(HaveOccurred())
+
 		cr.Spec.OLSConfig.DefaultModel = OpenAIAlternativeModel
 		if !slices.Contains(cr.Spec.LLMConfig.Providers[0].Models, olsv1alpha1.ModelSpec{Name: OpenAIAlternativeModel}) {
 			cr.Spec.LLMConfig.Providers[0].Models = append(cr.Spec.LLMConfig.Providers[0].Models, olsv1alpha1.ModelSpec{Name: OpenAIAlternativeModel})
@@ -199,6 +202,9 @@ var _ = Describe("Reconciliation From OLSConfig CR", Ordered, func() {
 		generation = deployment.Generation
 
 		By("change LLM token secret reference")
+		err = client.Get(cr)
+		Expect(err).NotTo(HaveOccurred())
+
 		cr.Spec.LLMConfig.Providers[0].CredentialsSecretRef.Name = LLMTokenSecondSecretName
 		err = client.Update(cr)
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Description

This fix is for the version conflict error of updating CR olsconfig during the e2e test. 
for example
```text
Reconciliation From OLSConfig CR [It] should reconcile app configmap after changing application settings
/home/hsun/lightspeed-operator/test/e2e/reconciliation_test.go:130

  [FAILED] Unexpected error:
      <*errors.StatusError | 0xc00041b220>:
      Operation cannot be fulfilled on olsconfigs.ols.openshift.io "cluster": the object has been modified; please apply your changes to the latest version and try again
      {
          ErrStatus: {
              TypeMeta: {Kind: "", APIVersion: ""},
              ListMeta: {
                  SelfLink: "",
                  ResourceVersion: "",
                  Continue: "",
                  RemainingItemCount: nil,
              },
              Status: "Failure",
              Message: "Operation cannot be fulfilled on olsconfigs.ols.openshift.io \"cluster\": the object has been modified; please apply your changes to the latest version and try again",
              Reason: "Conflict",
              Details: {
                  Name: "cluster",
                  Group: "ols.openshift.io",
                  Kind: "olsconfigs",
                  UID: "",
                  Causes: nil,
                  RetryAfterSeconds: 0,
              },
              Code: 409,
          },
      }
  occurred
  In [It] at: /home/hsun/lightspeed-operator/test/e2e/reconciliation_test.go:180 @ 06/11/24 11:41:30.113
```


## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
