### PR TITLE
OLS-886 snapshot_to_catalog.sh produce 2 channels with multiple bundle versions

### DIFF
--- a/hack/snapshot_to_catalog.sh
+++ b/hack/snapshot_to_catalog.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 
 usage() {
-  echo "Usage: $0 -s <snapshot-ref> -c <catalog-file>"
-  echo "  snapshot-ref: required, the snapshot reference to use, example: ols-bnxm2"
+  echo "Usage: $0 -s <snapshot-refs> -c <catalog-file> -n <channel-names>"
+  echo "  snapshot-refs: required, the snapshots' references to use, ordered by versions ascending, example: ols-cq8sl,ols-mdc8x"
   echo "  catalog-file: the catalog index file to update, default: lightspeed-catalog-4.16/index.yaml"
+  echo "  channel-names: the channel names to update, default: alpha"
+  echo "Example: $0 -s ols-cq8sl,ols-mdc8x -c lightspeed-catalog-4.16/index.yaml"
 }
 
 if [ $# == 0 ]; then
@@ -11,16 +13,20 @@ if [ $# == 0 ]; then
   exit 1
 fi
 
-SNAPSHOT_REF=""
+SNAPSHOT_REFS=""
 CATALOG_FILE="lightspeed-catalog-4.16/index.yaml"
+CHANNEL_NAMES="alpha"
 
-while getopts ":s:c:h" argname; do
+while getopts ":s:c:n:h" argname; do
   case "$argname" in
   "s")
-    SNAPSHOT_REF=${OPTARG}
+    SNAPSHOT_REFS=${OPTARG}
     ;;
   "c")
     CATALOG_FILE=${OPTARG}
+    ;;
+  "n")
+    CHANNEL_NAMES=${OPTARG}
     ;;
   "h")
     usage
@@ -38,27 +44,33 @@ while getopts ":s:c:h" argname; do
   esac
 done
 
-if [ -z "${SNAPSHOT_REF}" ]; then
-  echo "snapshot-ref is required"
+if [ -z "${SNAPSHOT_REFS}" ]; then
+  echo "snapshot-refs is required"
   usage
   exit 1
 fi
 
-echo "Update catalog ${CATALOG_FILE} from snapshot ${SNAPSHOT_REF}"
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CATALOG_INITIAL_FILE="${SCRIPT_DIR}/operator.yaml"
 
-# cache the snapshot from Konflux
-TMP_SNAPSHOT_JSON=$(mktemp)
-oc get snapshot ${SNAPSHOT_REF} -o json >"${TMP_SNAPSHOT_JSON}"
-if [ $? -ne 0 ]; then
-  echo "Failed to get snapshot ${SNAPSHOT_REF}"
-  echo "Please make sure the snapshot exists and the snapshot name is correct"
-  echo "Need to login Konflux through oc login, proxy command to be found here: https://registration-service-toolchain-host-operator.apps.stone-prd-host1.wdlc.p1.openshiftapps.com/"
+: ${OPM:=$(command -v opm)}
+echo "using opm from ${OPM}"
+# check if opm version is v1.39.0 or exit
+if ! ${OPM} version | grep -q "v1.27.1"; then
+  echo "opm version v1.27.1 is required"
   exit 1
 fi
 
+: ${YQ:=$(command -v yq)}
+echo "using yq from ${YQ}"
+# check if yq exists
+if [ -z "${YQ}" ]; then
+  echo "yq is required"
+  exit 1
+fi
+
+# temporary file for snapshot info from Konflux
+TMP_SNAPSHOT_JSON=$(mktemp)
 # temporary file for rendering the bundle part of the catalog
 TEMP_BUNDLE_FILE=$(mktemp)
 
@@ -77,41 +89,42 @@ cleanup() {
 
 trap cleanup EXIT
 
-: ${OPM:=$(command -v opm)}
-echo "using opm from ${OPM}"
-# check if opm version is v1.39.0 or exit
-if ! ${OPM} version | grep -q "v1.27.1"; then
-  echo "opm version v1.27.1 is required"
-  exit 1
-fi
+#Initialize catalog file from hack/operator.yaml
+DEFAULT_CHANNEL_NAME=$(cut -d ',' -f 1 <<<${CHANNEL_NAMES})
+sed "s/defaultChannel: preview/defaultChannel: ${DEFAULT_CHANNEL_NAME}/" ${CATALOG_INITIAL_FILE} >"${CATALOG_FILE}"
 
-: ${YQ:=$(command -v yq)}
-echo "using yq from ${YQ}"
-# check if yq exists
-if [ -z "${YQ}" ]; then
-  echo "yq is required"
-  exit 1
-fi
+# array to store the bundle versions
+BUNDLE_VERSIONS=()
 
-BUNDLE_IMAGE_BASE="registry.redhat.io/openshift-lightspeed-beta/lightspeed-operator-bundle"
-OPERATOR_IMAGE_BASE="registry.redhat.io/openshift-lightspeed-beta/lightspeed-rhel9-operator"
-CONSOLE_IMAGE_BASE="registry.redhat.io/openshift-lightspeed-beta/lightspeed-console-plugin-rhel9"
-SERVICE_IMAGE_BASE="registry.redhat.io/openshift-lightspeed-beta/lightspeed-service-api-rhel9"
+for SNAPSHOT_REF in $(echo ${SNAPSHOT_REFS} | tr "," "\n"); do
+  echo "Update catalog ${CATALOG_FILE} from snapshot ${SNAPSHOT_REF}"
+  # cache the snapshot from Konflux
+  oc get snapshot ${SNAPSHOT_REF} -o json >"${TMP_SNAPSHOT_JSON}"
+  if [ $? -ne 0 ]; then
+    echo "Failed to get snapshot ${SNAPSHOT_REF}"
+    echo "Please make sure the snapshot exists and the snapshot name is correct"
+    echo "Need to login Konflux through oc login, proxy command to be found here: https://registration-service-toolchain-host-operator.apps.stone-prd-host1.wdlc.p1.openshiftapps.com/"
+    exit 1
+  fi
+  BUNDLE_IMAGE_BASE="registry.redhat.io/openshift-lightspeed-beta/lightspeed-operator-bundle"
+  OPERATOR_IMAGE_BASE="registry.redhat.io/openshift-lightspeed-beta/lightspeed-rhel9-operator"
+  CONSOLE_IMAGE_BASE="registry.redhat.io/openshift-lightspeed-beta/lightspeed-console-plugin-rhel9"
+  SERVICE_IMAGE_BASE="registry.redhat.io/openshift-lightspeed-beta/lightspeed-service-api-rhel9"
 
-BUNDLE_IMAGE_ORIGIN=$(jq -r '.spec.components[]| select(.name=="bundle") | .containerImage' "${TMP_SNAPSHOT_JSON}")
-BUNDLE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/bundle|'"${BUNDLE_IMAGE_BASE}"'|g' <<<${BUNDLE_IMAGE_ORIGIN})
+  BUNDLE_IMAGE_ORIGIN=$(jq -r '.spec.components[]| select(.name=="bundle") | .containerImage' "${TMP_SNAPSHOT_JSON}")
+  BUNDLE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/bundle|'"${BUNDLE_IMAGE_BASE}"'|g' <<<${BUNDLE_IMAGE_ORIGIN})
 
-OPERATOR_IMAGE=$(jq -r '.spec.components[]| select(.name=="lightspeed-operator") | .containerImage' "${TMP_SNAPSHOT_JSON}")
-OPERATOR_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator|'"${OPERATOR_IMAGE_BASE}"'|g' <<<${OPERATOR_IMAGE})
+  OPERATOR_IMAGE=$(jq -r '.spec.components[]| select(.name=="lightspeed-operator") | .containerImage' "${TMP_SNAPSHOT_JSON}")
+  OPERATOR_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator|'"${OPERATOR_IMAGE_BASE}"'|g' <<<${OPERATOR_IMAGE})
 
-CONSOLE_IMAGE=$(jq -r '.spec.components[]| select(.name=="lightspeed-console") | .containerImage' "${TMP_SNAPSHOT_JSON}")
-CONSOLE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console|'"${CONSOLE_IMAGE_BASE}"'|g' <<<${CONSOLE_IMAGE})
+  CONSOLE_IMAGE=$(jq -r '.spec.components[]| select(.name=="lightspeed-console") | .containerImage' "${TMP_SNAPSHOT_JSON}")
+  CONSOLE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console|'"${CONSOLE_IMAGE_BASE}"'|g' <<<${CONSOLE_IMAGE})
 
-SERVICE_IMAGE=$(jq -r '.spec.components[]| select(.name=="lightspeed-service") | .containerImage' "${TMP_SNAPSHOT_JSON}")
-SERVICE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service|'"${SERVICE_IMAGE_BASE}"'|g' <<<${SERVICE_IMAGE})
+  SERVICE_IMAGE=$(jq -r '.spec.components[]| select(.name=="lightspeed-service") | .containerImage' "${TMP_SNAPSHOT_JSON}")
+  SERVICE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service|'"${SERVICE_IMAGE_BASE}"'|g' <<<${SERVICE_IMAGE})
 
-RELATED_IMAGES=$(
-  cat <<-EOF
+  RELATED_IMAGES=$(
+    cat <<-EOF
 [
   {
     "name": "lightspeed-service-api",
@@ -130,39 +143,56 @@ RELATED_IMAGES=$(
   }
 ]
 EOF
-)
+  )
+  echo "Catalog will use the following images:"
+  echo "BUNDLE_IMAGE=${BUNDLE_IMAGE}"
+  echo "OPERATOR_IMAGE=${OPERATOR_IMAGE}"
+  echo "CONSOLE_IMAGE=${CONSOLE_IMAGE}"
+  echo "SERVICE_IMAGE=${SERVICE_IMAGE}"
 
-echo "Catalog will use the following images:"
-echo "BUNDLE_IMAGE=${BUNDLE_IMAGE}"
-echo "OPERATOR_IMAGE=${OPERATOR_IMAGE}"
-echo "CONSOLE_IMAGE=${CONSOLE_IMAGE}"
-echo "SERVICE_IMAGE=${SERVICE_IMAGE}"
+  echo BUNDLE_IMAGE_ORIGIN=${BUNDLE_IMAGE_ORIGIN}
+  ${OPM} render ${BUNDLE_IMAGE_ORIGIN} --output=yaml >"${TEMP_BUNDLE_FILE}"
+  BUNDLE_VERSION=$(yq '.properties[]| select(.type=="olm.package")| select(.value.packageName=="lightspeed-operator") |.value.version' ${TEMP_BUNDLE_FILE})
+  echo "Bundle version is ${BUNDLE_VERSION}"
+  BUNDLE_VERSIONS+=("${BUNDLE_VERSION}")
+  # restore bundle image to the catalog file
+  ${YQ} eval -i '.image='"\"${BUNDLE_IMAGE}\"" "${TEMP_BUNDLE_FILE}"
+  # restore bundle related images and the bundle itself to the catalog file
+  ${YQ} eval -i '.relatedImages='"${RELATED_IMAGES}" "${TEMP_BUNDLE_FILE}"
 
-echo BUNDLE_IMAGE_ORIGIN=${BUNDLE_IMAGE_ORIGIN}
-${OPM} render ${BUNDLE_IMAGE_ORIGIN} --output=yaml >"${TEMP_BUNDLE_FILE}"
+  cat ${TEMP_BUNDLE_FILE} >>"${CATALOG_FILE}"
 
-BUNDLE_VERSION=$(yq '.properties[]| select(.type=="olm.package")| select(.value.packageName=="lightspeed-operator") |.value.version' ${TEMP_BUNDLE_FILE})
-echo "Bundle version is ${BUNDLE_VERSION}"
+done
+echo "Bundle versions are ${BUNDLE_VERSIONS[@]}"
 
-# restore bundle image to the catalog file
-${YQ} eval -i '.image='"\"${BUNDLE_IMAGE}\"" "${TEMP_BUNDLE_FILE}"
-# restore bundle related images and the bundle itself to the catalog file
-${YQ} eval -i '.relatedImages='"${RELATED_IMAGES}" "${TEMP_BUNDLE_FILE}"
-
-#Initialize catalog file from hack/operator.yaml
-cat ${CATALOG_INITIAL_FILE} >"${CATALOG_FILE}"
-
-cat ${TEMP_BUNDLE_FILE} >>"${CATALOG_FILE}"
-
-cat <<EOF >>"${CATALOG_FILE}"
+echo "Channel names are ${CHANNEL_NAMES}"
+for CHANNEL_NAME in $(echo ${CHANNEL_NAMES} | tr "," "\n"); do
+  echo "Add channel ${CHANNEL_NAME} in catalog ${CATALOG_FILE}"
+  cat <<EOF >>"${CATALOG_FILE}"
 ---
 schema: olm.channel
 package: lightspeed-operator
-name: preview
+name: ${CHANNEL_NAME}
 entries:
+EOF
+  PREV_VERSION=""
+  for BUNDLE_VERSION in ${BUNDLE_VERSIONS[@]}; do
+    cat <<EOF >>"${CATALOG_FILE}"
   - name: lightspeed-operator.v${BUNDLE_VERSION}
+EOF
+    if [ -z "${PREV_VERSION}" ]; then
+      cat <<EOF >>"${CATALOG_FILE}"
     skipRange: ">=0.1.0 <${BUNDLE_VERSION}"
 EOF
+    else
+      cat <<EOF >>"${CATALOG_FILE}"
+    replaces: lightspeed-operator.v${PREV_VERSION}
+EOF
+    fi
+    PREV_VERSION=${BUNDLE_VERSION}
+  done
+
+done
 
 ${OPM} validate "$(dirname "${CATALOG_FILE}")"
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
## Description

The script snapshot_to_catalog.sh produce 2 channels `alpha` and `preview` into the catalog.
The channel `preview` has the latest version and skips all older versions.
The channel `alpha` has all versions provided to the script, one replacing the closest older one.
Here is a catalog generated from command `./hack/snapshot_to_catalog.sh -s ols-cq8sl,ols-mdc8x`
More detail see [this PR](https://github.com/openshift/lightspeed-operator/pull/379)
```yaml
---
defaultChannel: preview
icon:
  base64data: ...
name: lightspeed-operator
schema: olm.package
---
image: registry.redhat.io/openshift-lightspeed-beta/lightspeed-operator-bundle@sha256:fd3849cb65fee7586b261c8c67336d1d0e5d98e89ae10f87f7ca7945d585b0ff
name: lightspeed-operator.v0.1.3
package: lightspeed-operator
properties:
  - type: olm.gvk
    value:
      group: ols.openshift.io
      kind: OLSConfig
      version: v1alpha1
  - type: olm.package
    value:
      packageName: lightspeed-operator
      version: 0.1.3
  - type: olm.bundle.object
    value:
      data:  ...
relatedImages:
  - name: lightspeed-service-api
    image: registry.redhat.io/openshift-lightspeed-beta/lightspeed-service-api-rhel9@sha256:9f4b71d0bfd0cdda5f872adf38a792eb7a0f0cba9097496cb1843b05f6f3e890
  - name: lightspeed-console-plugin
    image: registry.redhat.io/openshift-lightspeed-beta/lightspeed-console-plugin-rhel9@sha256:ebe5b5bbe3af1d6089667a001686ad152084a684f021abc52ec2884b7bae790b
  - name: lightspeed-operator
    image: registry.redhat.io/openshift-lightspeed-beta/lightspeed-rhel9-operator@sha256:af95acfcb1e685a8023cad68707e60cb81de2e117ce0d438e6481dbee3b60841
  - name: lightspeed-operator-bundle
    image: registry.redhat.io/openshift-lightspeed-beta/lightspeed-operator-bundle@sha256:fd3849cb65fee7586b261c8c67336d1d0e5d98e89ae10f87f7ca7945d585b0ff
schema: olm.bundle
---
image: registry.redhat.io/openshift-lightspeed-beta/lightspeed-operator-bundle@sha256:f467fbe0cb7dcf39a8caf8218b96e8e31f7077a256aaf95df6d4143cb3f49139
name: lightspeed-operator.v0.1.4
package: lightspeed-operator
properties:
  - type: olm.gvk
    value:
      group: ols.openshift.io
      kind: OLSConfig
      version: v1alpha1
  - type: olm.package
    value:
      packageName: lightspeed-operator
      version: 0.1.4
  - type: olm.bundle.object
    value:
      data: ...
relatedImages:
  - name: lightspeed-service-api
    image: registry.redhat.io/openshift-lightspeed-beta/lightspeed-service-api-rhel9@sha256:aef85c0c8fa86f7d669a54e82b2cb01cbb3f08959c78ac389f95024aae8f5b96
  - name: lightspeed-console-plugin
    image: registry.redhat.io/openshift-lightspeed-beta/lightspeed-console-plugin-rhel9@sha256:7fb081a73bc72f135f7b3fc42306372308e1c73e51149aede4bd63e7d76444f6
  - name: lightspeed-operator
    image: registry.redhat.io/openshift-lightspeed-beta/lightspeed-rhel9-operator@sha256:5bdb7a15cd2f2700841b0959da0c90134551d4fc34abdcd912746d3fbc5d77e4
  - name: lightspeed-operator-bundle
    image: registry.redhat.io/openshift-lightspeed-beta/lightspeed-operator-bundle@sha256:f467fbe0cb7dcf39a8caf8218b96e8e31f7077a256aaf95df6d4143cb3f49139
schema: olm.bundle
---
schema: olm.channel
package: lightspeed-operator
name: preview
entries:
  - name: lightspeed-operator.v0.1.4
    skipRange: ">=0.1.0 <0.1.4"
---
schema: olm.channel
package: lightspeed-operator
name: alpha
entries:
  - name: lightspeed-operator.v0.1.3
    skipRange: ">=0.1.0 <0.1.3"
  - name: lightspeed-operator.v0.1.4
    replaces: lightspeed-operator.v0.1.3

```

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # [OLS-886](https://issues.redhat.com//browse/OLS-886)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

