### PR TITLE
fix: wait TLS secret be created before fetching key and cert

### DIFF
--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -1,5 +1,7 @@
 package controller
 
+import "time"
+
 const (
 	/*** Operator Settings ***/
 	// OLSConfigName is the name of the OLSConfig Custom Resource
@@ -20,6 +22,8 @@ const (
 	ClientCACmNamespace = "openshift-monitoring"
 	// ClientCACertKey is the key of the client CA certificate in the configmap
 	ClientCACertKey = "client-ca.crt"
+	// ResourceCreationTimeout is the maximum time in seconds operator waiting for creating resources
+	ResourceCreationTimeout = 60 * time.Second
 
 	/*** application server configuration file ***/
 	// OLSConfigName is the name of the OLSConfig configmap


### PR DESCRIPTION
## Description

wait TLS secret be created before fetching key and certificate when creating application server and the console UI deployment. 
This PR will elimites this error:
```text
2024-06-28T10:07:01+02:00	ERROR	Reconciler	reconcileConsoleUI error	{"task": "reconcile Console Plugin TLS Certs", "error": "secret: lightspeed-console-plugin-cert does not have expected tls.key or tls.crt. error: secret not found: lightspeed-console-plugin-cert. error: Secret \"lightspeed-console-plugin-cert\" not found"}
github.com/openshift/lightspeed-operator/internal/controller.(*OLSConfigReconciler).reconcileConsoleUI
	/home/hsun/lightspeed-operator/internal/controller/ols_console_reconciliator.go:52
github.com/openshift/lightspeed-operator/internal/controller.(*OLSConfigReconciler).Reconcile
	/home/hsun/lightspeed-operator/internal/controller/olsconfig_controller.go:141
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
	/home/hsun/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:119
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/home/hsun/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:316
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/home/hsun/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:266
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/home/hsun/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:227
```

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
