### PR TITLE
Not restricting the secret to pull-secret as a temp fix

### DIFF
--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-06-21T10:00:37Z"
+    createdAt: "2024-06-28T13:11:13Z"
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-lightspeed
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
@@ -240,6 +240,7 @@ spec:
           verbs:
           - get
           - list
+          - watch
         - apiGroups:
           - console.openshift.io
           resources:
@@ -262,8 +263,6 @@ spec:
           - watch
         - apiGroups:
           - ""
-          resourceNames:
-          - pull-secret
           resources:
           - secrets
           verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -23,6 +23,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - console.openshift.io
   resources:
@@ -45,8 +46,6 @@ rules:
   - watch
 - apiGroups:
   - ""
-  resourceNames:
-  - pull-secret
   resources:
   - secrets
   verbs:

--- a/internal/controller/olsconfig_controller.go
+++ b/internal/controller/olsconfig_controller.go
@@ -85,7 +85,7 @@ type OLSConfigReconcilerOptions struct {
 // Secret access for redis server configuration
 // +kubebuilder:rbac:groups=core,namespace=openshift-lightspeed,resources=secrets,verbs=get;list;watch;create;update;patch;delete
 // Secret access for telemetry pull secret, must be a cluster role due to OLM limitations in managing roles in operator namespace
-// +kubebuilder:rbac:groups=core,resources=secrets,resourceNames=pull-secret,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
 // ConsolePlugin for install console plugin
 // +kubebuilder:rbac:groups=console.openshift.io,resources=consolelinks;consoleexternalloglinks;consoleplugins;consoleplugins/finalizers,verbs=get;create;update;delete
 // Modify console CR to activate console plugin
@@ -104,7 +104,7 @@ type OLSConfigReconcilerOptions struct {
 // +kubebuilder:rbac:groups=monitoring.coreos.com,namespace=openshift-lightspeed,resources=prometheusrules,verbs=get;list;watch;create;update;patch;delete
 
 // clusterversion for checking the openshift cluster version
-// +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list
+// +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list;watch
 
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.17.3/pkg/reconcile

--- a/lightspeed-catalog/index.yaml
+++ b/lightspeed-catalog/index.yaml
@@ -57,7 +57,7 @@ properties:
           }
         ]
       capabilities: Basic Install
-      createdAt: "2024-06-19T11:24:23Z"
+      createdAt: "2024-06-21T10:00:37Z"
       operatorframework.io/cluster-monitoring: "true"
       operatorframework.io/suggested-namespace: openshift-lightspeed
       operators.operatorframework.io/builder: operator-sdk-v1.33.0
@@ -197,6 +197,13 @@ properties:
           path: ols.summarizerProvider
           x-descriptors:
           - urn:alm:descriptor:com.tectonic.ui:advanced
+        - description: User data collection switches
+          displayName: User Data Collection
+          path: ols.userDataCollection
+        - displayName: Do Not Collect User Feedback
+          path: ols.userDataCollection.feedbackDisabled
+        - displayName: Do Not Collect Transcripts
+          path: ols.userDataCollection.transcriptsDisabled
         - description: Validator model name
           displayName: Validator Model
           path: ols.validatorModel


### PR DESCRIPTION
## Description
ServiceAccount used by sidecar only needs to watch the secret (pull-secret) in the namespace (openshift-config) but the controller attempts to watch all secrets in the namespace (openshift-config) . Until we find a long term solution , this PR gives access to all secrets(removed resourcename=pullsecret) 

Same with clusterversions - the controller code attempts to watch it, though we only need to `list and get` the clusterversion (as it will not change). 

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
