### PR TITLE
config: base image switch back to ubi9 minimal, FIPS compliant version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ USER 0
 RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -tags strictfipsruntime -o manager cmd/main.go
 
 
-FROM registry.redhat.io/rhel9-4-els/rhel-minimal@sha256:34ab194b05e765bbbaec550f6158ab907d864fecbb39af04b1e3501d858a5544
+FROM registry.redhat.io/ubi9/ubi-minimal@sha256:8b6978d555746877c73f52375f60fd7b6fd27d6aca000eaed27d0995303c13de
 
 WORKDIR /
 COPY --from=builder /workspace/manager .

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/rhel9-4-els/rhel-minimal@sha256:34ab194b05e765bbbaec550f6158ab907d864fecbb39af04b1e3501d858a5544
+FROM registry.redhat.io/ubi9/ubi-minimal@sha256:8b6978d555746877c73f52375f60fd7b6fd27d6aca000eaed27d0995303c13de
 
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1


### PR DESCRIPTION
## Description

Switch back to UBI9 image as base image. The new UBI9 images are already FIPS-140-3 compliant.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # [OLS-1244](https://issues.redhat.com/browse/OLS-1244)  [OLS-1181](https://issues.redhat.com/browse/OLS-1181)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
