### PR TITLE
e2e test: add wait in console resore tests, reduce false failure

### DIFF
--- a/test/e2e/autocorrection_test.go
+++ b/test/e2e/autocorrection_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Automatic correction against modifications on managed resource
 		Expect(err).NotTo(HaveOccurred())
 
 		By("restoring console plugin deployment")
-		err = client.Get(deployment)
+		err = client.WaitForObjectCreated(deployment)
 		Expect(err).NotTo(HaveOccurred())
 		originDeployment := deployment.DeepCopy()
 		deployment.Spec.Replicas = Ptr(1 + *deployment.Spec.Replicas)


### PR DESCRIPTION
## Description

This fix will eliminate this kind of false failure that the console deployment is not created in time: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_lightspeed-operator/453/pull-ci-openshift-lightspeed-operator-main-bundle-e2e-4-17/1841826432234295296

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
