### PR TITLE
fix: multi-line syntax in konflux config

### DIFF
--- a/.tekton/bundle-pull-request.yaml
+++ b/.tekton/bundle-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
     build.appstudio.redhat.com/target_branch: "{{target_branch}}"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression:
+    pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
       target_branch == "main" &&
       ("bundle/**/*".pathChanged() || "bundle.Dockerfile".pathChanged())

--- a/.tekton/bundle-push.yaml
+++ b/.tekton/bundle-push.yaml
@@ -6,9 +6,9 @@ metadata:
     build.appstudio.redhat.com/commit_sha: "{{revision}}"
     build.appstudio.redhat.com/target_branch: "{{target_branch}}"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression:
-      event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" &&
+      target_branch == "main"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: ols

--- a/.tekton/lightspeed-operator-pull-request.yaml
+++ b/.tekton/lightspeed-operator-pull-request.yaml
@@ -7,10 +7,10 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression:
+    pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
       target_branch == "main" &&
-      ( "Dockerfile".pathChanged() || "LICENSE".patchChanged() || "go.*".pathChanged() || "cmd/**".patchChanged() || "api/**".patchChanged() || "internal/**".patchChanged())
+      ( "Dockerfile".pathChanged() || "LICENSE".patchChanged() || "go.*".pathChanged() || "cmd/**".patchChanged() || "api/**".patchChanged() || "internal/**".patchChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: ols


### PR DESCRIPTION
## Description

fix the syntax for multiple-line string of `pipelinesascode.tekton.dev/on-cel-expression`

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library


