### PR TITLE
fix that checks for exactly one timeseries

### DIFF
--- a/test/e2e/prometheus_client.go
+++ b/test/e2e/prometheus_client.go
@@ -204,8 +204,7 @@ func (c *PrometheusClient) PrometheusLabel(label string) ([]byte, error) {
 }
 
 // GetFirstValueFromPromQuery takes a query api response body and returns the
-// value of the first timeseries. If body contains multiple timeseries
-// GetFirstValueFromPromQuery errors.
+// value of the first timeseries.
 func GetFirstValueFromPromQuery(body []byte) (float64, error) {
 	res, err := gabs.ParseJSON(body)
 	if err != nil {

--- a/test/e2e/prometheus_client.go
+++ b/test/e2e/prometheus_client.go
@@ -212,15 +212,6 @@ func GetFirstValueFromPromQuery(body []byte) (float64, error) {
 		return 0, err
 	}
 
-	count, err := res.ArrayCountP("data.result")
-	if err != nil {
-		return 0, err
-	}
-
-	if count != 1 {
-		return 0, fmt.Errorf("expected body to contain single timeseries but got %v", count)
-	}
-
 	timeseries, err := res.ArrayElementP(0, "data.result")
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
## Description
Fixes e2e test that is running on on hypershift clusters, where  we  can get multiple timeseries .

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
