### PR TITLE
on-cel-expression for the *push Konflux pipelines

### DIFF
--- a/.tekton/bundle-pull-request.yaml
+++ b/.tekton/bundle-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
       target_branch == "main" &&
-      (".tekton/bundle-pull-request.yaml".pathChanged() || "bundle/**/*".pathChanged() || "bundle.Dockerfile".pathChanged())
+      (".tekton/bundle-pull-request.yaml".pathChanged() || "bundle/***".pathChanged() || "bundle.Dockerfile".pathChanged())
     build.appstudio.openshift.io/build-nudge-files: ".*Dockerfile.*, .*.yaml, .*Containerfile.*,.*.sh"
   creationTimestamp: null
   labels:

--- a/.tekton/bundle-push.yaml
+++ b/.tekton/bundle-push.yaml
@@ -8,7 +8,8 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
-      target_branch == "main"
+      target_branch == "main" &&
+      (".tekton/bundle-push.yaml".pathChanged() || "bundle/***".pathChanged() || "bundle.Dockerfile".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: ols

--- a/.tekton/lightspeed-operator-push.yaml
+++ b/.tekton/lightspeed-operator-push.yaml
@@ -6,8 +6,10 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" &&
+      target_branch == "main" &&
+      (".tekton/lightspeed-operator-push.yaml".pathChanged() || "Dockerfile".pathChanged() || "LICENSE".pathChanged() || "go.*".pathChanged() || "cmd/***".pathChanged() || "api/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: ols


### PR DESCRIPTION
## Description

Added pipelinesascode.tekton.dev/on-cel-expression to the on-push tekton pipelines to be in sync with the on-pull pipelines and to differentiate between the operator and bundle components wrt Konflux notifications.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
