### PR TITLE
OLS-881  CRD status points out missing secrets for LLM provider and service TLS certs

### DIFF
--- a/internal/controller/errors.go
+++ b/internal/controller/errors.go
@@ -36,6 +36,8 @@ const (
 	ErrGetConsolePluginConfigMap       = "failed to get Console Plugin configmap"
 	ErrGetConsolePluginDeployment      = "failed to get Console Plugin deployment"
 	ErrGetConsolePluginService         = "failed to get Console Plugin service"
+	ErrGetLLMSecret                    = "failed to get LLM provider secret" // #nosec G101
+	ErrGetTLSSecret                    = "failed to get TLS secret"          // #nosec G101
 	ErrGetSARClusterRole               = "failed to get SAR cluster role"
 	ErrGetSARClusterRoleBinding        = "failed to get SAR cluster role binding"
 	ErrGetServiceMonitor               = "failed to get ServiceMonitor"

--- a/internal/controller/helpers_test.go
+++ b/internal/controller/helpers_test.go
@@ -1,0 +1,19 @@
+package controller
+
+import (
+	olsv1alpha1 "github.com/openshift/lightspeed-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func statusHasCondition(status olsv1alpha1.OLSConfigStatus, condition metav1.Condition) bool {
+	// ignore ObservedGeneration and LastTransitionTime
+	for _, c := range status.Conditions {
+		if c.Type == condition.Type &&
+			c.Status == condition.Status &&
+			c.Reason == condition.Reason &&
+			c.Message == condition.Message {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/controller/ols_app_server_reconciliator.go
+++ b/internal/controller/ols_app_server_reconciliator.go
@@ -277,6 +277,7 @@ func (r *OLSConfigReconciler) reconcileLLMSecrets(ctx context.Context, cr *olsv1
 		foundSecret := &corev1.Secret{}
 		secretValues, err := getAllSecretContent(r.Client, provider.CredentialsSecretRef.Name, r.Options.Namespace, foundSecret)
 		if err != nil {
+			r.updateStatusCondition(ctx, cr, typeApiReady, false, ErrGetLLMSecret, err)
 			return fmt.Errorf("Secret token not found for provider: %s. error: %w", provider.Name, err)
 		}
 		for key, value := range secretValues {
@@ -376,7 +377,8 @@ func (r *OLSConfigReconciler) reconcileTLSSecret(ctx context.Context, cr *olsv1a
 		return true, nil
 	})
 	if err != nil {
-		return fmt.Errorf("failed to get TLS key and cert - wait err %w; last error: %w", err, lastErr)
+		r.updateStatusCondition(ctx, cr, typeApiReady, false, fmt.Sprintf("%s - %s", ErrGetTLSSecret, OLSCertsSecretName), err)
+		return fmt.Errorf("%s -%s - wait err %w; last error: %w", ErrGetTLSSecret, OLSCertsSecretName, err, lastErr)
 	}
 
 	annotateSecretWatcher(foundSecret)


### PR DESCRIPTION
## Description

Missing secrets will be pointed out in the status condition "ApiReady" with mentioning the name of secret. 
So that the user can quickly find out the cause.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # 
- Closes # [OLS-881](https://issues.redhat.com//browse/OLS-881)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
