### PR TITLE
Removed leftover providers and models from the API

### DIFF
--- a/api/v1alpha1/olsconfig_types.go
+++ b/api/v1alpha1/olsconfig_types.go
@@ -74,30 +74,6 @@ type OLSSpec struct {
 	// Default provider for usage
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Provider",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
 	DefaultProvider string `json:"defaultProvider,omitempty"`
-	// Classifier provider name
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Classifier Provider",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
-	ClassifierProvider string `json:"classifierProvider,omitempty"`
-	// Classifier model name
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Classifier Model",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
-	ClassifierModel string `json:"classifierModel,omitempty"`
-	// Summarizer provider name
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Summarizer Provider",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
-	SummarizerProvider string `json:"summarizerProvider,omitempty"`
-	// Summarizer model name
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Summarizer Model",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
-	SummarizerModel string `json:"summarizerModel,omitempty"`
-	// Validator provider name
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Validator Provider",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
-	ValidatorProvider string `json:"validatorProvider,omitempty"`
-	// Validator model name
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Validator Model",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
-	ValidatorModel string `json:"validatorModel,omitempty"`
-	// YAML provider name
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="YAML Provider",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
-	YamlProvider string `json:"yamlProvider,omitempty"`
-	// YAML model name
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="YAML Model",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
-	YamlModel string `json:"yamlModel,omitempty"`
 	// Query filters
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Query Filters"
 	QueryFilters []QueryFiltersSpec `json:"queryFilters,omitempty"`

--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -113,16 +113,6 @@ spec:
             path: llm.providers[0].type
           - displayName: OLS Settings
             path: ols
-          - description: Classifier model name
-            displayName: Classifier Model
-            path: ols.classifierModel
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:advanced
-          - description: Classifier provider name
-            displayName: Classifier Provider
-            path: ols.classifierProvider
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:advanced
           - displayName: Redis
             path: ols.conversationCache.redis
           - description: Secret that holds redis credentials
@@ -204,16 +194,6 @@ spec:
           - description: Replacement for the matched pattern.
             displayName: Replace With
             path: ols.queryFilters[0].replaceWith
-          - description: Summarizer model name
-            displayName: Summarizer Model
-            path: ols.summarizerModel
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:advanced
-          - description: Summarizer provider name
-            displayName: Summarizer Provider
-            path: ols.summarizerProvider
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:advanced
           - description: User data collection switches
             displayName: User Data Collection
             path: ols.userDataCollection
@@ -221,26 +201,6 @@ spec:
             path: ols.userDataCollection.feedbackDisabled
           - displayName: Do Not Collect Transcripts
             path: ols.userDataCollection.transcriptsDisabled
-          - description: Validator model name
-            displayName: Validator Model
-            path: ols.validatorModel
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:advanced
-          - description: Validator provider name
-            displayName: Validator Provider
-            path: ols.validatorProvider
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:advanced
-          - description: YAML model name
-            displayName: YAML Model
-            path: ols.yamlModel
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:advanced
-          - description: YAML provider name
-            displayName: YAML Provider
-            path: ols.yamlProvider
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:advanced
           - displayName: OLS Data Collector Settings
             path: olsDataCollector
           - description: 'Log level. Valid options are DEBUG, INFO, WARNING, ERROR and CRITICAL. Default: "INFO".'

--- a/bundle/manifests/ols.openshift.io_olsconfigs.yaml
+++ b/bundle/manifests/ols.openshift.io_olsconfigs.yaml
@@ -127,12 +127,6 @@ spec:
               ols:
                 description: OLSSpec defines the desired state of OLS deployment.
                 properties:
-                  classifierModel:
-                    description: Classifier model name
-                    type: string
-                  classifierProvider:
-                    description: Classifier provider name
-                    type: string
                   conversationCache:
                     description: Conversation cache settings
                     properties:
@@ -474,12 +468,6 @@ spec:
                           type: string
                       type: object
                     type: array
-                  summarizerModel:
-                    description: Summarizer model name
-                    type: string
-                  summarizerProvider:
-                    description: Summarizer provider name
-                    type: string
                   userDataCollection:
                     description: User data collection switches
                     properties:
@@ -488,18 +476,6 @@ spec:
                       transcriptsDisabled:
                         type: boolean
                     type: object
-                  validatorModel:
-                    description: Validator model name
-                    type: string
-                  validatorProvider:
-                    description: Validator provider name
-                    type: string
-                  yamlModel:
-                    description: YAML model name
-                    type: string
-                  yamlProvider:
-                    description: YAML provider name
-                    type: string
                 required:
                 - defaultModel
                 type: object

--- a/config/crd/bases/ols.openshift.io_olsconfigs.yaml
+++ b/config/crd/bases/ols.openshift.io_olsconfigs.yaml
@@ -128,12 +128,6 @@ spec:
               ols:
                 description: OLSSpec defines the desired state of OLS deployment.
                 properties:
-                  classifierModel:
-                    description: Classifier model name
-                    type: string
-                  classifierProvider:
-                    description: Classifier provider name
-                    type: string
                   conversationCache:
                     description: Conversation cache settings
                     properties:
@@ -475,12 +469,6 @@ spec:
                           type: string
                       type: object
                     type: array
-                  summarizerModel:
-                    description: Summarizer model name
-                    type: string
-                  summarizerProvider:
-                    description: Summarizer provider name
-                    type: string
                   userDataCollection:
                     description: User data collection switches
                     properties:
@@ -489,18 +477,6 @@ spec:
                       transcriptsDisabled:
                         type: boolean
                     type: object
-                  validatorModel:
-                    description: Validator model name
-                    type: string
-                  validatorProvider:
-                    description: Validator provider name
-                    type: string
-                  yamlModel:
-                    description: YAML model name
-                    type: string
-                  yamlProvider:
-                    description: YAML provider name
-                    type: string
                 required:
                 - defaultModel
                 type: object

--- a/config/manifests/bases/lightspeed-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/lightspeed-operator.clusterserviceversion.yaml
@@ -79,16 +79,6 @@ spec:
         path: llm.providers[0].type
       - displayName: OLS Settings
         path: ols
-      - description: Classifier model name
-        displayName: Classifier Model
-        path: ols.classifierModel
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-      - description: Classifier provider name
-        displayName: Classifier Provider
-        path: ols.classifierProvider
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Redis
         path: ols.conversationCache.redis
       - description: Secret that holds redis credentials
@@ -171,16 +161,6 @@ spec:
       - description: Replacement for the matched pattern.
         displayName: Replace With
         path: ols.queryFilters[0].replaceWith
-      - description: Summarizer model name
-        displayName: Summarizer Model
-        path: ols.summarizerModel
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-      - description: Summarizer provider name
-        displayName: Summarizer Provider
-        path: ols.summarizerProvider
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: User data collection switches
         displayName: User Data Collection
         path: ols.userDataCollection
@@ -188,26 +168,6 @@ spec:
         path: ols.userDataCollection.feedbackDisabled
       - displayName: Do Not Collect Transcripts
         path: ols.userDataCollection.transcriptsDisabled
-      - description: Validator model name
-        displayName: Validator Model
-        path: ols.validatorModel
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-      - description: Validator provider name
-        displayName: Validator Provider
-        path: ols.validatorProvider
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-      - description: YAML model name
-        displayName: YAML Model
-        path: ols.yamlModel
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-      - description: YAML provider name
-        displayName: YAML Provider
-        path: ols.yamlProvider
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
       statusDescriptors:
       - displayName: Conditions
         path: conditions


### PR DESCRIPTION
## Description

Removed leftover providers and models (classifier, summarizer, yaml and validator) from the API.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
