### PR TITLE
cleanup: update catalog index to latest CRD

### DIFF
--- a/lightspeed-catalog/index.yaml
+++ b/lightspeed-catalog/index.yaml
@@ -57,7 +57,7 @@ properties:
           }
         ]
       capabilities: Basic Install
-      createdAt: "2024-05-15T07:03:09Z"
+      createdAt: "2024-05-21T10:01:38Z"
       operatorframework.io/cluster-monitoring: "true"
       operatorframework.io/suggested-namespace: openshift-lightspeed
       operators.operatorframework.io/builder: operator-sdk-v1.33.0
@@ -171,11 +171,6 @@ properties:
           path: ols.deployment.replicas
           x-descriptors:
           - urn:alm:descriptor:com.tectonic.ui:podCount
-        - description: 'Disable Authorization for OLS server. Default: "false"'
-          displayName: Disable Authorization
-          path: ols.disableAuth
-          x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
         - description: 'Log level. Valid options are DEBUG, INFO, WARNING, ERROR and
             CRITICAL. Default: "INFO".'
           displayName: Log level


### PR DESCRIPTION
## Description

Complete https://github.com/openshift/lightspeed-operator/pull/140 by cleaning up the remenants of `disableAuth` field in the catalog index.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
