### PR TITLE
 updated catalog base image with 4.16

### DIFF
--- a/lightspeed-catalog.Dockerfile
+++ b/lightspeed-catalog.Dockerfile
@@ -1,6 +1,4 @@
-# The base image is expected to contain
-# /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM registry.redhat.io/openshift4/ose-operator-registry:latest
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.16
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]


### PR DESCRIPTION
## Description

Updated the base image with 4.than using latest. We want to  build from SCRATCH , but currently I see a problem with running in 4.15 OCP clusters . We will fix using https://issues.redhat.com/browse/OLS-863

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
