### PR TITLE
OLS-935: Create RHOAI  and RHELAI config support on the operator side

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Kubernetes operator for managing [Red Hat OpenShift Lightspeed](https://github
 You'll need an OpenShift 4.15+ cluster to run against.
 
 > [!IMPORTANT]
-> Officially, the Operator only supports OpenAI, Azure OpenAI and WatsonX as large language model (LLM) providers, but technically, if you have an OpenAI API compatible model server (Ollama, VLLM, MLX), it should work.
+> Officially, the Operator only supports OpenAI, Azure OpenAI, WatsonX, RHELAI and RHOAI as large language model (LLM) providers, but technically, if you have an OpenAI API compatible model server (Ollama, VLLM, MLX), it should work.
 
 ### Running on the cluster
 

--- a/api/v1alpha1/olsconfig_types.go
+++ b/api/v1alpha1/olsconfig_types.go
@@ -224,7 +224,7 @@ type ProviderSpec struct {
 	// Provider type
 	// +kubebuilder:validation:Required
 	// +required
-	// +kubebuilder:validation:Enum=azure_openai;bam;openai;watsonx;fake_provider
+	// +kubebuilder:validation:Enum=azure_openai;bam;openai;watsonx;rhoai_vllm;rhelai_vllm;fake_provider
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Provider Type"
 	Type string `json:"type"`
 	// Azure OpenAI deployment name

--- a/bundle/manifests/ols.openshift.io_olsconfigs.yaml
+++ b/bundle/manifests/ols.openshift.io_olsconfigs.yaml
@@ -103,6 +103,8 @@ spec:
                           - bam
                           - openai
                           - watsonx
+                          - rhoai_vllm
+                          - rhelai_vllm
                           - fake_provider
                           type: string
                         url:

--- a/config/crd/bases/ols.openshift.io_olsconfigs.yaml
+++ b/config/crd/bases/ols.openshift.io_olsconfigs.yaml
@@ -104,6 +104,8 @@ spec:
                           - bam
                           - openai
                           - watsonx
+                          - rhoai_vllm
+                          - rhelai_vllm
                           - fake_provider
                           type: string
                         url:

--- a/internal/controller/ols_app_server_assets_test.go
+++ b/internal/controller/ols_app_server_assets_test.go
@@ -210,6 +210,34 @@ var _ = Describe("App server assets", func() {
 			}))))
 		})
 
+		It("should generate configmap with rhoai_vllm provider", func() {
+			provider := addRHOAIProvider(cr)
+			cm, err := r.generateOLSConfigMap(context.TODO(), provider)
+			Expect(err).NotTo(HaveOccurred())
+
+			var olsConfigMap map[string]interface{}
+			err = yaml.Unmarshal([]byte(cm.Data[OLSConfigFilename]), &olsConfigMap)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(olsConfigMap).To(HaveKeyWithValue("llm_providers", ContainElement(MatchKeys(Options(IgnoreExtras), Keys{
+				"name": Equal("rhoai_vllm"),
+				"type": Equal("rhoai_vllm"),
+			}))))
+		})
+
+		It("should generate configmap with rhelia_vllm provider", func() {
+			provider := addRHELAIProvider(cr)
+			cm, err := r.generateOLSConfigMap(context.TODO(), provider)
+			Expect(err).NotTo(HaveOccurred())
+
+			var olsConfigMap map[string]interface{}
+			err = yaml.Unmarshal([]byte(cm.Data[OLSConfigFilename]), &olsConfigMap)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(olsConfigMap).To(HaveKeyWithValue("llm_providers", ContainElement(MatchKeys(Options(IgnoreExtras), Keys{
+				"name": Equal("rhelai_vllm"),
+				"type": Equal("rhelai_vllm"),
+			}))))
+		})
+
 		It("should generate the OLS deployment", func() {
 			By("generate full deployment when telemetry pull secret exists")
 			createTelemetryPullSecret()
@@ -897,6 +925,18 @@ func addWatsonxProvider(cr *olsv1alpha1.OLSConfig) *olsv1alpha1.OLSConfig {
 	cr.Spec.LLMConfig.Providers[0].Name = "watsonx"
 	cr.Spec.LLMConfig.Providers[0].Type = "watsonx"
 	cr.Spec.LLMConfig.Providers[0].WatsonProjectID = "testProjectID"
+	return cr
+}
+
+func addRHOAIProvider(cr *olsv1alpha1.OLSConfig) *olsv1alpha1.OLSConfig {
+	cr.Spec.LLMConfig.Providers[0].Name = "rhoai_vllm"
+	cr.Spec.LLMConfig.Providers[0].Type = "rhoai_vllm"
+	return cr
+}
+
+func addRHELAIProvider(cr *olsv1alpha1.OLSConfig) *olsv1alpha1.OLSConfig {
+	cr.Spec.LLMConfig.Providers[0].Name = "rhelai_vllm"
+	cr.Spec.LLMConfig.Providers[0].Type = "rhelai_vllm"
 	return cr
 }
 


### PR DESCRIPTION
## Description

Create RHOAI  and RHELAI config support on the operator side: added rhoai_vllm as a provider type

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes # https://issues.redhat.com/browse/OLS-935

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
