### PR TITLE
config: fix ignorePaths in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,8 @@
 {
     "ignorePaths": [
-        "lightspeed-catalog**/**"
+        "lightspeed-catalog-4.15/**",
+        "lightspeed-catalog-4.16/**",
+        "lightspeed-catalog-4.17/**",
+        "lightspeed-catalog-4.18/**"
     ]
 }


### PR DESCRIPTION
## Description

fix the ignorePaths in renovate bot configuration. 

Renovate was still trying to update the catalog indexes after the intial renovate config is in place, for example: 
https://github.com/openshift/lightspeed-operator/pull/550

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
