### PR TITLE
OLS-567: catalog refers production image + version specific dockerfile for catalog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -356,7 +356,7 @@ endif
 # https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
 .PHONY: catalog-build
 catalog-build: opm ## Build a catalog image.
-	$(OPM) index add --container-tool docker --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
+	$(OPM) index add --container-tool ${CONTAINER_TOOL} --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
 
 # Push the catalog image.
 .PHONY: catalog-push

--- a/hack/update_bundle_catalog.sh
+++ b/hack/update_bundle_catalog.sh
@@ -41,7 +41,7 @@ fi
 : "${BUNDLE_IMAGE:=registry.redhat.io/openshift-lightspeed-beta/lightspeed-operator-bundle@sha256:e46e337502a00282473e083c16a64e6201df3677905e4b056b7f48ef0b8f6e4b}"
 : "${CONSOLE_IMAGE:=registry.redhat.io/openshift-lightspeed-beta/lightspeed-console-plugin-rhel9@sha256:4f45c9ba068cf92e592bb3a502764ce6bc93cd154d081fa49d05cb040885155b}"
 
-CATALOG_FILE="lightspeed-catalog/index.yaml"
+: "${CATALOG_FILE:=lightspeed-catalog/index.yaml}"
 CATALOG_INITIAL_FILE="hack/operator.yaml"
 CSV_FILE="bundle/manifests/lightspeed-operator.clusterserviceversion.yaml"
 
@@ -139,4 +139,13 @@ name: preview
 entries:
   - name: lightspeed-operator.v$BUNDLE_TAG
 EOF
+
+${OPM} validate $(dirname "${CATALOG_FILE}")
+if [ $? -ne 0 ]; then
+  echo "Validation failed for ${CATALOG_FILE}"
+  exit 1
+else
+  echo "Validation passed for ${CATALOG_FILE}"
+fi
+
 echo "Finished running $(basename "$0")"

--- a/hack/update_bundle_catalog.sh
+++ b/hack/update_bundle_catalog.sh
@@ -7,6 +7,17 @@
 
 set -euo pipefail
 
+TEMP_BUNDLE_FILE=""
+cleanup() {
+  # remove temporary bundle file
+  if [ -n "${TEMP_BUNDLE_FILE}" ]; then
+    rm -f "${TEMP_BUNDLE_FILE}"
+  fi
+
+}
+
+trap cleanup EXIT
+
 : ${OPM:=$(command -v opm)}
 echo "using opm from ${OPM}"
 # check if opm version is v1.39.0 or exit
@@ -67,8 +78,8 @@ make bundle VERSION="${BUNDLE_TAG}" IMG="${OPERATOR_IMAGE}"
 ${YQ} eval -i '.spec.relatedImages='"${RELATED_IMAGES}" ${CSV_FILE}
 
 # use UBI image as base image for bundle image
-: "${BASE_IMAGE:=registry.access.redhat.com/ubi9/ubi-minimal}"
-sed -i 's@^FROM scratch@FROM '"${BASE_IMAGE}"'@' ${BUNDLE_DOCKERFILE}
+: "${BASE_IMAGE:=registry.access.redhat.com/ubi9/ubi-minimal@sha256:104cf11d890aeb7dd5728b7d7732e175a0e4018f1bb00d2faebcc8f6bf29bd52}"
+sed -i 's|^FROM scratch|FROM '"${BASE_IMAGE}"'|' ${BUNDLE_DOCKERFILE}
 
 # make bundle image comply with enterprise contract requirements
 cat <<EOF >>${BUNDLE_DOCKERFILE}
@@ -96,11 +107,30 @@ USER 1001
 EOF
 
 echo "Adding bundle image to FBC using image ${BUNDLE_IMAGE}"
-
 #Initialize lightspeed-catalog/index.yaml from hack/operator.yaml
 cat "${CATALOG_INITIAL_FILE}" >"${CATALOG_FILE}"
 
-${OPM} render "${BUNDLE_IMAGE}" --output=yaml >>"${CATALOG_FILE}"
+# This bundle image is used to build the catalog image
+# Give it a reference in a writable image registry
+TEMP_BUNDLE_IMG=${TEMP_BUNDLE_IMG:-}
+if [ -z "${TEMP_BUNDLE_IMG}" ]; then
+  TEMP_BUNDLE_IMG="quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/bundle@sha256:c83533f0f96a7290886c5b651a3b5c8a6a4dd1058db24861b8f1d3ee3c86eaec"
+  echo "No TEMP_BUNDLE_IMG specified. Catalog is built using default bundle image ${TEMP_BUNDLE_IMG}"
+  echo "If you have changed the CRD, please specifiy TEMP_BUNDLE_IMG to your writable image registry and re-run the script"
+fi
+
+# create a temporary file for the bundle part of the catalog
+TEMP_BUNDLE_FILE=$(mktemp)
+
+${OPM} render "${TEMP_BUNDLE_IMG}" --output=yaml >"${TEMP_BUNDLE_FILE}"
+# restore bundle image to the catalog file
+${YQ} eval -i '.image='"\"${BUNDLE_IMAGE}\"" ${TEMP_BUNDLE_FILE}
+# restore bundle related images and the bundle itself to the catalog file
+${YQ} eval -i '.relatedImages='"${RELATED_IMAGES}" ${TEMP_BUNDLE_FILE}
+${YQ} eval -i '.relatedImages += [{"name": "lightspeed-operator-bundle", "image": "'"${BUNDLE_IMAGE}"'"}]' ${TEMP_BUNDLE_FILE}
+
+cat ${TEMP_BUNDLE_FILE} >>${CATALOG_FILE}
+
 cat <<EOF >>"${CATALOG_FILE}"
 ---
 schema: olm.channel

--- a/lightspeed-catalog-4.15.Dockerfile
+++ b/lightspeed-catalog-4.15.Dockerfile
@@ -1,0 +1,15 @@
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.15
+
+# Configure the entrypoint and command
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
+
+# Copy licenses required by Red Hat certification policy
+ADD licenses/ /licenses/
+# Copy declarative config root into image at /configs and pre-populate serve cache
+ADD lightspeed-catalog-4.15 /configs
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
+
+# Set DC-specific label for the location of the DC root directory
+# in the image
+LABEL operators.operatorframework.io.index.configs.v1=/configs

--- a/lightspeed-catalog-4.15/index.yaml
+++ b/lightspeed-catalog-4.15/index.yaml
@@ -1,0 +1,301 @@
+---
+defaultChannel: preview
+icon:
+  base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIGlkPSJ1dWlkLTQ2NzAxNDY4LTY2NDEtNDhjYi05ODdhLWFkOGFhYWE0Y2M1NyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2aWV3Qm94PSIwIDAgMzggMzgiPjxkZWZzPjxzdHlsZT4udXVpZC0wNWM4ZjUzZC0zOTZhLTRhNzctYjYxMC00Y2FlMTYwN2IzN2Z7ZmlsbDojZTAwO30udXVpZC0wNThiNjM1ZC1iNjFjLTQ2ZjQtOTgyYS1hOTFkNmEyMjYzZWJ7ZmlsbDojZmZmO30udXVpZC0wMTY4MTg4Yy1kMGE2LTQ5NmUtYTJkOC01Y2Q2ZWUzMGRjYjJ7ZmlsbDojZTBlMGUwO308L3N0eWxlPjwvZGVmcz48cGF0aCBjbGFzcz0idXVpZC0wNThiNjM1ZC1iNjFjLTQ2ZjQtOTgyYS1hOTFkNmEyMjYzZWIiIGQ9Im0yOCwxSDEwQzUuMDI5NDQsMSwxLDUuMDI5NDQsMSwxMHYxOGMwLDQuOTcwNTcsNC4wMjk0NCw5LDksOWgxOGM0Ljk3MDU2LDAsOS00LjAyOTQzLDktOVYxMGMwLTQuOTcwNTYtNC4wMjk0NC05LTktOWgwWiIvPjxwYXRoIGNsYXNzPSJ1dWlkLTAxNjgxODhjLWQwYTYtNDk2ZS1hMmQ4LTVjZDZlZTMwZGNiMiIgZD0ibTI4LDIuMjVjNC4yNzMzMiwwLDcuNzUsMy40NzY2NCw3Ljc1LDcuNzV2MThjMCw0LjI3MzM2LTMuNDc2NjgsNy43NS03Ljc1LDcuNzVIMTBjLTQuMjczMzIsMC03Ljc1LTMuNDc2NjQtNy43NS03Ljc1VjEwYzAtNC4yNzMzNiwzLjQ3NjY4LTcuNzUsNy43NS03Ljc1aDE4bTAtMS4yNUgxMEM1LjAyOTQyLDEsMSw1LjAyOTQ0LDEsMTB2MThjMCw0Ljk3MDU3LDQuMDI5NDIsOSw5LDloMThjNC45NzA1OCwwLDktNC4wMjk0Myw5LTlWMTBjMC00Ljk3MDU2LTQuMDI5NDItOS05LTloMFoiLz48cGF0aCBjbGFzcz0idXVpZC0wNWM4ZjUzZC0zOTZhLTRhNzctYjYxMC00Y2FlMTYwN2IzN2YiIGQ9Im0yMCwxNS42MjVjLS4zNDQ3MywwLS42MjUtLjI4MDI3LS42MjUtLjYyNXYtN2MwLS4zNDQ3My4yODAyNy0uNjI1LjYyNS0uNjI1cy42MjUuMjgwMjcuNjI1LjYyNXY3YzAsLjM0NDczLS4yODAyNy42MjUtLjYyNS42MjVaIi8+PHBhdGggY2xhc3M9InV1aWQtMDVjOGY1M2QtMzk2YS00YTc3LWI2MTAtNGNhZTE2MDdiMzdmIiBkPSJtMTYsMTkuNjI1aC03Yy0uMzQ0NzMsMC0uNjI1LS4yODAyNy0uNjI1LS42MjVzLjI4MDI3LS42MjUuNjI1LS42MjVoN2MuMzQ0NzMsMCwuNjI1LjI4MDI3LjYyNS42MjVzLS4yODAyNy42MjUtLjYyNS42MjVaIi8+PHBhdGggY2xhc3M9InV1aWQtMDVjOGY1M2QtMzk2YS00YTc3LWI2MTAtNGNhZTE2MDdiMzdmIiBkPSJtMjAsMzAuNjI1Yy0uMzQ0NzMsMC0uNjI1LS4yODAyNy0uNjI1LS42MjV2LTdjMC0uMzQ0NzMuMjgwMjctLjYyNS42MjUtLjYyNXMuNjI1LjI4MDI3LjYyNS42MjV2N2MwLC4zNDQ3My0uMjgwMjcuNjI1LS42MjUuNjI1WiIvPjxwYXRoIGQ9Im0zMC41NzY1NCwxOS4yMzk0NGMuMDI3OTUtLjA2NzY5LjAzOTU1LS4xMzk0Ny4wNDI4NS0uMjExNDkuMDAwNDktLjAwOTgzLjAwNTYyLS4wMTgwNy4wMDU2Mi0uMDI3OTVzLS4wMDUxMy0uMDE4MTMtLjAwNTYyLS4wMjc5NWMtLjAwMzMtLjA3MjAyLS4wMTQ4OS0uMTQzOC0uMDQyODUtLjIxMTQ5LS4wMjAwMi0uMDQ3OTEtLjA1MzgzLS4wODY2Ny0uMDg0NDctLjEyNzc1LS4wMTgwNy0uMDI0NDgtLjAyNzU5LS4wNTMwNC0uMDQ5NjgtLjA3NTJsLTItMmMtLjI0NDE0LS4yNDQxNC0uNjQwNjItLjI0NDE0LS44ODQ3NywwLS4yNDMxNi4yNDQxNC0uMjQzMTYuNjQwNjIsMCwuODg0NzdsLjkzMzIzLjkzMjYyaC05LjQ5MDg0Yy0uMzQ0NzMsMC0uNjI1LjI4MDI3LS42MjUuNjI1cy4yODAyNy42MjUuNjI1LjYyNWg5LjQ5MDg0bC0uOTMzMjMuOTMyNjJjLS4yNDMxNi4yNDQxNC0uMjQzMTYuNjQwNjIsMCwuODg0NzcuMTIyMDcuMTIyMDcuMjgyMjMuMTgyNjIuNDQyMzguMTgyNjJzLjMyMDMxLS4wNjA1NS40NDIzOC0uMTgyNjJsMi0yYy4wMjIwOS0uMDIyMTYuMDMxNjItLjA1MDcyLjA0OTY4LS4wNzUyLjAzMDY0LS4wNDEwOC4wNjQ0NS0uMDc5ODMuMDg0NDctLjEyNzc1WiIvPjxwYXRoIGQ9Im0xNywxNi42MjVjLS4xNjAxNiwwLS4zMjAzMS0uMDYwNTUtLjQ0MjM4LS4xODI2MmwtNC00Yy0uMjQzMTYtLjI0NDE0LS4yNDMxNi0uNjQwNjIsMC0uODg0NzcuMjQ0MTQtLjI0NDE0LjY0MDYyLS4yNDQxNC44ODQ3NywwbDQsNGMuMjQzMTYuMjQ0MTQuMjQzMTYuNjQwNjIsMCwuODg0NzctLjEyMjA3LjEyMjA3LS4yODIyMy4xODI2Mi0uNDQyMzguMTgyNjJaIi8+PHBhdGggZD0ibTEzLDI2LjYyNWMtLjE2MDE2LDAtLjMyMDMxLS4wNjA1NS0uNDQyMzgtLjE4MjYyLS4yNDMxNi0uMjQ0MTQtLjI0MzE2LS42NDA2MiwwLS44ODQ3N2w0LTRjLjI0NDE0LS4yNDQxNC42NDA2Mi0uMjQ0MTQuODg0NzcsMCwuMjQzMTYuMjQ0MTQuMjQzMTYuNjQwNjIsMCwuODg0NzdsLTQsNGMtLjEyMjA3LjEyMjA3LS4yODIyMy4xODI2Mi0uNDQyMzguMTgyNjJaIi8+PHBhdGggY2xhc3M9InV1aWQtMDVjOGY1M2QtMzk2YS00YTc3LWI2MTAtNGNhZTE2MDdiMzdmIiBkPSJtMTcuNDIzODMsMTMuNjI1Yy0uMjg4MDksMC0uNTQ3ODUtLjIwMTE3LS42MTAzNS0uNDk1MTJsLS40MjQ4LTJjLS4wNzEyOS0uMzM3ODkuMTQzNTUtLjY2OTkyLjQ4MTQ1LS43NDEyMS4zMzg4Ny0uMDc1Mi42Njk5Mi4xNDM1NS43NDEyMS40ODE0NWwuNDI0OCwyYy4wNzEyOS4zMzc4OS0uMTQzNTUuNjY5OTItLjQ4MTQ1Ljc0MTIxLS4wNDM5NS4wMDk3Ny0uMDg3ODkuMDEzNjctLjEzMDg2LjAxMzY3WiIvPjxwYXRoIGNsYXNzPSJ1dWlkLTA1YzhmNTNkLTM5NmEtNGE3Ny1iNjEwLTRjYWUxNjA3YjM3ZiIgZD0ibTE0LjAwMDk4LDE3LjA0OThjLS4wNDI5NywwLS4wODY5MS0uMDAzOTEtLjEzMDg2LS4wMTM2N2wtMi0uNDI0OGMtLjMzNzg5LS4wNzEyOS0uNTUyNzMtLjQwMzMyLS40ODE0NS0uNzQxMjEuMDcyMjctLjMzNzg5LjQwMjM0LS41NTg1OS43NDEyMS0uNDgxNDVsMiwuNDI0OGMuMzM3ODkuMDcxMjkuNTUyNzMuNDAzMzIuNDgxNDUuNzQxMjEtLjA2MjUuMjkzOTUtLjMyMjI3LjQ5NTEyLS42MTAzNS40OTUxMloiLz48cGF0aCBjbGFzcz0idXVpZC0wNWM4ZjUzZC0zOTZhLTRhNzctYjYxMC00Y2FlMTYwN2IzN2YiIGQ9Im0xNy4wMDA5OCwyNy42MjVjLS4wNDI5NywwLS4wODY5MS0uMDAzOTEtLjEzMDg2LS4wMTM2Ny0uMzM3ODktLjA3MTI5LS41NTI3My0uNDAzMzItLjQ4MTQ1LS43NDEyMWwuNDI0OC0yYy4wNzIyNy0uMzM3ODkuNDAxMzctLjU1NTY2Ljc0MTIxLS40ODE0NS4zMzc4OS4wNzEyOS41NTI3My40MDMzMi40ODE0NS43NDEyMWwtLjQyNDgsMmMtLjA2MjUuMjkzOTUtLjMyMjI3LjQ5NTEyLS42MTAzNS40OTUxMloiLz48cGF0aCBjbGFzcz0idXVpZC0wNWM4ZjUzZC0zOTZhLTRhNzctYjYxMC00Y2FlMTYwN2IzN2YiIGQ9Im0xMS45OTkwMiwyMi42MjVjLS4yODgwOSwwLS41NDc4NS0uMjAxMTctLjYxMDM1LS40OTUxMi0uMDcxMjktLjMzNzg5LjE0MzU1LS42Njk5Mi40ODE0NS0uNzQxMjFsMi0uNDI0OGMuMzQwODItLjA3NjE3LjY2OTkyLjE0MzU1Ljc0MTIxLjQ4MTQ1cy0uMTQzNTUuNjY5OTItLjQ4MTQ1Ljc0MTIxbC0yLC40MjQ4Yy0uMDQzOTUuMDA5NzctLjA4Nzg5LjAxMzY3LS4xMzA4Ni4wMTM2N1oiLz48cGF0aCBkPSJtOSwxNS42Mjk4OGMtLjE2MDE2LDAtLjMyMDMxLS4wNzAzMS0uNDQwNDMtLjE5MDQzLS4wNTk1Ny0uMDU5NTctLjA5OTYxLS4xMjAxMi0uMTM5NjUtLjE5OTIyLS4wMzAyNy0uMDgwMDgtLjA0OTgtLjE2MDE2LS4wNDk4LS4yNDAyMywwLS4xNjAxNi4wNjkzNC0uMzIwMzEuMTg5NDUtLjQ0MDQzLjIzMDQ3LS4yMjk0OS42NTAzOS0uMjQwMjMuODc5ODgsMCwuMTIwMTIuMTIwMTIuMTkwNDMuMjgwMjcuMTkwNDMuNDQwNDMsMCwuMDgwMDgtLjAyMDUxLjE2MDE2LS4wNDk4LjI0MDIzLS4wMzAyNy4wNzkxLS4wODAwOC4xMzk2NS0uMTQwNjIuMTk5MjItLjEyMDEyLjEyMDEyLS4yNzkzLjE5MDQzLS40Mzk0NS4xOTA0M1oiLz48cGF0aCBkPSJtOSwyMy42Mjk4OGMtLjE2MDE2LDAtLjMyMDMxLS4wNzAzMS0uNDQwNDMtLjE5MDQzLS4xMjAxMi0uMTA5MzgtLjE4OTQ1LS4yNzkzLS4xODk0NS0uNDM5NDVzLjA2OTM0LS4zMjAzMS4xODk0NS0uNDQwNDNjLjIzMDQ3LS4yMjk0OS42NDA2Mi0uMjQwMjMuODc5ODgsMCwuMTIwMTIuMTIwMTIuMTkwNDMuMjgwMjcuMTkwNDMuNDQwNDNzLS4wNzAzMS4zMzAwOC0uMTkwNDMuNDM5NDVjLS4xMjAxMi4xMjAxMi0uMjc5My4xOTA0My0uNDM5NDUuMTkwNDNaIi8+PC9zdmc+
+  mediatype: image/svg+xml
+name: lightspeed-operator
+schema: olm.package
+---
+image: registry.redhat.io/openshift-lightspeed-beta/lightspeed-operator-bundle@sha256:e46e337502a00282473e083c16a64e6201df3677905e4b056b7f48ef0b8f6e4b
+name: lightspeed-operator.v0.0.1
+package: lightspeed-operator
+properties:
+  - type: olm.gvk
+    value:
+      group: ols.openshift.io
+      kind: OLSConfig
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: lightspeed-operator
+      version: 0.0.1
+  - type: olm.csv.metadata
+    value:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "ols.openshift.io/v1alpha1",
+              "kind": "OLSConfig",
+              "metadata": {
+                "labels": {
+                  "app.kubernetes.io/created-by": "lightspeed-operator",
+                  "app.kubernetes.io/instance": "olsconfig-sample",
+                  "app.kubernetes.io/managed-by": "kustomize",
+                  "app.kubernetes.io/name": "olsconfig",
+                  "app.kubernetes.io/part-of": "lightspeed-operator"
+                },
+                "name": "cluster"
+              },
+              "spec": {
+                "llm": {
+                  "providers": [
+                    {
+                      "credentialsSecretRef": {
+                        "name": "credentials"
+                      },
+                      "models": [
+                        {
+                          "name": "gpt-3.5-turbo-1106"
+                        }
+                      ],
+                      "name": "OpenAI"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        capabilities: Basic Install
+        createdAt: "2024-07-15T02:15:30Z"
+        features.operators.openshift.io/cnf: "false"
+        features.operators.openshift.io/cni: "false"
+        features.operators.openshift.io/csi: "false"
+        features.operators.openshift.io/disconnected: "true"
+        features.operators.openshift.io/fips-compliant: "true"
+        features.operators.openshift.io/proxy-aware: "true"
+        features.operators.openshift.io/tls-profiles: "false"
+        features.operators.openshift.io/token-auth-aws: "false"
+        features.operators.openshift.io/token-auth-azure: "false"
+        features.operators.openshift.io/token-auth-gcp: "false"
+        operatorframework.io/cluster-monitoring: "true"
+        operatorframework.io/suggested-namespace: openshift-lightspeed
+        operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
+        operators.operatorframework.io/builder: operator-sdk-v1.33.0
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+        repository: https://github.com/openshift/lightspeed-operator
+      apiServiceDefinitions: {}
+      crdDescriptions:
+        owned:
+          - description: Red Hat OpenShift Lightspeed instance. OLSConfig is the Schema for the olsconfigs API
+            displayName: OLSConfig
+            kind: OLSConfig
+            name: olsconfigs.ols.openshift.io
+            specDescriptors:
+              - description: Provider name
+                displayName: Name
+                path: llm.providers[0].name
+              - description: OLS deployment settings
+                displayName: Deployment
+                path: ols.deployment
+              - description: Provider API URL
+                displayName: URL
+                path: llm.providers[0].url
+              - description: Conversation cache settings
+                displayName: Conversation Cache
+                path: ols.conversationCache
+              - description: The name of the secret object that stores API provider credentials
+                displayName: Credential Secret
+                path: llm.providers[0].credentialsSecretRef
+              - displayName: LLM Settings
+                path: llm
+              - displayName: Providers
+                path: llm.providers
+              - description: Azure OpenAI deployment name
+                displayName: Azure OpenAI deployment name
+                path: llm.providers[0].deploymentName
+              - description: List of models from the provider
+                displayName: Models
+                path: llm.providers[0].models
+              - description: Model name
+                displayName: Name
+                path: llm.providers[0].models[0].name
+              - description: Model API parameters
+                displayName: Parameters
+                path: llm.providers[0].models[0].parameters
+              - description: Max tokens for response
+                displayName: Max Tokens For Response
+                path: llm.providers[0].models[0].parameters.maxTokensForResponse
+              - description: Model API URL
+                displayName: URL
+                path: llm.providers[0].models[0].url
+              - description: Watsonx Project ID
+                displayName: Watsonx Project ID
+                path: llm.providers[0].projectID
+              - description: Provider type
+                displayName: Provider Type
+                path: llm.providers[0].type
+              - displayName: OLS Settings
+                path: ols
+              - description: Classifier model name
+                displayName: Classifier Model
+                path: ols.classifierModel
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:advanced
+              - description: Classifier provider name
+                displayName: Classifier Provider
+                path: ols.classifierProvider
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:advanced
+              - displayName: Redis
+                path: ols.conversationCache.redis
+              - description: Secret that holds redis credentials
+                displayName: Credentials secret
+                path: ols.conversationCache.redis.credentialsSecret
+              - description: Redis maxmemory
+                displayName: Max Memory
+                path: ols.conversationCache.redis.maxMemory
+              - description: 'Redis maxmemory policy. Default: "allkeys-lru"'
+                displayName: Max Memory Policy
+                path: ols.conversationCache.redis.maxMemoryPolicy
+              - description: 'Conversation cache type. Default: "redis"'
+                displayName: Cache Type
+                path: ols.conversationCache.type
+              - description: Default model for usage
+                displayName: Default Model
+                path: ols.defaultModel
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:advanced
+              - description: Default provider for usage
+                displayName: Default Provider
+                path: ols.defaultProvider
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:advanced
+              - description: API container settings.
+                displayName: API Container
+                path: ols.deployment.api
+              - displayName: Node Selector
+                path: ols.deployment.api.nodeSelector
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:nodeSelector
+              - displayName: Resource Requirements
+                path: ols.deployment.api.resources
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+              - displayName: Tolerations
+                path: ols.deployment.api.tolerations
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:tolerations
+              - description: Console container settings.
+                displayName: Console Container
+                path: ols.deployment.console
+              - displayName: Node Selector
+                path: ols.deployment.console.nodeSelector
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:nodeSelector
+              - displayName: Resource Requirements
+                path: ols.deployment.console.resources
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+              - displayName: Tolerations
+                path: ols.deployment.console.tolerations
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:tolerations
+              - description: Data Collector container settings.
+                displayName: Data Collector Container
+                path: ols.deployment.dataCollector
+              - displayName: Resource Requirements
+                path: ols.deployment.dataCollector.resources
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+              - description: 'Defines the number of desired OLS pods. Default: "1"'
+                displayName: Number of replicas
+                path: ols.deployment.replicas
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:podCount
+              - description: 'Log level. Valid options are DEBUG, INFO, WARNING, ERROR and CRITICAL. Default: "INFO".'
+                displayName: Log level
+                path: ols.logLevel
+              - description: Query filters
+                displayName: Query Filters
+                path: ols.queryFilters
+              - description: Filter name.
+                displayName: Filter Name
+                path: ols.queryFilters[0].name
+              - description: Filter pattern.
+                displayName: The pattern to replace
+                path: ols.queryFilters[0].pattern
+              - description: Replacement for the matched pattern.
+                displayName: Replace With
+                path: ols.queryFilters[0].replaceWith
+              - description: Summarizer model name
+                displayName: Summarizer Model
+                path: ols.summarizerModel
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:advanced
+              - description: Summarizer provider name
+                displayName: Summarizer Provider
+                path: ols.summarizerProvider
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:advanced
+              - description: User data collection switches
+                displayName: User Data Collection
+                path: ols.userDataCollection
+              - displayName: Do Not Collect User Feedback
+                path: ols.userDataCollection.feedbackDisabled
+              - displayName: Do Not Collect Transcripts
+                path: ols.userDataCollection.transcriptsDisabled
+              - description: Validator model name
+                displayName: Validator Model
+                path: ols.validatorModel
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:advanced
+              - description: Validator provider name
+                displayName: Validator Provider
+                path: ols.validatorProvider
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:advanced
+              - description: YAML model name
+                displayName: YAML Model
+                path: ols.yamlModel
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:advanced
+              - description: YAML provider name
+                displayName: YAML Provider
+                path: ols.yamlProvider
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:advanced
+            statusDescriptors:
+              - displayName: Conditions
+                path: conditions
+            version: v1alpha1
+      description: OpenShift Lightspeed is an AI-powered assistant that runs on OpenShift and answers questions about OpenShift using backend LLM services.
+      displayName: OpenShift Lightspeed Operator
+      installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+      keywords:
+        - ai
+        - assistant
+        - openshift
+        - llm
+      links:
+        - name: Lightspeed Operator
+          url: https://github.com/openshift/lightspeed-operator
+      maturity: alpha
+      minKubeVersion: 1.28.0
+      provider:
+        name: Red Hat, Inc
+        url: https://github.com/openshift/lightspeed-service
+relatedImages:
+  - name: lightspeed-service-api
+    image: registry.redhat.io/openshift-lightspeed-beta/lightspeed-service-api-rhel9@sha256:fedfaaba10cf2dd952cf735167e9898c034ecec433a22b38293aeccaeed6e3bf
+  - name: lightspeed-console-plugin
+    image: registry.redhat.io/openshift-lightspeed-beta/lightspeed-console-plugin-rhel9@sha256:4f45c9ba068cf92e592bb3a502764ce6bc93cd154d081fa49d05cb040885155b
+  - name: lightspeed-operator
+    image: registry.redhat.io/openshift-lightspeed-beta/lightspeed-rhel9-operator@sha256:049a1a398ed87e4f35c99b36304055c7f75d0188a4d8c1726df59b5f400561e5
+  - name: lightspeed-operator-bundle
+    image: registry.redhat.io/openshift-lightspeed-beta/lightspeed-operator-bundle@sha256:e46e337502a00282473e083c16a64e6201df3677905e4b056b7f48ef0b8f6e4b
+schema: olm.bundle
+---
+schema: olm.channel
+package: lightspeed-operator
+name: preview
+entries:
+  - name: lightspeed-operator.v0.0.1

--- a/lightspeed-catalog-4.16.Dockerfile
+++ b/lightspeed-catalog-4.16.Dockerfile
@@ -1,0 +1,15 @@
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.16
+
+# Configure the entrypoint and command
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
+
+# Copy licenses required by Red Hat certification policy
+ADD licenses/ /licenses/
+# Copy declarative config root into image at /configs and pre-populate serve cache
+ADD lightspeed-catalog-4.16 /configs
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
+
+# Set DC-specific label for the location of the DC root directory
+# in the image
+LABEL operators.operatorframework.io.index.configs.v1=/configs

--- a/lightspeed-catalog-4.16/index.yaml
+++ b/lightspeed-catalog-4.16/index.yaml
@@ -1,0 +1,301 @@
+---
+defaultChannel: preview
+icon:
+  base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIGlkPSJ1dWlkLTQ2NzAxNDY4LTY2NDEtNDhjYi05ODdhLWFkOGFhYWE0Y2M1NyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2aWV3Qm94PSIwIDAgMzggMzgiPjxkZWZzPjxzdHlsZT4udXVpZC0wNWM4ZjUzZC0zOTZhLTRhNzctYjYxMC00Y2FlMTYwN2IzN2Z7ZmlsbDojZTAwO30udXVpZC0wNThiNjM1ZC1iNjFjLTQ2ZjQtOTgyYS1hOTFkNmEyMjYzZWJ7ZmlsbDojZmZmO30udXVpZC0wMTY4MTg4Yy1kMGE2LTQ5NmUtYTJkOC01Y2Q2ZWUzMGRjYjJ7ZmlsbDojZTBlMGUwO308L3N0eWxlPjwvZGVmcz48cGF0aCBjbGFzcz0idXVpZC0wNThiNjM1ZC1iNjFjLTQ2ZjQtOTgyYS1hOTFkNmEyMjYzZWIiIGQ9Im0yOCwxSDEwQzUuMDI5NDQsMSwxLDUuMDI5NDQsMSwxMHYxOGMwLDQuOTcwNTcsNC4wMjk0NCw5LDksOWgxOGM0Ljk3MDU2LDAsOS00LjAyOTQzLDktOVYxMGMwLTQuOTcwNTYtNC4wMjk0NC05LTktOWgwWiIvPjxwYXRoIGNsYXNzPSJ1dWlkLTAxNjgxODhjLWQwYTYtNDk2ZS1hMmQ4LTVjZDZlZTMwZGNiMiIgZD0ibTI4LDIuMjVjNC4yNzMzMiwwLDcuNzUsMy40NzY2NCw3Ljc1LDcuNzV2MThjMCw0LjI3MzM2LTMuNDc2NjgsNy43NS03Ljc1LDcuNzVIMTBjLTQuMjczMzIsMC03Ljc1LTMuNDc2NjQtNy43NS03Ljc1VjEwYzAtNC4yNzMzNiwzLjQ3NjY4LTcuNzUsNy43NS03Ljc1aDE4bTAtMS4yNUgxMEM1LjAyOTQyLDEsMSw1LjAyOTQ0LDEsMTB2MThjMCw0Ljk3MDU3LDQuMDI5NDIsOSw5LDloMThjNC45NzA1OCwwLDktNC4wMjk0Myw5LTlWMTBjMC00Ljk3MDU2LTQuMDI5NDItOS05LTloMFoiLz48cGF0aCBjbGFzcz0idXVpZC0wNWM4ZjUzZC0zOTZhLTRhNzctYjYxMC00Y2FlMTYwN2IzN2YiIGQ9Im0yMCwxNS42MjVjLS4zNDQ3MywwLS42MjUtLjI4MDI3LS42MjUtLjYyNXYtN2MwLS4zNDQ3My4yODAyNy0uNjI1LjYyNS0uNjI1cy42MjUuMjgwMjcuNjI1LjYyNXY3YzAsLjM0NDczLS4yODAyNy42MjUtLjYyNS42MjVaIi8+PHBhdGggY2xhc3M9InV1aWQtMDVjOGY1M2QtMzk2YS00YTc3LWI2MTAtNGNhZTE2MDdiMzdmIiBkPSJtMTYsMTkuNjI1aC03Yy0uMzQ0NzMsMC0uNjI1LS4yODAyNy0uNjI1LS42MjVzLjI4MDI3LS42MjUuNjI1LS42MjVoN2MuMzQ0NzMsMCwuNjI1LjI4MDI3LjYyNS42MjVzLS4yODAyNy42MjUtLjYyNS42MjVaIi8+PHBhdGggY2xhc3M9InV1aWQtMDVjOGY1M2QtMzk2YS00YTc3LWI2MTAtNGNhZTE2MDdiMzdmIiBkPSJtMjAsMzAuNjI1Yy0uMzQ0NzMsMC0uNjI1LS4yODAyNy0uNjI1LS42MjV2LTdjMC0uMzQ0NzMuMjgwMjctLjYyNS42MjUtLjYyNXMuNjI1LjI4MDI3LjYyNS42MjV2N2MwLC4zNDQ3My0uMjgwMjcuNjI1LS42MjUuNjI1WiIvPjxwYXRoIGQ9Im0zMC41NzY1NCwxOS4yMzk0NGMuMDI3OTUtLjA2NzY5LjAzOTU1LS4xMzk0Ny4wNDI4NS0uMjExNDkuMDAwNDktLjAwOTgzLjAwNTYyLS4wMTgwNy4wMDU2Mi0uMDI3OTVzLS4wMDUxMy0uMDE4MTMtLjAwNTYyLS4wMjc5NWMtLjAwMzMtLjA3MjAyLS4wMTQ4OS0uMTQzOC0uMDQyODUtLjIxMTQ5LS4wMjAwMi0uMDQ3OTEtLjA1MzgzLS4wODY2Ny0uMDg0NDctLjEyNzc1LS4wMTgwNy0uMDI0NDgtLjAyNzU5LS4wNTMwNC0uMDQ5NjgtLjA3NTJsLTItMmMtLjI0NDE0LS4yNDQxNC0uNjQwNjItLjI0NDE0LS44ODQ3NywwLS4yNDMxNi4yNDQxNC0uMjQzMTYuNjQwNjIsMCwuODg0NzdsLjkzMzIzLjkzMjYyaC05LjQ5MDg0Yy0uMzQ0NzMsMC0uNjI1LjI4MDI3LS42MjUuNjI1cy4yODAyNy42MjUuNjI1LjYyNWg5LjQ5MDg0bC0uOTMzMjMuOTMyNjJjLS4yNDMxNi4yNDQxNC0uMjQzMTYuNjQwNjIsMCwuODg0NzcuMTIyMDcuMTIyMDcuMjgyMjMuMTgyNjIuNDQyMzguMTgyNjJzLjMyMDMxLS4wNjA1NS40NDIzOC0uMTgyNjJsMi0yYy4wMjIwOS0uMDIyMTYuMDMxNjItLjA1MDcyLjA0OTY4LS4wNzUyLjAzMDY0LS4wNDEwOC4wNjQ0NS0uMDc5ODMuMDg0NDctLjEyNzc1WiIvPjxwYXRoIGQ9Im0xNywxNi42MjVjLS4xNjAxNiwwLS4zMjAzMS0uMDYwNTUtLjQ0MjM4LS4xODI2MmwtNC00Yy0uMjQzMTYtLjI0NDE0LS4yNDMxNi0uNjQwNjIsMC0uODg0NzcuMjQ0MTQtLjI0NDE0LjY0MDYyLS4yNDQxNC44ODQ3NywwbDQsNGMuMjQzMTYuMjQ0MTQuMjQzMTYuNjQwNjIsMCwuODg0NzctLjEyMjA3LjEyMjA3LS4yODIyMy4xODI2Mi0uNDQyMzguMTgyNjJaIi8+PHBhdGggZD0ibTEzLDI2LjYyNWMtLjE2MDE2LDAtLjMyMDMxLS4wNjA1NS0uNDQyMzgtLjE4MjYyLS4yNDMxNi0uMjQ0MTQtLjI0MzE2LS42NDA2MiwwLS44ODQ3N2w0LTRjLjI0NDE0LS4yNDQxNC42NDA2Mi0uMjQ0MTQuODg0NzcsMCwuMjQzMTYuMjQ0MTQuMjQzMTYuNjQwNjIsMCwuODg0NzdsLTQsNGMtLjEyMjA3LjEyMjA3LS4yODIyMy4xODI2Mi0uNDQyMzguMTgyNjJaIi8+PHBhdGggY2xhc3M9InV1aWQtMDVjOGY1M2QtMzk2YS00YTc3LWI2MTAtNGNhZTE2MDdiMzdmIiBkPSJtMTcuNDIzODMsMTMuNjI1Yy0uMjg4MDksMC0uNTQ3ODUtLjIwMTE3LS42MTAzNS0uNDk1MTJsLS40MjQ4LTJjLS4wNzEyOS0uMzM3ODkuMTQzNTUtLjY2OTkyLjQ4MTQ1LS43NDEyMS4zMzg4Ny0uMDc1Mi42Njk5Mi4xNDM1NS43NDEyMS40ODE0NWwuNDI0OCwyYy4wNzEyOS4zMzc4OS0uMTQzNTUuNjY5OTItLjQ4MTQ1Ljc0MTIxLS4wNDM5NS4wMDk3Ny0uMDg3ODkuMDEzNjctLjEzMDg2LjAxMzY3WiIvPjxwYXRoIGNsYXNzPSJ1dWlkLTA1YzhmNTNkLTM5NmEtNGE3Ny1iNjEwLTRjYWUxNjA3YjM3ZiIgZD0ibTE0LjAwMDk4LDE3LjA0OThjLS4wNDI5NywwLS4wODY5MS0uMDAzOTEtLjEzMDg2LS4wMTM2N2wtMi0uNDI0OGMtLjMzNzg5LS4wNzEyOS0uNTUyNzMtLjQwMzMyLS40ODE0NS0uNzQxMjEuMDcyMjctLjMzNzg5LjQwMjM0LS41NTg1OS43NDEyMS0uNDgxNDVsMiwuNDI0OGMuMzM3ODkuMDcxMjkuNTUyNzMuNDAzMzIuNDgxNDUuNzQxMjEtLjA2MjUuMjkzOTUtLjMyMjI3LjQ5NTEyLS42MTAzNS40OTUxMloiLz48cGF0aCBjbGFzcz0idXVpZC0wNWM4ZjUzZC0zOTZhLTRhNzctYjYxMC00Y2FlMTYwN2IzN2YiIGQ9Im0xNy4wMDA5OCwyNy42MjVjLS4wNDI5NywwLS4wODY5MS0uMDAzOTEtLjEzMDg2LS4wMTM2Ny0uMzM3ODktLjA3MTI5LS41NTI3My0uNDAzMzItLjQ4MTQ1LS43NDEyMWwuNDI0OC0yYy4wNzIyNy0uMzM3ODkuNDAxMzctLjU1NTY2Ljc0MTIxLS40ODE0NS4zMzc4OS4wNzEyOS41NTI3My40MDMzMi40ODE0NS43NDEyMWwtLjQyNDgsMmMtLjA2MjUuMjkzOTUtLjMyMjI3LjQ5NTEyLS42MTAzNS40OTUxMloiLz48cGF0aCBjbGFzcz0idXVpZC0wNWM4ZjUzZC0zOTZhLTRhNzctYjYxMC00Y2FlMTYwN2IzN2YiIGQ9Im0xMS45OTkwMiwyMi42MjVjLS4yODgwOSwwLS41NDc4NS0uMjAxMTctLjYxMDM1LS40OTUxMi0uMDcxMjktLjMzNzg5LjE0MzU1LS42Njk5Mi40ODE0NS0uNzQxMjFsMi0uNDI0OGMuMzQwODItLjA3NjE3LjY2OTkyLjE0MzU1Ljc0MTIxLjQ4MTQ1cy0uMTQzNTUuNjY5OTItLjQ4MTQ1Ljc0MTIxbC0yLC40MjQ4Yy0uMDQzOTUuMDA5NzctLjA4Nzg5LjAxMzY3LS4xMzA4Ni4wMTM2N1oiLz48cGF0aCBkPSJtOSwxNS42Mjk4OGMtLjE2MDE2LDAtLjMyMDMxLS4wNzAzMS0uNDQwNDMtLjE5MDQzLS4wNTk1Ny0uMDU5NTctLjA5OTYxLS4xMjAxMi0uMTM5NjUtLjE5OTIyLS4wMzAyNy0uMDgwMDgtLjA0OTgtLjE2MDE2LS4wNDk4LS4yNDAyMywwLS4xNjAxNi4wNjkzNC0uMzIwMzEuMTg5NDUtLjQ0MDQzLjIzMDQ3LS4yMjk0OS42NTAzOS0uMjQwMjMuODc5ODgsMCwuMTIwMTIuMTIwMTIuMTkwNDMuMjgwMjcuMTkwNDMuNDQwNDMsMCwuMDgwMDgtLjAyMDUxLjE2MDE2LS4wNDk4LjI0MDIzLS4wMzAyNy4wNzkxLS4wODAwOC4xMzk2NS0uMTQwNjIuMTk5MjItLjEyMDEyLjEyMDEyLS4yNzkzLjE5MDQzLS40Mzk0NS4xOTA0M1oiLz48cGF0aCBkPSJtOSwyMy42Mjk4OGMtLjE2MDE2LDAtLjMyMDMxLS4wNzAzMS0uNDQwNDMtLjE5MDQzLS4xMjAxMi0uMTA5MzgtLjE4OTQ1LS4yNzkzLS4xODk0NS0uNDM5NDVzLjA2OTM0LS4zMjAzMS4xODk0NS0uNDQwNDNjLjIzMDQ3LS4yMjk0OS42NDA2Mi0uMjQwMjMuODc5ODgsMCwuMTIwMTIuMTIwMTIuMTkwNDMuMjgwMjcuMTkwNDMuNDQwNDNzLS4wNzAzMS4zMzAwOC0uMTkwNDMuNDM5NDVjLS4xMjAxMi4xMjAxMi0uMjc5My4xOTA0My0uNDM5NDUuMTkwNDNaIi8+PC9zdmc+
+  mediatype: image/svg+xml
+name: lightspeed-operator
+schema: olm.package
+---
+image: registry.redhat.io/openshift-lightspeed-beta/lightspeed-operator-bundle@sha256:e46e337502a00282473e083c16a64e6201df3677905e4b056b7f48ef0b8f6e4b
+name: lightspeed-operator.v0.0.1
+package: lightspeed-operator
+properties:
+  - type: olm.gvk
+    value:
+      group: ols.openshift.io
+      kind: OLSConfig
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: lightspeed-operator
+      version: 0.0.1
+  - type: olm.csv.metadata
+    value:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "ols.openshift.io/v1alpha1",
+              "kind": "OLSConfig",
+              "metadata": {
+                "labels": {
+                  "app.kubernetes.io/created-by": "lightspeed-operator",
+                  "app.kubernetes.io/instance": "olsconfig-sample",
+                  "app.kubernetes.io/managed-by": "kustomize",
+                  "app.kubernetes.io/name": "olsconfig",
+                  "app.kubernetes.io/part-of": "lightspeed-operator"
+                },
+                "name": "cluster"
+              },
+              "spec": {
+                "llm": {
+                  "providers": [
+                    {
+                      "credentialsSecretRef": {
+                        "name": "credentials"
+                      },
+                      "models": [
+                        {
+                          "name": "gpt-3.5-turbo-1106"
+                        }
+                      ],
+                      "name": "OpenAI"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        capabilities: Basic Install
+        createdAt: "2024-07-15T02:15:30Z"
+        features.operators.openshift.io/cnf: "false"
+        features.operators.openshift.io/cni: "false"
+        features.operators.openshift.io/csi: "false"
+        features.operators.openshift.io/disconnected: "true"
+        features.operators.openshift.io/fips-compliant: "true"
+        features.operators.openshift.io/proxy-aware: "true"
+        features.operators.openshift.io/tls-profiles: "false"
+        features.operators.openshift.io/token-auth-aws: "false"
+        features.operators.openshift.io/token-auth-azure: "false"
+        features.operators.openshift.io/token-auth-gcp: "false"
+        operatorframework.io/cluster-monitoring: "true"
+        operatorframework.io/suggested-namespace: openshift-lightspeed
+        operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
+        operators.operatorframework.io/builder: operator-sdk-v1.33.0
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+        repository: https://github.com/openshift/lightspeed-operator
+      apiServiceDefinitions: {}
+      crdDescriptions:
+        owned:
+          - description: Red Hat OpenShift Lightspeed instance. OLSConfig is the Schema for the olsconfigs API
+            displayName: OLSConfig
+            kind: OLSConfig
+            name: olsconfigs.ols.openshift.io
+            specDescriptors:
+              - description: Provider name
+                displayName: Name
+                path: llm.providers[0].name
+              - description: OLS deployment settings
+                displayName: Deployment
+                path: ols.deployment
+              - description: Provider API URL
+                displayName: URL
+                path: llm.providers[0].url
+              - description: Conversation cache settings
+                displayName: Conversation Cache
+                path: ols.conversationCache
+              - description: The name of the secret object that stores API provider credentials
+                displayName: Credential Secret
+                path: llm.providers[0].credentialsSecretRef
+              - displayName: LLM Settings
+                path: llm
+              - displayName: Providers
+                path: llm.providers
+              - description: Azure OpenAI deployment name
+                displayName: Azure OpenAI deployment name
+                path: llm.providers[0].deploymentName
+              - description: List of models from the provider
+                displayName: Models
+                path: llm.providers[0].models
+              - description: Model name
+                displayName: Name
+                path: llm.providers[0].models[0].name
+              - description: Model API parameters
+                displayName: Parameters
+                path: llm.providers[0].models[0].parameters
+              - description: Max tokens for response
+                displayName: Max Tokens For Response
+                path: llm.providers[0].models[0].parameters.maxTokensForResponse
+              - description: Model API URL
+                displayName: URL
+                path: llm.providers[0].models[0].url
+              - description: Watsonx Project ID
+                displayName: Watsonx Project ID
+                path: llm.providers[0].projectID
+              - description: Provider type
+                displayName: Provider Type
+                path: llm.providers[0].type
+              - displayName: OLS Settings
+                path: ols
+              - description: Classifier model name
+                displayName: Classifier Model
+                path: ols.classifierModel
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:advanced
+              - description: Classifier provider name
+                displayName: Classifier Provider
+                path: ols.classifierProvider
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:advanced
+              - displayName: Redis
+                path: ols.conversationCache.redis
+              - description: Secret that holds redis credentials
+                displayName: Credentials secret
+                path: ols.conversationCache.redis.credentialsSecret
+              - description: Redis maxmemory
+                displayName: Max Memory
+                path: ols.conversationCache.redis.maxMemory
+              - description: 'Redis maxmemory policy. Default: "allkeys-lru"'
+                displayName: Max Memory Policy
+                path: ols.conversationCache.redis.maxMemoryPolicy
+              - description: 'Conversation cache type. Default: "redis"'
+                displayName: Cache Type
+                path: ols.conversationCache.type
+              - description: Default model for usage
+                displayName: Default Model
+                path: ols.defaultModel
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:advanced
+              - description: Default provider for usage
+                displayName: Default Provider
+                path: ols.defaultProvider
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:advanced
+              - description: API container settings.
+                displayName: API Container
+                path: ols.deployment.api
+              - displayName: Node Selector
+                path: ols.deployment.api.nodeSelector
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:nodeSelector
+              - displayName: Resource Requirements
+                path: ols.deployment.api.resources
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+              - displayName: Tolerations
+                path: ols.deployment.api.tolerations
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:tolerations
+              - description: Console container settings.
+                displayName: Console Container
+                path: ols.deployment.console
+              - displayName: Node Selector
+                path: ols.deployment.console.nodeSelector
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:nodeSelector
+              - displayName: Resource Requirements
+                path: ols.deployment.console.resources
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+              - displayName: Tolerations
+                path: ols.deployment.console.tolerations
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:tolerations
+              - description: Data Collector container settings.
+                displayName: Data Collector Container
+                path: ols.deployment.dataCollector
+              - displayName: Resource Requirements
+                path: ols.deployment.dataCollector.resources
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+              - description: 'Defines the number of desired OLS pods. Default: "1"'
+                displayName: Number of replicas
+                path: ols.deployment.replicas
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:podCount
+              - description: 'Log level. Valid options are DEBUG, INFO, WARNING, ERROR and CRITICAL. Default: "INFO".'
+                displayName: Log level
+                path: ols.logLevel
+              - description: Query filters
+                displayName: Query Filters
+                path: ols.queryFilters
+              - description: Filter name.
+                displayName: Filter Name
+                path: ols.queryFilters[0].name
+              - description: Filter pattern.
+                displayName: The pattern to replace
+                path: ols.queryFilters[0].pattern
+              - description: Replacement for the matched pattern.
+                displayName: Replace With
+                path: ols.queryFilters[0].replaceWith
+              - description: Summarizer model name
+                displayName: Summarizer Model
+                path: ols.summarizerModel
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:advanced
+              - description: Summarizer provider name
+                displayName: Summarizer Provider
+                path: ols.summarizerProvider
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:advanced
+              - description: User data collection switches
+                displayName: User Data Collection
+                path: ols.userDataCollection
+              - displayName: Do Not Collect User Feedback
+                path: ols.userDataCollection.feedbackDisabled
+              - displayName: Do Not Collect Transcripts
+                path: ols.userDataCollection.transcriptsDisabled
+              - description: Validator model name
+                displayName: Validator Model
+                path: ols.validatorModel
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:advanced
+              - description: Validator provider name
+                displayName: Validator Provider
+                path: ols.validatorProvider
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:advanced
+              - description: YAML model name
+                displayName: YAML Model
+                path: ols.yamlModel
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:advanced
+              - description: YAML provider name
+                displayName: YAML Provider
+                path: ols.yamlProvider
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:advanced
+            statusDescriptors:
+              - displayName: Conditions
+                path: conditions
+            version: v1alpha1
+      description: OpenShift Lightspeed is an AI-powered assistant that runs on OpenShift and answers questions about OpenShift using backend LLM services.
+      displayName: OpenShift Lightspeed Operator
+      installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+      keywords:
+        - ai
+        - assistant
+        - openshift
+        - llm
+      links:
+        - name: Lightspeed Operator
+          url: https://github.com/openshift/lightspeed-operator
+      maturity: alpha
+      minKubeVersion: 1.28.0
+      provider:
+        name: Red Hat, Inc
+        url: https://github.com/openshift/lightspeed-service
+relatedImages:
+  - name: lightspeed-service-api
+    image: registry.redhat.io/openshift-lightspeed-beta/lightspeed-service-api-rhel9@sha256:fedfaaba10cf2dd952cf735167e9898c034ecec433a22b38293aeccaeed6e3bf
+  - name: lightspeed-console-plugin
+    image: registry.redhat.io/openshift-lightspeed-beta/lightspeed-console-plugin-rhel9@sha256:4f45c9ba068cf92e592bb3a502764ce6bc93cd154d081fa49d05cb040885155b
+  - name: lightspeed-operator
+    image: registry.redhat.io/openshift-lightspeed-beta/lightspeed-rhel9-operator@sha256:049a1a398ed87e4f35c99b36304055c7f75d0188a4d8c1726df59b5f400561e5
+  - name: lightspeed-operator-bundle
+    image: registry.redhat.io/openshift-lightspeed-beta/lightspeed-operator-bundle@sha256:e46e337502a00282473e083c16a64e6201df3677905e4b056b7f48ef0b8f6e4b
+schema: olm.bundle
+---
+schema: olm.channel
+package: lightspeed-operator
+name: preview
+entries:
+  - name: lightspeed-operator.v0.0.1

--- a/lightspeed-catalog/index.yaml
+++ b/lightspeed-catalog/index.yaml
@@ -6,274 +6,292 @@ icon:
 name: lightspeed-operator
 schema: olm.package
 ---
-image: quay.io/openshift-lightspeed/lightspeed-operator-bundle:v0.0.1
+image: registry.redhat.io/openshift-lightspeed-beta/lightspeed-operator-bundle@sha256:e46e337502a00282473e083c16a64e6201df3677905e4b056b7f48ef0b8f6e4b
 name: lightspeed-operator.v0.0.1
 package: lightspeed-operator
 properties:
-- type: olm.gvk
-  value:
-    group: ols.openshift.io
-    kind: OLSConfig
-    version: v1alpha1
-- type: olm.package
-  value:
-    packageName: lightspeed-operator
-    version: 0.0.1
-- type: olm.csv.metadata
-  value:
-    annotations:
-      alm-examples: |-
-        [
-          {
-            "apiVersion": "ols.openshift.io/v1alpha1",
-            "kind": "OLSConfig",
-            "metadata": {
-              "labels": {
-                "app.kubernetes.io/created-by": "lightspeed-operator",
-                "app.kubernetes.io/instance": "olsconfig-sample",
-                "app.kubernetes.io/managed-by": "kustomize",
-                "app.kubernetes.io/name": "olsconfig",
-                "app.kubernetes.io/part-of": "lightspeed-operator"
+  - type: olm.gvk
+    value:
+      group: ols.openshift.io
+      kind: OLSConfig
+      version: v1alpha1
+  - type: olm.package
+    value:
+      packageName: lightspeed-operator
+      version: 0.0.1
+  - type: olm.csv.metadata
+    value:
+      annotations:
+        alm-examples: |-
+          [
+            {
+              "apiVersion": "ols.openshift.io/v1alpha1",
+              "kind": "OLSConfig",
+              "metadata": {
+                "labels": {
+                  "app.kubernetes.io/created-by": "lightspeed-operator",
+                  "app.kubernetes.io/instance": "olsconfig-sample",
+                  "app.kubernetes.io/managed-by": "kustomize",
+                  "app.kubernetes.io/name": "olsconfig",
+                  "app.kubernetes.io/part-of": "lightspeed-operator"
+                },
+                "name": "cluster"
               },
-              "name": "cluster"
-            },
-            "spec": {
-              "llm": {
-                "providers": [
-                  {
-                    "credentialsSecretRef": {
-                      "name": "credentials"
-                    },
-                    "models": [
-                      {
-                        "name": "gpt-3.5-turbo-1106"
-                      }
-                    ],
-                    "name": "OpenAI"
-                  }
-                ]
+              "spec": {
+                "llm": {
+                  "providers": [
+                    {
+                      "credentialsSecretRef": {
+                        "name": "credentials"
+                      },
+                      "models": [
+                        {
+                          "name": "gpt-3.5-turbo-1106"
+                        }
+                      ],
+                      "name": "OpenAI"
+                    }
+                  ]
+                }
               }
             }
-          }
-        ]
-      capabilities: Basic Install
-      createdAt: "2024-07-12T14:24:56Z"
-      features.operators.openshift.io/cnf: "false"
-      features.operators.openshift.io/cni: "false"
-      features.operators.openshift.io/csi: "false"
-      features.operators.openshift.io/disconnected: "true"
-      features.operators.openshift.io/fips-compliant: "true"
-      features.operators.openshift.io/proxy-aware: "true"
-      features.operators.openshift.io/tls-profiles: "false"
-      features.operators.openshift.io/token-auth-aws: "false"
-      features.operators.openshift.io/token-auth-azure: "false"
-      features.operators.openshift.io/token-auth-gcp: "false"
-      operatorframework.io/cluster-monitoring: "true"
-      operatorframework.io/suggested-namespace: openshift-lightspeed
-      operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
-        "OpenShift Container Platform", "OpenShift Platform Plus"]'
-      operators.operatorframework.io/builder: operator-sdk-v1.33.0
-      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
-      repository: https://github.com/openshift/lightspeed-operator
-    apiServiceDefinitions: {}
-    crdDescriptions:
-      owned:
-      - description: Red Hat OpenShift Lightspeed instance. OLSConfig is the Schema
-          for the olsconfigs API
-        displayName: OLSConfig
-        kind: OLSConfig
-        name: olsconfigs.ols.openshift.io
-        specDescriptors:
-        - description: Provider name
-          displayName: Name
-          path: llm.providers[0].name
-        - description: OLS deployment settings
-          displayName: Deployment
-          path: ols.deployment
-        - description: Provider API URL
-          displayName: URL
-          path: llm.providers[0].url
-        - description: Conversation cache settings
-          displayName: Conversation Cache
-          path: ols.conversationCache
-        - description: The name of the secret object that stores API provider credentials
-          displayName: Credential Secret
-          path: llm.providers[0].credentialsSecretRef
-        - displayName: LLM Settings
-          path: llm
-        - displayName: Providers
-          path: llm.providers
-        - description: Azure OpenAI deployment name
-          displayName: Azure OpenAI deployment name
-          path: llm.providers[0].deploymentName
-        - description: List of models from the provider
-          displayName: Models
-          path: llm.providers[0].models
-        - description: Model name
-          displayName: Name
-          path: llm.providers[0].models[0].name
-        - description: Model API URL
-          displayName: URL
-          path: llm.providers[0].models[0].url
-        - description: Watsonx Project ID
-          displayName: Watsonx Project ID
-          path: llm.providers[0].projectID
-        - description: Provider type
-          displayName: Provider Type
-          path: llm.providers[0].type
-        - displayName: OLS Settings
-          path: ols
-        - description: Classifier model name
-          displayName: Classifier Model
-          path: ols.classifierModel
-          x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:advanced
-        - description: Classifier provider name
-          displayName: Classifier Provider
-          path: ols.classifierProvider
-          x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:advanced
-        - displayName: Redis
-          path: ols.conversationCache.redis
-        - description: Secret that holds redis credentials
-          displayName: Credentials secret
-          path: ols.conversationCache.redis.credentialsSecret
-        - description: Redis maxmemory
-          displayName: Max Memory
-          path: ols.conversationCache.redis.maxMemory
-        - description: 'Redis maxmemory policy. Default: "allkeys-lru"'
-          displayName: Max Memory Policy
-          path: ols.conversationCache.redis.maxMemoryPolicy
-        - description: 'Conversation cache type. Default: "redis"'
-          displayName: Cache Type
-          path: ols.conversationCache.type
-        - description: Default model for usage
-          displayName: Default Model
-          path: ols.defaultModel
-          x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:advanced
-        - description: Default provider for usage
-          displayName: Default Provider
-          path: ols.defaultProvider
-          x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:advanced
-        - description: API container settings.
-          displayName: API Container
-          path: ols.deployment.api
-        - displayName: Resource Requirements
-          path: ols.deployment.api.resources
-          x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
-        - description: Console container settings.
-          displayName: Console Container
-          path: ols.deployment.console
-        - displayName: Resource Requirements
-          path: ols.deployment.console.resources
-          x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
-        - description: Data Collector container settings.
-          displayName: Data Collector Container
-          path: ols.deployment.dataCollector
-        - displayName: Resource Requirements
-          path: ols.deployment.dataCollector.resources
-          x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
-        - description: 'Defines the number of desired OLS pods. Default: "1"'
-          displayName: Number of replicas
-          path: ols.deployment.replicas
-          x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:podCount
-        - description: 'Log level. Valid options are DEBUG, INFO, WARNING, ERROR and
-            CRITICAL. Default: "INFO".'
-          displayName: Log level
-          path: ols.logLevel
-        - description: Query filters
-          displayName: Query Filters
-          path: ols.queryFilters
-        - description: Filter name.
-          displayName: Filter Name
-          path: ols.queryFilters[0].name
-        - description: Filter pattern.
-          displayName: The pattern to replace
-          path: ols.queryFilters[0].pattern
-        - description: Replacement for the matched pattern.
-          displayName: Replace With
-          path: ols.queryFilters[0].replaceWith
-        - description: Summarizer model name
-          displayName: Summarizer Model
-          path: ols.summarizerModel
-          x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:advanced
-        - description: Summarizer provider name
-          displayName: Summarizer Provider
-          path: ols.summarizerProvider
-          x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:advanced
-        - description: User data collection switches
-          displayName: User Data Collection
-          path: ols.userDataCollection
-        - displayName: Do Not Collect User Feedback
-          path: ols.userDataCollection.feedbackDisabled
-        - displayName: Do Not Collect Transcripts
-          path: ols.userDataCollection.transcriptsDisabled
-        - description: Validator model name
-          displayName: Validator Model
-          path: ols.validatorModel
-          x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:advanced
-        - description: Validator provider name
-          displayName: Validator Provider
-          path: ols.validatorProvider
-          x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:advanced
-        - description: YAML model name
-          displayName: YAML Model
-          path: ols.yamlModel
-          x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:advanced
-        - description: YAML provider name
-          displayName: YAML Provider
-          path: ols.yamlProvider
-          x-descriptors:
-          - urn:alm:descriptor:com.tectonic.ui:advanced
-        statusDescriptors:
-        - displayName: Conditions
-          path: conditions
-        version: v1alpha1
-    description: OpenShift Lightspeed is an AI-powered assistant that runs on OpenShift
-      and answers questions about OpenShift using backend LLM services.
-    displayName: OpenShift Lightspeed Operator
-    installModes:
-    - supported: false
-      type: OwnNamespace
-    - supported: false
-      type: SingleNamespace
-    - supported: false
-      type: MultiNamespace
-    - supported: true
-      type: AllNamespaces
-    keywords:
-    - ai
-    - assistant
-    - openshift
-    - llm
-    links:
-    - name: Lightspeed Operator
-      url: https://github.com/openshift/lightspeed-operator
-    maturity: alpha
-    minKubeVersion: 1.28.0
-    provider:
-      name: Red Hat, Inc
-      url: https://github.com/openshift/lightspeed-service
+          ]
+        capabilities: Basic Install
+        createdAt: "2024-07-15T02:15:30Z"
+        features.operators.openshift.io/cnf: "false"
+        features.operators.openshift.io/cni: "false"
+        features.operators.openshift.io/csi: "false"
+        features.operators.openshift.io/disconnected: "true"
+        features.operators.openshift.io/fips-compliant: "true"
+        features.operators.openshift.io/proxy-aware: "true"
+        features.operators.openshift.io/tls-profiles: "false"
+        features.operators.openshift.io/token-auth-aws: "false"
+        features.operators.openshift.io/token-auth-azure: "false"
+        features.operators.openshift.io/token-auth-gcp: "false"
+        operatorframework.io/cluster-monitoring: "true"
+        operatorframework.io/suggested-namespace: openshift-lightspeed
+        operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
+        operators.operatorframework.io/builder: operator-sdk-v1.33.0
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+        repository: https://github.com/openshift/lightspeed-operator
+      apiServiceDefinitions: {}
+      crdDescriptions:
+        owned:
+          - description: Red Hat OpenShift Lightspeed instance. OLSConfig is the Schema for the olsconfigs API
+            displayName: OLSConfig
+            kind: OLSConfig
+            name: olsconfigs.ols.openshift.io
+            specDescriptors:
+              - description: Provider name
+                displayName: Name
+                path: llm.providers[0].name
+              - description: OLS deployment settings
+                displayName: Deployment
+                path: ols.deployment
+              - description: Provider API URL
+                displayName: URL
+                path: llm.providers[0].url
+              - description: Conversation cache settings
+                displayName: Conversation Cache
+                path: ols.conversationCache
+              - description: The name of the secret object that stores API provider credentials
+                displayName: Credential Secret
+                path: llm.providers[0].credentialsSecretRef
+              - displayName: LLM Settings
+                path: llm
+              - displayName: Providers
+                path: llm.providers
+              - description: Azure OpenAI deployment name
+                displayName: Azure OpenAI deployment name
+                path: llm.providers[0].deploymentName
+              - description: List of models from the provider
+                displayName: Models
+                path: llm.providers[0].models
+              - description: Model name
+                displayName: Name
+                path: llm.providers[0].models[0].name
+              - description: Model API parameters
+                displayName: Parameters
+                path: llm.providers[0].models[0].parameters
+              - description: Max tokens for response
+                displayName: Max Tokens For Response
+                path: llm.providers[0].models[0].parameters.maxTokensForResponse
+              - description: Model API URL
+                displayName: URL
+                path: llm.providers[0].models[0].url
+              - description: Watsonx Project ID
+                displayName: Watsonx Project ID
+                path: llm.providers[0].projectID
+              - description: Provider type
+                displayName: Provider Type
+                path: llm.providers[0].type
+              - displayName: OLS Settings
+                path: ols
+              - description: Classifier model name
+                displayName: Classifier Model
+                path: ols.classifierModel
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:advanced
+              - description: Classifier provider name
+                displayName: Classifier Provider
+                path: ols.classifierProvider
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:advanced
+              - displayName: Redis
+                path: ols.conversationCache.redis
+              - description: Secret that holds redis credentials
+                displayName: Credentials secret
+                path: ols.conversationCache.redis.credentialsSecret
+              - description: Redis maxmemory
+                displayName: Max Memory
+                path: ols.conversationCache.redis.maxMemory
+              - description: 'Redis maxmemory policy. Default: "allkeys-lru"'
+                displayName: Max Memory Policy
+                path: ols.conversationCache.redis.maxMemoryPolicy
+              - description: 'Conversation cache type. Default: "redis"'
+                displayName: Cache Type
+                path: ols.conversationCache.type
+              - description: Default model for usage
+                displayName: Default Model
+                path: ols.defaultModel
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:advanced
+              - description: Default provider for usage
+                displayName: Default Provider
+                path: ols.defaultProvider
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:advanced
+              - description: API container settings.
+                displayName: API Container
+                path: ols.deployment.api
+              - displayName: Node Selector
+                path: ols.deployment.api.nodeSelector
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:nodeSelector
+              - displayName: Resource Requirements
+                path: ols.deployment.api.resources
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+              - displayName: Tolerations
+                path: ols.deployment.api.tolerations
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:tolerations
+              - description: Console container settings.
+                displayName: Console Container
+                path: ols.deployment.console
+              - displayName: Node Selector
+                path: ols.deployment.console.nodeSelector
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:nodeSelector
+              - displayName: Resource Requirements
+                path: ols.deployment.console.resources
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+              - displayName: Tolerations
+                path: ols.deployment.console.tolerations
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:tolerations
+              - description: Data Collector container settings.
+                displayName: Data Collector Container
+                path: ols.deployment.dataCollector
+              - displayName: Resource Requirements
+                path: ols.deployment.dataCollector.resources
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+              - description: 'Defines the number of desired OLS pods. Default: "1"'
+                displayName: Number of replicas
+                path: ols.deployment.replicas
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:podCount
+              - description: 'Log level. Valid options are DEBUG, INFO, WARNING, ERROR and CRITICAL. Default: "INFO".'
+                displayName: Log level
+                path: ols.logLevel
+              - description: Query filters
+                displayName: Query Filters
+                path: ols.queryFilters
+              - description: Filter name.
+                displayName: Filter Name
+                path: ols.queryFilters[0].name
+              - description: Filter pattern.
+                displayName: The pattern to replace
+                path: ols.queryFilters[0].pattern
+              - description: Replacement for the matched pattern.
+                displayName: Replace With
+                path: ols.queryFilters[0].replaceWith
+              - description: Summarizer model name
+                displayName: Summarizer Model
+                path: ols.summarizerModel
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:advanced
+              - description: Summarizer provider name
+                displayName: Summarizer Provider
+                path: ols.summarizerProvider
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:advanced
+              - description: User data collection switches
+                displayName: User Data Collection
+                path: ols.userDataCollection
+              - displayName: Do Not Collect User Feedback
+                path: ols.userDataCollection.feedbackDisabled
+              - displayName: Do Not Collect Transcripts
+                path: ols.userDataCollection.transcriptsDisabled
+              - description: Validator model name
+                displayName: Validator Model
+                path: ols.validatorModel
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:advanced
+              - description: Validator provider name
+                displayName: Validator Provider
+                path: ols.validatorProvider
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:advanced
+              - description: YAML model name
+                displayName: YAML Model
+                path: ols.yamlModel
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:advanced
+              - description: YAML provider name
+                displayName: YAML Provider
+                path: ols.yamlProvider
+                x-descriptors:
+                  - urn:alm:descriptor:com.tectonic.ui:advanced
+            statusDescriptors:
+              - displayName: Conditions
+                path: conditions
+            version: v1alpha1
+      description: OpenShift Lightspeed is an AI-powered assistant that runs on OpenShift and answers questions about OpenShift using backend LLM services.
+      displayName: OpenShift Lightspeed Operator
+      installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+      keywords:
+        - ai
+        - assistant
+        - openshift
+        - llm
+      links:
+        - name: Lightspeed Operator
+          url: https://github.com/openshift/lightspeed-operator
+      maturity: alpha
+      minKubeVersion: 1.28.0
+      provider:
+        name: Red Hat, Inc
+        url: https://github.com/openshift/lightspeed-service
 relatedImages:
-- image: quay.io/openshift-lightspeed/lightspeed-operator-bundle:v0.0.1
-  name: ""
-- image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console@sha256:4f45c9ba068cf92e592bb3a502764ce6bc93cd154d081fa49d05cb040885155b
-  name: lightspeed-console-plugin
-- image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator@sha256:0ebfc27123718c2806746ffcbdbed1b9f65f52268a42640a82f757bf9990b922
-  name: lightspeed-operator
-- image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service@sha256:7129eef4a6918b61ace72f1c946490bf74aef06e37b4fadbb879a73e68e68f3d
-  name: lightspeed-service-api
+  - name: lightspeed-service-api
+    image: registry.redhat.io/openshift-lightspeed-beta/lightspeed-service-api-rhel9@sha256:fedfaaba10cf2dd952cf735167e9898c034ecec433a22b38293aeccaeed6e3bf
+  - name: lightspeed-console-plugin
+    image: registry.redhat.io/openshift-lightspeed-beta/lightspeed-console-plugin-rhel9@sha256:4f45c9ba068cf92e592bb3a502764ce6bc93cd154d081fa49d05cb040885155b
+  - name: lightspeed-operator
+    image: registry.redhat.io/openshift-lightspeed-beta/lightspeed-rhel9-operator@sha256:049a1a398ed87e4f35c99b36304055c7f75d0188a4d8c1726df59b5f400561e5
+  - name: lightspeed-operator-bundle
+    image: registry.redhat.io/openshift-lightspeed-beta/lightspeed-operator-bundle@sha256:e46e337502a00282473e083c16a64e6201df3677905e4b056b7f48ef0b8f6e4b
 schema: olm.bundle
 ---
 schema: olm.channel


### PR DESCRIPTION
## Description

The catalog refers production image, the same as bunlde image does.
Add 4.15 and 4.16 version specific dockerfile for catalog images.
The script `update_bundle_catalog.sh` is updated to generate the corret catalog index.
The 2 dockerfile allow us to build FBC component for 4.15 and 4.16 catalog.
The old catalog will be removed afterwards.

Konflux component onboard PRs to merge after this PR:
- ols-fbc-v4-16 https://github.com/openshift/lightspeed-operator/pull/285
- ols-fbc-v4-15 https://github.com/openshift/lightspeed-operator/pull/284

Catalog files are generated by 
```shell
#!/bin/bash

OPERATOR_IMAGE="registry.redhat.io/openshift-lightspeed-beta/lightspeed-rhel9-operator@sha256:049a1a398ed87e4f35c99b36304055c7f75d0188a4d8c1726df59b5f400561e5"
BUNDLE_IMAGE="registry.redhat.io/openshift-lightspeed-beta/lightspeed-operator-bundle@sha256:e46e337502a00282473e083c16a64e6201df3677905e4b056b7f48ef0b8f6e4b"
CONSOLE_IMAGE="registry.redhat.io/openshift-lightspeed-beta/lightspeed-console-plugin-rhel9@sha256:4f45c9ba068cf92e592bb3a502764ce6bc93cd154d081fa49d05cb040885155b"
SERVICE_IMAGE="registry.redhat.io/openshift-lightspeed-beta/lightspeed-service-api-rhel9@sha256:fedfaaba10cf2dd952cf735167e9898c034ecec433a22b38293aeccaeed6e3bf"
RELATED_IMAGES=$(
  cat <<-EOF
[
  {
    "name": "lightspeed-service-api",
    "image": "${SERVICE_IMAGE}"
  },
  {
    "name": "lightspeed-console-plugin",
    "image": "${CONSOLE_IMAGE}"
  },
  {
    "name": "lightspeed-operator",
    "image": "${OPERATOR_IMAGE}"
  }
]
EOF
)

find config/ -type f -name "*.yaml" | while read -r manifest; do
  echo "Updating ${manifest}"
  sed -i 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator@sha256:[0-9a-f]\{64\}|'"${OPERATOR_IMAGE}"'|g' ${manifest}
  sed -i 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console@sha256:[a-z0-9]\{64\}|'"${CONSOLE_IMAGE}"'|g' ${manifest}
  sed -i 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service@sha256:[0-9a-f]\{64\}|'"${SERVICE_IMAGE}"'|g' ${manifest}
done

# Put BUNDLE_IMAGE=$BUNDLE_IMAGE when the bunlde is built and pushed to the staging registry
OPERATOR_IMAGE=${OPERATOR_IMAGE} RELATED_IMAGES=${RELATED_IMAGES} BUNDLE_IMAGE=${BUNDLE_IMAGE} CATALOG_FILE=lightspeed-catalog-4.15/index.yaml ./hack/update_bundle_catalog.sh
OPERATOR_IMAGE=${OPERATOR_IMAGE} RELATED_IMAGES=${RELATED_IMAGES} BUNDLE_IMAGE=${BUNDLE_IMAGE} CATALOG_FILE=lightspeed-catalog-4.16/index.yaml ./hack/update_bundle_catalog.sh
OPERATOR_IMAGE=${OPERATOR_IMAGE} RELATED_IMAGES=${RELATED_IMAGES} BUNDLE_IMAGE=${BUNDLE_IMAGE} CATALOG_FILE=lightspeed-catalog/index.yaml ./hack/update_bundle_catalog.sh

```

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # [OLS-567](https://issues.redhat.com//browse/OLS-567)
- Closes #


