### PR TITLE
OLS-1009 bugfix: add label `openshift.io/user-monitoring: false` to ServiceMonitors

### DIFF
--- a/bundle/manifests/lightspeed-operator-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/bundle/manifests/lightspeed-operator-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/name: servicemonitor
     app.kubernetes.io/part-of: lightspeed-operator
     control-plane: controller-manager
+    openshift.io/user-monitoring: "false"
   name: lightspeed-operator-controller-manager-metrics-monitor
 spec:
   endpoints:

--- a/config/prometheus/monitor-operator.yaml
+++ b/config/prometheus/monitor-operator.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/created-by: lightspeed-operator
     app.kubernetes.io/part-of: lightspeed-operator
     app.kubernetes.io/managed-by: kustomize
+    openshift.io/user-monitoring: "false"
   name: controller-manager-metrics-monitor
   namespace: system
 spec:

--- a/internal/controller/ols_app_server_assets.go
+++ b/internal/controller/ols_app_server_assets.go
@@ -352,6 +352,7 @@ func (r *OLSConfigReconciler) generateServiceMonitor(cr *olsv1alpha1.OLSConfig) 
 	metaLabels := generateAppServerSelectorLabels()
 	metaLabels["monitoring.openshift.io/collection-profile"] = "full"
 	metaLabels["app.kubernetes.io/component"] = "metrics"
+	metaLabels["openshift.io/user-monitoring"] = "false"
 
 	serviceMonitor := monv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/ols_app_server_assets_test.go
+++ b/internal/controller/ols_app_server_assets_test.go
@@ -832,6 +832,7 @@ user_data_collector_config: {}
 				},
 			))
 			Expect(serviceMonitor.Spec.Selector.MatchLabels).To(Equal(generateAppServerSelectorLabels()))
+			Expect(serviceMonitor.ObjectMeta.Labels).To(HaveKeyWithValue("openshift.io/user-monitoring", "false"))
 		})
 
 		It("should generate the OLS prometheus rules", func() {


### PR DESCRIPTION
## Description

Fix the bug that PrometheusOperatorRejectedResources alert is trigger if the namespace openshift-lightspeed does not have the label `openshift.io/cluster-monitoring: true` . 

We add the label `openshift.io/user-monitoring: false` to ServiceMonitor so that the prometheus operator of User Workload Monitoring stack will not process these ServiceMonitors.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # [OLS-1009](https://issues.redhat.com//browse/OLS-1009)
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
