### PR TITLE
OLS-584: e2e-test - user without RBAC roles are barred off

### DIFF
--- a/test/e2e/http_client.go
+++ b/test/e2e/http_client.go
@@ -135,3 +135,25 @@ func (c *HTTPSClient) waitForHTTPSGetStatus(queryUrl string, statusCode int, hea
 
 	return nil
 }
+
+func (c *HTTPSClient) waitForHTTPSPostStatus(queryUrl string, body []byte, statusCode int, headers ...map[string]string) error { // nolint:unused
+	var lastErr error
+	err := wait.PollUntilContextTimeout(c.ctx, DefaultPollInterval, DefaultPollTimeout, true, func(ctx context.Context) (bool, error) {
+		var resp *http.Response
+		resp, lastErr = c.PostJson(queryUrl, body, headers...)
+		if lastErr != nil {
+			return false, nil
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != statusCode {
+			lastErr = fmt.Errorf("unexpected status code %d", resp.StatusCode)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to wait for HTTPS response status: %w, lastErr: %w", err, lastErr)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Description

Add a test cases that users without the required RBAC roles cannot access the respective OLS API endpoints.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes # [OLS-584](https://issues.redhat.com//browse/OLS-584)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
