### PR TITLE
FBC pipeline config update

### DIFF
--- a/.tekton/fbc-v4-15-pull-request.yaml
+++ b/.tekton/fbc-v4-15-pull-request.yaml
@@ -195,7 +195,7 @@ spec:
         - name: name
           value: buildah
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.1@sha256:72e4ddd9b543e2766830e3a513da5c2fec26ea7a72a50e8c85be642912caa603
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.2@sha256:1af5619570fd8bead0f0bee3a3f29a0a140df5e82f00b71192b2bbb1130be417
         - name: kind
           value: task
         resolver: bundles
@@ -209,8 +209,6 @@ spec:
         workspace: workspace
     - name: deprecated-base-image-check
       params:
-      - name: BASE_IMAGES_DIGESTS
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       - name: IMAGE_URL
         value: $(tasks.build-container.results.IMAGE_URL)
       - name: IMAGE_DIGEST

--- a/.tekton/fbc-v4-15-pull-request.yaml
+++ b/.tekton/fbc-v4-15-pull-request.yaml
@@ -7,8 +7,10 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request" && 
+      target_branch == "main" &&
+      (".tekton/fbc-v4-15-pull-request.yaml".pathChanged() || "lightspeed-catalog-4.15/***".pathChanged() || "lightspeed-catalog-4.15.Dockerfile".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: ols-fbc-v4-15

--- a/.tekton/fbc-v4-15-push.yaml
+++ b/.tekton/fbc-v4-15-push.yaml
@@ -192,7 +192,7 @@ spec:
         - name: name
           value: buildah
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.1@sha256:72e4ddd9b543e2766830e3a513da5c2fec26ea7a72a50e8c85be642912caa603
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.2@sha256:1af5619570fd8bead0f0bee3a3f29a0a140df5e82f00b71192b2bbb1130be417
         - name: kind
           value: task
         resolver: bundles
@@ -206,8 +206,6 @@ spec:
         workspace: workspace
     - name: deprecated-base-image-check
       params:
-      - name: BASE_IMAGES_DIGESTS
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       - name: IMAGE_URL
         value: $(tasks.build-container.results.IMAGE_URL)
       - name: IMAGE_DIGEST

--- a/.tekton/fbc-v4-15-push.yaml
+++ b/.tekton/fbc-v4-15-push.yaml
@@ -6,8 +6,10 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" &&
+      target_branch == "main" &&
+      ("fbc-v4-15-push.yaml".pathChanged() || "lightspeed-catalog-4.15/***".pathChanged() || "lightspeed-catalog-4.15.Dockerfile".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: ols-fbc-v4-15

--- a/.tekton/fbc-v4-16-pull-request.yaml
+++ b/.tekton/fbc-v4-16-pull-request.yaml
@@ -7,8 +7,10 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request" &&
+      target_branch == "main" &&
+      (".tekton/fbc-v4-16-pull-request.yaml".pathChanged() || "lightspeed-catalog-4.16/***".pathChanged() || "lightspeed-catalog-4.16.Dockerfile".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: ols-fbc-v4-16

--- a/.tekton/fbc-v4-16-pull-request.yaml
+++ b/.tekton/fbc-v4-16-pull-request.yaml
@@ -195,7 +195,7 @@ spec:
         - name: name
           value: buildah
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.1@sha256:72e4ddd9b543e2766830e3a513da5c2fec26ea7a72a50e8c85be642912caa603
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.2@sha256:1af5619570fd8bead0f0bee3a3f29a0a140df5e82f00b71192b2bbb1130be417
         - name: kind
           value: task
         resolver: bundles
@@ -209,8 +209,6 @@ spec:
         workspace: workspace
     - name: deprecated-base-image-check
       params:
-      - name: BASE_IMAGES_DIGESTS
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       - name: IMAGE_URL
         value: $(tasks.build-container.results.IMAGE_URL)
       - name: IMAGE_DIGEST

--- a/.tekton/fbc-v4-16-push.yaml
+++ b/.tekton/fbc-v4-16-push.yaml
@@ -192,7 +192,7 @@ spec:
         - name: name
           value: buildah
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.1@sha256:72e4ddd9b543e2766830e3a513da5c2fec26ea7a72a50e8c85be642912caa603
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.2@sha256:1af5619570fd8bead0f0bee3a3f29a0a140df5e82f00b71192b2bbb1130be417
         - name: kind
           value: task
         resolver: bundles
@@ -206,8 +206,6 @@ spec:
         workspace: workspace
     - name: deprecated-base-image-check
       params:
-      - name: BASE_IMAGES_DIGESTS
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       - name: IMAGE_URL
         value: $(tasks.build-container.results.IMAGE_URL)
       - name: IMAGE_DIGEST

--- a/.tekton/fbc-v4-16-push.yaml
+++ b/.tekton/fbc-v4-16-push.yaml
@@ -6,8 +6,10 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" && 
+      target_branch == "main" &&
+      (".tekton/fbc-v4-16-pull-request.yaml".pathChanged() || "lightspeed-catalog-4.16/***".pathChanged() || "lightspeed-catalog-4.16.Dockerfile".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: ols-fbc-v4-16


### PR DESCRIPTION
## Description

FBC pipeline run only when FBC related file changes. Avoid excessive runs that produce the same FBC image.
Remove deprecated BASE_IMAGES_DIGESTS argument and upgrade buildah task image.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
