### PR TITLE
OLS-885: Catalog generation from konflux snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,35 @@ When using Visual Studio Code, we can use the debugger settings below to execute
 
 **NOTE:** Run `make --help` for more information on all potential `make` targets
 
+### Update Catalog From Konflux Snapshot
+
+To update the catalog index from a Konflux snapshot, we need to connect to Konflux using `oc login`  command:
+1. Go to the Developer Sandbox web portal https://registration-service-toolchain-host-operator.apps.stone-prd-host1.wdlc.p1.openshiftapps.com/
+2. Copy the proxy login command on the top right corner. It should look like this `oc login --token=$TOKEN --server=https://api-toolchain-host-operator.apps.stone-prd-host1.wdlc.p1.openshiftapps.com`
+3. Append our workspace to the server URL `oc login --token=$TOKEN --server=https://api-toolchain-host-operator.apps.stone-prd-host1.wdlc.p1.openshiftapps.com/workspaces/crt-nshift-lightspeed/`
+4. Login using that command
+
+Now we can use the script `hack/snapshot_to_catalog.sh` to update the catalog index. It takes 3 parameters `snapshot_to_catalog.sh -s <snapshot-ref> -c <catalog-file>`:
+- snapshot-ref: required, the snapshot reference to use, example: ols-bnxm2
+- catalog-file: optional, the catalog index file to update, default: lightspeed-catalog-4.16/index.yaml
+
+To generate catalog index file `lightspeed-catalog-4.16/index.yaml` from the snapshot `ols-bnxm2`
+```
+➜  lightspeed-operator ✗ ./hack/snapshot_to_catalog.sh -s ols-bnxm2 -c lightspeed-catalog-4.16/index.yaml
+
+Update catalog lightspeed-catalog-4.16/index.yaml from snapshot ols-bnxm2
+using opm from /home/hasun/GitRepo/lightspeed-operator/bin/opm
+using yq from /usr/bin/yq
+Catalog will use the following images:
+BUNDLE_IMAGE=registry.redhat.io/openshift-lightspeed-beta/lightspeed-operator-bundle@sha256:b9387e5900e700db47d2b4d7f106b43d0958a3b0d3d4f4b68495141675b66a1c
+OPERATOR_IMAGE=registry.redhat.io/openshift-lightspeed-beta/lightspeed-rhel9-operator@sha256:4bb81dfec6cce853543c7c0e7f2898ece23105fe3a5c5b17d845b1ff58fdc92a
+CONSOLE_IMAGE=registry.redhat.io/openshift-lightspeed-beta/lightspeed-console-plugin-rhel9@sha256:4f45c9ba068cf92e592bb3a502764ce6bc93cd154d081fa49d05cb040885155b
+SERVICE_IMAGE=registry.redhat.io/openshift-lightspeed-beta/lightspeed-service-api-rhel9@sha256:794017379e28cfbbd17c8a8343f3326f2c99b8f9da5e593fa5afd52258d0c563
+BUNDLE_IMAGE_ORIGIN=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/bundle@sha256:b9387e5900e700db47d2b4d7f106b43d0958a3b0d3d4f4b68495141675b66a1c
+Bundle version is 0.1.0
+Validation passed for lightspeed-catalog-4.16/index.yaml
+```
+
 ## Prerequisites
 
 You'll need the following tools to develop the Operator:

--- a/hack/snapshot_to_catalog.sh
+++ b/hack/snapshot_to_catalog.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+
+usage() {
+  echo "Usage: $0 -s <snapshot-ref> -c <catalog-file>"
+  echo "  snapshot-ref: required, the snapshot reference to use, example: ols-bnxm2"
+  echo "  catalog-file: the catalog index file to update, default: lightspeed-catalog-4.16/index.yaml"
+}
+
+if [ $# == 0 ]; then
+  usage
+  exit 1
+fi
+
+SNAPSHOT_REF=""
+CATALOG_FILE="lightspeed-catalog-4.16/index.yaml"
+
+while getopts ":s:c:h" argname; do
+  case "$argname" in
+  "s")
+    SNAPSHOT_REF=${OPTARG}
+    ;;
+  "c")
+    CATALOG_FILE=${OPTARG}
+    ;;
+  "h")
+    usage
+    exit 0
+    ;;
+  "?")
+    echo "Unknown option $OPTARG"
+    usage
+    exit 1
+    ;;
+  *)
+    echo "Unknown error while processing options"
+    exit 1
+    ;;
+  esac
+done
+
+if [ -z "${SNAPSHOT_REF}" ]; then
+  echo "snapshot-ref is required"
+  usage
+  exit 1
+fi
+
+echo "Update catalog ${CATALOG_FILE} from snapshot ${SNAPSHOT_REF}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CATALOG_INITIAL_FILE="${SCRIPT_DIR}/operator.yaml"
+
+# cache the snapshot from Konflux
+TMP_SNAPSHOT_JSON=$(mktemp)
+oc get snapshot ${SNAPSHOT_REF} -o json >"${TMP_SNAPSHOT_JSON}"
+if [ $? -ne 0 ]; then
+  echo "Failed to get snapshot ${SNAPSHOT_REF}"
+  echo "Please make sure the snapshot exists and the snapshot name is correct"
+  echo "Need to login Konflux through oc login, proxy command to be found here: https://registration-service-toolchain-host-operator.apps.stone-prd-host1.wdlc.p1.openshiftapps.com/"
+  exit 1
+fi
+
+# temporary file for rendering the bundle part of the catalog
+TEMP_BUNDLE_FILE=$(mktemp)
+
+cleanup() {
+  # remove temporary snapshot file
+  if [ -n "${TMP_SNAPSHOT_JSON}" ]; then
+    rm -f "${TMP_SNAPSHOT_JSON}"
+  fi
+
+  # remove temporary bundle file
+  if [ -n "${TEMP_BUNDLE_FILE}" ]; then
+    rm -f "${TEMP_BUNDLE_FILE}"
+  fi
+
+}
+
+trap cleanup EXIT
+
+: ${OPM:=$(command -v opm)}
+echo "using opm from ${OPM}"
+# check if opm version is v1.39.0 or exit
+if ! ${OPM} version | grep -q "v1.27.1"; then
+  echo "opm version v1.27.1 is required"
+  exit 1
+fi
+
+: ${YQ:=$(command -v yq)}
+echo "using yq from ${YQ}"
+# check if yq exists
+if [ -z "${YQ}" ]; then
+  echo "yq is required"
+  exit 1
+fi
+
+BUNDLE_IMAGE_BASE="registry.redhat.io/openshift-lightspeed-beta/lightspeed-operator-bundle"
+OPERATOR_IMAGE_BASE="registry.redhat.io/openshift-lightspeed-beta/lightspeed-rhel9-operator"
+CONSOLE_IMAGE_BASE="registry.redhat.io/openshift-lightspeed-beta/lightspeed-console-plugin-rhel9"
+SERVICE_IMAGE_BASE="registry.redhat.io/openshift-lightspeed-beta/lightspeed-service-api-rhel9"
+
+BUNDLE_IMAGE_ORIGIN=$(jq -r '.spec.components[]| select(.name=="bundle") | .containerImage' "${TMP_SNAPSHOT_JSON}")
+BUNDLE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/bundle|'"${BUNDLE_IMAGE_BASE}"'|g' <<<${BUNDLE_IMAGE_ORIGIN})
+
+OPERATOR_IMAGE=$(jq -r '.spec.components[]| select(.name=="lightspeed-operator") | .containerImage' "${TMP_SNAPSHOT_JSON}")
+OPERATOR_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator|'"${OPERATOR_IMAGE_BASE}"'|g' <<<${OPERATOR_IMAGE})
+
+CONSOLE_IMAGE=$(jq -r '.spec.components[]| select(.name=="lightspeed-console") | .containerImage' "${TMP_SNAPSHOT_JSON}")
+CONSOLE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console|'"${CONSOLE_IMAGE_BASE}"'|g' <<<${CONSOLE_IMAGE})
+
+SERVICE_IMAGE=$(jq -r '.spec.components[]| select(.name=="lightspeed-service") | .containerImage' "${TMP_SNAPSHOT_JSON}")
+SERVICE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service|'"${SERVICE_IMAGE_BASE}"'|g' <<<${SERVICE_IMAGE})
+
+RELATED_IMAGES=$(
+  cat <<-EOF
+[
+  {
+    "name": "lightspeed-service-api",
+    "image": "${SERVICE_IMAGE}"
+  },
+  {
+    "name": "lightspeed-console-plugin",
+    "image": "${CONSOLE_IMAGE}"
+  },
+  {
+    "name": "lightspeed-operator",
+    "image": "${OPERATOR_IMAGE}"
+  },
+  { "name": "lightspeed-operator-bundle",
+    "image": "${BUNDLE_IMAGE}"
+  }
+]
+EOF
+)
+
+echo "Catalog will use the following images:"
+echo "BUNDLE_IMAGE=${BUNDLE_IMAGE}"
+echo "OPERATOR_IMAGE=${OPERATOR_IMAGE}"
+echo "CONSOLE_IMAGE=${CONSOLE_IMAGE}"
+echo "SERVICE_IMAGE=${SERVICE_IMAGE}"
+
+echo BUNDLE_IMAGE_ORIGIN=${BUNDLE_IMAGE_ORIGIN}
+${OPM} render ${BUNDLE_IMAGE_ORIGIN} --output=yaml >"${TEMP_BUNDLE_FILE}"
+
+BUNDLE_VERSION=$(yq '.properties[]| select(.type=="olm.package")| select(.value.packageName=="lightspeed-operator") |.value.version' ${TEMP_BUNDLE_FILE})
+echo "Bundle version is ${BUNDLE_VERSION}"
+
+# restore bundle image to the catalog file
+${YQ} eval -i '.image='"\"${BUNDLE_IMAGE}\"" "${TEMP_BUNDLE_FILE}"
+# restore bundle related images and the bundle itself to the catalog file
+${YQ} eval -i '.relatedImages='"${RELATED_IMAGES}" "${TEMP_BUNDLE_FILE}"
+
+#Initialize catalog file from hack/operator.yaml
+cat ${CATALOG_INITIAL_FILE} >"${CATALOG_FILE}"
+
+cat ${TEMP_BUNDLE_FILE} >>"${CATALOG_FILE}"
+
+cat <<EOF >>"${CATALOG_FILE}"
+---
+schema: olm.channel
+package: lightspeed-operator
+name: preview
+entries:
+  - name: lightspeed-operator.v${BUNDLE_VERSION}
+EOF
+
+${OPM} validate "$(dirname "${CATALOG_FILE}")"
+if [ $? -ne 0 ]; then
+  echo "Validation failed for ${CATALOG_FILE}"
+  exit 1
+else
+  echo "Validation passed for ${CATALOG_FILE}"
+fi


### PR DESCRIPTION
## Description

add a new script `snapshot_to_catalog.sh` to generate catalog index file from Konflux snapshot.

To generate a new catalog index using snapshot `ols-bnxm2` to the catalog file `lightspeed-catalog-4.16/index.yaml` for bundle `0.1.0`, execute this command.
```
./hack/snapshot_to_catalog.sh ols-bnxm2 lightspeed-catalog-4.16/index.yaml
```
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # [OLS-855](https://issues.redhat.com//browse/OLS-855)
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
