### PR TITLE
config: enable hermetic build for FBC + pin task "task-validate-fbc"

### DIFF
--- a/.tekton/fbc-v4-15-pull-request.yaml
+++ b/.tekton/fbc-v4-15-pull-request.yaml
@@ -36,6 +36,8 @@ spec:
     value: lightspeed-catalog-4.15.Dockerfile
   - name: build-source-image
     value: "true"
+  - name: hermetic
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -495,7 +497,7 @@ spec:
         - name: name
           value: validate-fbc
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-validate-fbc:0.1
+          value: quay.io/konflux-ci/tekton-catalog/task-validate-fbc:0.1@sha256:4348a28a109daeab3af9515120e6332eb3c2af2020b96a54afc2365b6c7703ed
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/fbc-v4-15-push.yaml
+++ b/.tekton/fbc-v4-15-push.yaml
@@ -33,6 +33,8 @@ spec:
     value: lightspeed-catalog-4.15.Dockerfile
   - name: build-source-image
     value: "true"
+  - name: hermetic
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -492,7 +494,7 @@ spec:
         - name: name
           value: validate-fbc
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-validate-fbc:0.1
+          value: quay.io/konflux-ci/tekton-catalog/task-validate-fbc:0.1@sha256:4348a28a109daeab3af9515120e6332eb3c2af2020b96a54afc2365b6c7703ed
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/fbc-v4-16-pull-request.yaml
+++ b/.tekton/fbc-v4-16-pull-request.yaml
@@ -36,6 +36,8 @@ spec:
     value: lightspeed-catalog-4.16.Dockerfile
   - name: build-source-image
     value: "true"
+  - name: hermetic
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -495,7 +497,7 @@ spec:
         - name: name
           value: validate-fbc
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-validate-fbc:0.1
+          value: quay.io/konflux-ci/tekton-catalog/task-validate-fbc:0.1@sha256:4348a28a109daeab3af9515120e6332eb3c2af2020b96a54afc2365b6c7703ed
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/fbc-v4-16-push.yaml
+++ b/.tekton/fbc-v4-16-push.yaml
@@ -33,6 +33,8 @@ spec:
     value: lightspeed-catalog-4.16.Dockerfile
   - name: build-source-image
     value: "true"
+  - name: hermetic
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -492,7 +494,7 @@ spec:
         - name: name
           value: validate-fbc
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-validate-fbc:0.1
+          value: quay.io/konflux-ci/tekton-catalog/task-validate-fbc:0.1@sha256:4348a28a109daeab3af9515120e6332eb3c2af2020b96a54afc2365b6c7703ed
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/fbc-v4-17-pull-request.yaml
+++ b/.tekton/fbc-v4-17-pull-request.yaml
@@ -36,6 +36,8 @@ spec:
     value: lightspeed-catalog-4.17.Dockerfile
   - name: build-source-image
     value: "true"
+  - name: hermetic
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -495,7 +497,7 @@ spec:
         - name: name
           value: validate-fbc
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-validate-fbc:0.1
+          value: quay.io/konflux-ci/tekton-catalog/task-validate-fbc:0.1@sha256:4348a28a109daeab3af9515120e6332eb3c2af2020b96a54afc2365b6c7703ed
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/fbc-v4-17-push.yaml
+++ b/.tekton/fbc-v4-17-push.yaml
@@ -33,6 +33,8 @@ spec:
     value: lightspeed-catalog-4.17.Dockerfile
   - name: build-source-image
     value: "true"
+  - name: hermetic
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -492,7 +494,7 @@ spec:
         - name: name
           value: validate-fbc
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-validate-fbc:0.1
+          value: quay.io/konflux-ci/tekton-catalog/task-validate-fbc:0.1@sha256:4348a28a109daeab3af9515120e6332eb3c2af2020b96a54afc2365b6c7703ed
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
## Description

Fix the EC violations on FBC components

```text
 [Violation] hermetic_build_task.build_task_hermetic
  ImageRef: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols-fbc-v4-17/fbc-v4-17@sha256:5a97493c08277f1e5374ed87ef4f937734b7feb1045a3ee237c30b06500e8bf0
  Reason: Build task was not invoked with the hermetic parameter set
  Title: Build task called with hermetic param set
  Description: Verify the build task in the PipelineRun attestation was invoked with the proper parameters to make the build
  process hermetic. To exclude this rule add "hermetic_build_task.build_task_hermetic" to the `exclude` section of the policy
  configuration.
  Solution: Make sure the task that builds the image has a parameter named 'HERMETIC' and it's set to 'true'.

✕ [Violation] tasks.pinned_task_refs
  ImageRef: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols-fbc-v4-17/fbc-v4-17@sha256:5a97493c08277f1e5374ed87ef4f937734b7feb1045a3ee237c30b06500e8bf0
  Reason: Task validate-fbc is used by pipeline task validate-fbc via an unpinned reference.
  Title: Pinned Task references
  Description: Ensure that all Tasks in the SLSA Provenance attestation use an immuntable reference to the Task definition. To
  exclude this rule add "tasks.pinned_task_refs:validate-fbc" to the `exclude` section of the policy configuration.
  Solution: Make sure the build pipeline uses Tasks via pinned references. For example, if the git resolver is used, use a commit
  ID instead of a branch name.

✕ [Violation] trusted_task.trusted
  ImageRef: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols-fbc-v4-17/fbc-v4-17@sha256:5a97493c08277f1e5374ed87ef4f937734b7feb1045a3ee237c30b06500e8bf0
  Reason: Code tampering detected, untrusted PipelineTask "validate-fbc" (Task "validate-fbc") was included in build chain
  comprised of: validate-fbc
  Title: Tasks are trusted
  Description: Check the trust of the Tekton Tasks used in the build Pipeline. There are two modes in which trust is verified. The
  first mode is used if Trusted Artifacts are enabled. In this case, a chain of trust is established for all the Tasks involved in
  creating an artifact. If the chain contains an untrusted Task, then a violation is emitted. The second mode is used as a
  fallback when Trusted Artifacts are not enabled. In this case, **all** Tasks in the build Pipeline must be trusted. To exclude
  this rule add "trusted_task.trusted:validate-fbc" to the `exclude` section of the policy configuration.
  Solution: If using Trusted Artifacts, be sure every Task in the build Pipeline responsible for producing a Trusted Artifact is
  trusted. Otherwise, ensure **all** Tasks in the build Pipeline are trusted. Note that trust is eventually revoked from Tasks
  when newer versions are made available.
```

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
