### PR TITLE
OLS-567: add catalog as subdirectory into olm config

### DIFF
--- a/lightspeed-catalog-4.15.Dockerfile
+++ b/lightspeed-catalog-4.15.Dockerfile
@@ -7,7 +7,7 @@ CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
 # Copy licenses required by Red Hat certification policy
 ADD LICENSE /licenses/
 # Copy declarative config root into image at /configs and pre-populate serve cache
-ADD lightspeed-catalog-4.15 /configs
+ADD lightspeed-catalog-4.15 /configs/lightspeed-operator
 RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
 
 # Set DC-specific label for the location of the DC root directory

--- a/lightspeed-catalog-4.16.Dockerfile
+++ b/lightspeed-catalog-4.16.Dockerfile
@@ -7,7 +7,7 @@ CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
 # Copy licenses required by Red Hat certification policy
 ADD LICENSE /licenses/
 # Copy declarative config root into image at /configs and pre-populate serve cache
-ADD lightspeed-catalog-4.16 /configs
+ADD lightspeed-catalog-4.16 /configs/lightspeed-operator
 RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
 
 # Set DC-specific label for the location of the DC root directory


### PR DESCRIPTION
## Description

The konflux fbc release task `add-fbc-contribution-to-index-image` expects catalogs are kept in subdirectories in OLM's config directory.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # [OLS-567](https://issues.redhat.com//browse/OLS-567)
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
