### PR TITLE
OLS-810: Create option in olsconfig CRD for context_window_size per model

### DIFF
--- a/api/v1alpha1/olsconfig_types.go
+++ b/api/v1alpha1/olsconfig_types.go
@@ -211,6 +211,10 @@ type ModelSpec struct {
 	// +kubebuilder:validation:Pattern=`^https?://.*$`
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="URL"
 	URL string `json:"url,omitempty"`
+	// Defines the model's context window size. Default is specific to provider/model.
+	// +kubebuilder:validation:Minimum=1024
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Context Window Size"
+	ContextWindowSize uint `json:"contextWindowSize,omitempty"`
 	// Model API parameters
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Parameters"
 	Parameters ModelParametersSpec `json:"parameters,omitempty"`

--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -102,6 +102,9 @@ spec:
           - description: Model API URL
             displayName: URL
             path: llm.providers[0].models[0].url
+          - description: Model context window size
+            displayName: Context Window Size
+            path: llm.providers[0].models[0].contextWindowSize
           - description: Watsonx Project ID
             displayName: Watsonx Project ID
             path: llm.providers[0].projectID

--- a/bundle/manifests/ols.openshift.io_olsconfigs.yaml
+++ b/bundle/manifests/ols.openshift.io_olsconfigs.yaml
@@ -82,6 +82,10 @@ spec:
                                 description: Model API URL
                                 pattern: ^https?://.*$
                                 type: string
+                              contextWindowSize:
+                                description: Model context window size
+                                minimum: 1024
+                                type: integer
                             required:
                             - name
                             type: object

--- a/config/crd/bases/ols.openshift.io_olsconfigs.yaml
+++ b/config/crd/bases/ols.openshift.io_olsconfigs.yaml
@@ -68,6 +68,11 @@ spec:
                           items:
                             description: ModelSpec defines the desired state of cache.
                             properties:
+                              contextWindowSize:
+                                description: Defines the model's context window size.
+                                  Default is specific to provider/model.
+                                minimum: 1024
+                                type: integer
                               name:
                                 description: Model name
                                 type: string

--- a/config/manifests/bases/lightspeed-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/lightspeed-operator.clusterserviceversion.yaml
@@ -68,6 +68,9 @@ spec:
       - description: Model API URL
         displayName: URL
         path: llm.providers[0].models[0].url
+      - description: Model context window size
+        displayName: Context Window Size
+        path: llm.providers[0].models[0].contextWindowSize
       - description: Watsonx Project ID
         displayName: Watsonx Project ID
         path: llm.providers[0].projectID

--- a/internal/controller/ols_app_server_assets.go
+++ b/internal/controller/ols_app_server_assets.go
@@ -118,6 +118,7 @@ func (r *OLSConfigReconciler) generateOLSConfigMap(ctx context.Context, cr *olsv
 				Parameters: ModelParameters{
 					MaxTokensForResponse: model.Parameters.MaxTokensForResponse,
 				},
+				ContextWindowSize: model.ContextWindowSize,
 			}
 			modelConfigs = append(modelConfigs, modelConfig)
 		}

--- a/internal/controller/ols_app_server_assets_test.go
+++ b/internal/controller/ols_app_server_assets_test.go
@@ -142,6 +142,7 @@ var _ = Describe("App server assets", func() {
 								Parameters: ModelParameters{
 									MaxTokensForResponse: 20,
 								},
+								ContextWindowSize: 32768,
 							},
 						},
 					},
@@ -860,6 +861,7 @@ func getDefaultOLSConfigCR() *olsv1alpha1.OLSConfig {
 								Parameters: olsv1alpha1.ModelParametersSpec{
 									MaxTokensForResponse: 20,
 								},
+								ContextWindowSize: 32768,
 							},
 						},
 					},

--- a/internal/controller/types.go
+++ b/internal/controller/types.go
@@ -67,6 +67,8 @@ type ModelConfig struct {
 	Name string `json:"name"`
 	// Model API URL
 	URL string `json:"url,omitempty"`
+	// Model context window size
+	ContextWindowSize uint `json:"context_window_size,omitempty"`
 	// Model parameters
 	Parameters ModelParameters `json:"parameters,omitempty"`
 }


### PR DESCRIPTION
## Description

As an OLS admin , I want the ability in the CR to set the context_window_size for my model, so that OLS can send the right content size to the LLM provider.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # https://issues.redhat.com/browse/OLS-810
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
