### PR TITLE
OLS-1161: konflux: renovate bot does not update image references in catalogs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+    "ignorePaths": [
+        "lightspeed-catalog**/**"
+    ]
+}


### PR DESCRIPTION
## Description

Renovate bot does not update image references in catalogs. Because these updates are not consistent with the bundle content and we need to control catalog updates for each release. We do not want Renovate bot interfere with our releasing procedure.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # [OLS-1161](https://issues.redhat.com//browse/OLS-1161)
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
