### PR TITLE
OLS-1073: add the supported versions in bundle to 4.15-4.17

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -11,9 +11,6 @@ LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.33.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 
-# OCP compatibility labels
-LABEL com.redhat.openshift.versions=v4.15-v4.16
-
 # Labels for testing.
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
@@ -40,6 +37,9 @@ LABEL url="https://github.com/openshift/lightspeed-operator"
 LABEL vendor="Red Hat, Inc."
 LABEL version=0.1.6
 LABEL summary="Red Hat OpenShift Lightspeed"
+
+# OCP compatibility labels
+LABEL com.redhat.openshift.versions=v4.15-v4.17
 
 # Set user to non-root for security reasons.
 USER 1001

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -9,10 +9,8 @@ annotations:
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.33.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
-
-  # OCP compatibility annotations
-  com.redhat.openshift.versions: v4.15-v4.16
-
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
+  # OCP compatibility labels
+  com.redhat.openshift.versions: v4.15-v4.17


### PR DESCRIPTION
## Description

The compatiblitiy labels set to `v4.15-v4.17` in bundle.
The tool script `hack/update_bundle_catalog.sh` is updated accordingly, too.

After merging this PR, we go to merge the PR in openshift/release:https://github.com/openshift/release/pull/57108

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # [OLS-1073](https://issues.redhat.com//browse/OLS-1073)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
