### PR TITLE
OLS-768:  bundle uses konflux built images

### DIFF
--- a/.tekton/bundle-pull-request.yaml
+++ b/.tekton/bundle-pull-request.yaml
@@ -8,8 +8,10 @@ metadata:
     build.appstudio.redhat.com/target_branch: "{{target_branch}}"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression:
-      event == "pull_request" && target_branch
-      == "main"
+      event == "pull_request" &&
+      target_branch == "main" &&
+      ("bundle/**/*".pathChanged() || "bundle.Dockerfile".pathChanged())
+    build.appstudio.openshift.io/build-nudge-files: ".*Dockerfile.*, .*.yaml, .*Containerfile.*,.*.sh"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: ols

--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-06-28T13:11:13Z"
+    createdAt: "2024-07-03T18:06:34Z"
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-lightspeed
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
@@ -342,7 +342,7 @@ spec:
                 - --metrics-bind-address=:8443
                 - --secure-metrics-server
                 - --cert-dir=/etc/tls/private
-                - --images=lightspeed-service=quay.io/openshift-lightspeed/lightspeed-service-api:latest
+                - --images=lightspeed-service=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service@sha256:c72c20851aac390ba4a9d5d5b47e78af82bc2a59fb237fa4850066b52243cd53,console-plugin=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console@sha256:c5379d8871822a9bd7642705a31e9201d7594a52aa50593e0fd4e44853085bee
                 command:
                 - /manager
                 env:
@@ -350,7 +350,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/openshift-lightspeed/lightspeed-operator:latest
+                image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator@sha256:e7c4661a256560de864a7076f66ec5729aa7d4617b93cb8804a5f4831ad31e6c
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:
@@ -544,8 +544,8 @@ spec:
   version: 0.0.1
   relatedImages:
     - name: lightspeed-service-api
-      image: quay.io/openshift-lightspeed/lightspeed-service-api:latest
+      image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service@sha256:c72c20851aac390ba4a9d5d5b47e78af82bc2a59fb237fa4850066b52243cd53
     - name: lightspeed-console-plugin
-      image: quay.io/openshift-lightspeed/lightspeed-console-plugin:latest
+      image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console@sha256:c5379d8871822a9bd7642705a31e9201d7594a52aa50593e0fd4e44853085bee
     - name: lightspeed-operator
-      image: quay.io/openshift-lightspeed/lightspeed-operator:latest
+      image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator@sha256:e7c4661a256560de864a7076f66ec5729aa7d4617b93cb8804a5f4831ad31e6c

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -33,7 +33,8 @@ patches:
   - patch: |-
       - op: add
         path: /spec/template/spec/containers/0/args/-
-        value: --images=lightspeed-service=quay.io/openshift-lightspeed/lightspeed-service-api:latest
+        value: --images=lightspeed-service=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service@sha256:c72c20851aac390ba4a9d5d5b47e78af82bc2a59fb237fa4850066b52243cd53,console-plugin=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console@sha256:c5379d8871822a9bd7642705a31e9201d7594a52aa50593e0fd4e44853085bee
+
     target:
       group: apps
       version: v1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -3,6 +3,6 @@ resources:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- name: controller
-  newName: quay.io/openshift-lightspeed/lightspeed-operator
-  newTag: latest
+- digest: sha256:e7c4661a256560de864a7076f66ec5729aa7d4617b93cb8804a5f4831ad31e6c
+  name: controller
+  newName: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator


### PR DESCRIPTION
## Description

This is step 3 of building our bundle image on konflux. images referenced in the bundle are set to use images built on Konflux.

Attention: Merge the PR on openshift/release before this one, to allow image substitutions on images built on konflux and by consequence the prow CI test will keep working after this PR is merged.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # [OLS-768](https://issues.redhat.com//browse/OLS-768)
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
