### PR TITLE
fix: e2e test - metric test aggregaton fix

### DIFF
--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -90,11 +90,11 @@ var _ = Describe("Prometheus Metrics", Ordered, func() {
 
 	It("should have operator metrics in Prometheus", func() {
 		By("verify Prometheus is working correctly by querying prometheus' own metrics")
-		err = prometheusClient.WaitForQueryReturnGreaterEqualOne("prometheus_build_info", DefaultClientTimeout)
+		err = prometheusClient.WaitForQueryReturnGreaterEqualOne("topk(1,prometheus_build_info)", DefaultClientTimeout)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("verify prometheus scrapes metrics from operator, this should happen every 60 seconds")
-		err = prometheusClient.WaitForQueryReturn("scrape_duration_seconds{job=\"lightspeed-operator-controller-manager-service\"}",
+		err = prometheusClient.WaitForQueryReturn("avg(scrape_duration_seconds{job=\"lightspeed-operator-controller-manager-service\"})",
 			60*time.Second,
 			func(val float64) error {
 				if val > 0.0 {


### PR DESCRIPTION
## Description

This fixes a issue caused by querying multiple timeseries using the `WaitForQueryReturnGreaterEqualOne` function in E2E test

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
