### PR TITLE
OLS-780: fix double reconciliation on deployment creation

### DIFF
--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -1,0 +1,81 @@
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	// . "github.com/onsi/gomega/gstruct"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+var _ = Describe("Probe Equality", func() {
+	It("should return true when probes are equal", func() {
+		var sixty int64 = int64(60)
+		probe1 := &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path:   "/liveness",
+					Port:   intstr.FromString("https"),
+					Scheme: corev1.URISchemeHTTPS,
+				},
+			},
+			InitialDelaySeconds:           60,
+			PeriodSeconds:                 10,
+			TimeoutSeconds:                1,
+			FailureThreshold:              3,
+			SuccessThreshold:              1,
+			TerminationGracePeriodSeconds: &sixty,
+		}
+		probe2 := probe1.DeepCopy()
+		Expect(probeEqual(probe1, probe2)).To(BeTrue())
+	})
+	It("should return false when probes are not equal", func() {
+		probe1 := &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path:   "/liveness",
+					Port:   intstr.FromString("https"),
+					Scheme: corev1.URISchemeHTTPS,
+				},
+			},
+			InitialDelaySeconds: 60,
+			PeriodSeconds:       10,
+			TimeoutSeconds:      1,
+			FailureThreshold:    3,
+			SuccessThreshold:    1,
+		}
+		probe2 := probe1.DeepCopy()
+		probe2.InitialDelaySeconds = probe2.InitialDelaySeconds + 1
+		Expect(probeEqual(probe1, probe2)).To(BeFalse())
+	})
+	It("should ignore empty values when comparing partial defined probes with complete probes", func() {
+		partialDefined := &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path:   "/liveness",
+					Port:   intstr.FromString("https"),
+					Scheme: corev1.URISchemeHTTPS,
+				},
+			},
+			InitialDelaySeconds: 60,
+			PeriodSeconds:       10,
+		}
+		defaultFilled := &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path:   "/liveness",
+					Port:   intstr.FromString("https"),
+					Scheme: corev1.URISchemeHTTPS,
+				},
+			},
+			InitialDelaySeconds: 60,
+			PeriodSeconds:       10,
+			TimeoutSeconds:      1,
+			FailureThreshold:    3,
+			SuccessThreshold:    1,
+		}
+		Expect(probeEqual(partialDefined, defaultFilled)).To(BeTrue())
+	})
+
+})


### PR DESCRIPTION
## Description

This PR fixes the issue that when creating the application deployment, the operator immediately reconciles the just created deployment due to a difference in the readiness & liveness probes: the created deployment does not specify all fields and upon next even the comparison between desired deployment and the existing deployment differ in the probe specifications. For example the `FailureThreshold` field.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # [OLS-780](https://issues.redhat.com/browse/OLS-780)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
