### PR TITLE
OLS-1270: add FIPS-compliant annotation in bundle

### DIFF
--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
       ]
     capabilities: Basic Install
     console.openshift.io/operator-monitoring-default: "true"
-    createdAt: "2024-10-24T09:33:47Z"
+    createdAt: "2025-01-03T12:57:27Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -266,6 +266,15 @@ spec:
       clusterPermissions:
         - rules:
             - apiGroups:
+                - ""
+              resources:
+                - configmaps
+                - secrets
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
                 - authentication.k8s.io
               resources:
                 - tokenreviews
@@ -298,22 +307,6 @@ spec:
                 - delete
                 - get
                 - update
-            - apiGroups:
-                - ""
-              resources:
-                - configmaps
-              verbs:
-                - get
-                - list
-                - watch
-            - apiGroups:
-                - ""
-              resources:
-                - secrets
-              verbs:
-                - get
-                - list
-                - watch
             - apiGroups:
                 - ols.openshift.io
               resources:
@@ -473,6 +466,21 @@ spec:
                 - create
                 - patch
             - apiGroups:
+                - ""
+              resources:
+                - configmaps
+                - secrets
+                - serviceaccounts
+                - services
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
                 - apps
               resources:
                 - deployments
@@ -485,68 +493,9 @@ spec:
                 - update
                 - watch
             - apiGroups:
-                - ""
-              resources:
-                - configmaps
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - ""
-              resources:
-                - secrets
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - ""
-              resources:
-                - serviceaccounts
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - ""
-              resources:
-                - services
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
                 - monitoring.coreos.com
               resources:
                 - prometheusrules
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - monitoring.coreos.com
-              resources:
                 - servicemonitors
               verbs:
                 - create

--- a/bundle/manifests/ols.openshift.io_olsconfigs.yaml
+++ b/bundle/manifests/ols.openshift.io_olsconfigs.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   creationTimestamp: null
   name: olsconfigs.ols.openshift.io
 spec:
@@ -56,10 +56,13 @@ spec:
                             provider credentials
                           properties:
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -111,21 +114,15 @@ spec:
                                 profile as invalid configurations can be catastrophic. An example custom profile
                                 looks like this:
 
-
                                   ciphers:
-
 
                                     - ECDHE-ECDSA-CHACHA20-POLY1305
 
-
                                     - ECDHE-RSA-CHACHA20-POLY1305
-
 
                                     - ECDHE-RSA-AES128-GCM-SHA256
 
-
                                     - ECDHE-ECDSA-AES128-GCM-SHA256
-
 
                                   minTLSVersion: VersionTLS11
                               nullable: true
@@ -135,7 +132,6 @@ spec:
                                     ciphers is used to specify the cipher algorithms that are negotiated
                                     during the TLS handshake.  Operators may remove entries their operands
                                     do not support.  For example, to use DES-CBC3-SHA  (yaml):
-
 
                                       ciphers:
                                         - DES-CBC3-SHA
@@ -148,9 +144,7 @@ spec:
                                     that is negotiated during the TLS handshake. For example, to use TLS
                                     versions 1.1, 1.2 and 1.3 (yaml):
 
-
                                       minTLSVersion: VersionTLS11
-
 
                                     NOTE: currently the highest minTLSVersion allowed is VersionTLS12
                                   enum:
@@ -164,48 +158,33 @@ spec:
                               description: |-
                                 intermediate is a TLS security profile based on:
 
-
                                 https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
-
 
                                 and looks like this (yaml):
 
-
                                   ciphers:
-
 
                                     - TLS_AES_128_GCM_SHA256
 
-
                                     - TLS_AES_256_GCM_SHA384
-
 
                                     - TLS_CHACHA20_POLY1305_SHA256
 
-
                                     - ECDHE-ECDSA-AES128-GCM-SHA256
-
 
                                     - ECDHE-RSA-AES128-GCM-SHA256
 
-
                                     - ECDHE-ECDSA-AES256-GCM-SHA384
-
 
                                     - ECDHE-RSA-AES256-GCM-SHA384
 
-
                                     - ECDHE-ECDSA-CHACHA20-POLY1305
-
 
                                     - ECDHE-RSA-CHACHA20-POLY1305
 
-
                                     - DHE-RSA-AES128-GCM-SHA256
 
-
                                     - DHE-RSA-AES256-GCM-SHA384
-
 
                                   minTLSVersion: VersionTLS12
                               nullable: true
@@ -214,24 +193,17 @@ spec:
                               description: |-
                                 modern is a TLS security profile based on:
 
-
                                 https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
-
 
                                 and looks like this (yaml):
 
-
                                   ciphers:
-
 
                                     - TLS_AES_128_GCM_SHA256
 
-
                                     - TLS_AES_256_GCM_SHA384
 
-
                                     - TLS_CHACHA20_POLY1305_SHA256
-
 
                                   minTLSVersion: VersionTLS13
                               nullable: true
@@ -240,102 +212,69 @@ spec:
                               description: |-
                                 old is a TLS security profile based on:
 
-
                                 https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility
-
 
                                 and looks like this (yaml):
 
-
                                   ciphers:
-
 
                                     - TLS_AES_128_GCM_SHA256
 
-
                                     - TLS_AES_256_GCM_SHA384
-
 
                                     - TLS_CHACHA20_POLY1305_SHA256
 
-
                                     - ECDHE-ECDSA-AES128-GCM-SHA256
-
 
                                     - ECDHE-RSA-AES128-GCM-SHA256
 
-
                                     - ECDHE-ECDSA-AES256-GCM-SHA384
-
 
                                     - ECDHE-RSA-AES256-GCM-SHA384
 
-
                                     - ECDHE-ECDSA-CHACHA20-POLY1305
-
 
                                     - ECDHE-RSA-CHACHA20-POLY1305
 
-
                                     - DHE-RSA-AES128-GCM-SHA256
-
 
                                     - DHE-RSA-AES256-GCM-SHA384
 
-
                                     - DHE-RSA-CHACHA20-POLY1305
-
 
                                     - ECDHE-ECDSA-AES128-SHA256
 
-
                                     - ECDHE-RSA-AES128-SHA256
-
 
                                     - ECDHE-ECDSA-AES128-SHA
 
-
                                     - ECDHE-RSA-AES128-SHA
-
 
                                     - ECDHE-ECDSA-AES256-SHA384
 
-
                                     - ECDHE-RSA-AES256-SHA384
-
 
                                     - ECDHE-ECDSA-AES256-SHA
 
-
                                     - ECDHE-RSA-AES256-SHA
-
 
                                     - DHE-RSA-AES128-SHA256
 
-
                                     - DHE-RSA-AES256-SHA256
-
 
                                     - AES128-GCM-SHA256
 
-
                                     - AES256-GCM-SHA384
-
 
                                     - AES128-SHA256
 
-
                                     - AES256-SHA256
-
 
                                     - AES128-SHA
 
-
                                     - AES256-SHA
 
-
                                     - DES-CBC3-SHA
-
 
                                   minTLSVersion: VersionTLS10
                               nullable: true
@@ -346,14 +285,11 @@ spec:
                                 the ability to specify individual TLS security profile parameters.
                                 Old, Intermediate and Modern are TLS security profiles based on:
 
-
                                 https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations
-
 
                                 The profiles are intent based, so they may change over time as new ciphers are developed and existing ciphers
                                 are found to be insecure.  Depending on precisely which ciphers are available to a process, the list may be
                                 reduced.
-
 
                                 Note that the Modern profile is currently not supported because it is not
                                 yet well adopted by common software libraries.
@@ -380,6 +316,9 @@ spec:
                           pattern: ^https?://.*$
                           type: string
                       required:
+                      - credentialsSecretRef
+                      - models
+                      - name
                       - type
                       type: object
                       x-kubernetes-validations:
@@ -402,10 +341,13 @@ spec:
                       between OLS service and LLM Provider
                     properties:
                       name:
+                        default: ""
                         description: |-
                           Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
@@ -463,10 +405,8 @@ spec:
                                   Claims lists the names of resources, defined in spec.resourceClaims,
                                   that are used by this container.
 
-
                                   This is an alpha field and requires enabling the
                                   DynamicResourceAllocation feature gate.
-
 
                                   This field is immutable. It can only be set for containers.
                                 items:
@@ -478,6 +418,12 @@ spec:
                                         Name must match the name of one entry in pod.spec.resourceClaims of
                                         the Pod where this field is used. It makes that resource available
                                         inside a container.
+                                      type: string
+                                    request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
                                       type: string
                                   required:
                                   - name
@@ -579,10 +525,8 @@ spec:
                                   Claims lists the names of resources, defined in spec.resourceClaims,
                                   that are used by this container.
 
-
                                   This is an alpha field and requires enabling the
                                   DynamicResourceAllocation feature gate.
-
 
                                   This field is immutable. It can only be set for containers.
                                 items:
@@ -594,6 +538,12 @@ spec:
                                         Name must match the name of one entry in pod.spec.resourceClaims of
                                         the Pod where this field is used. It makes that resource available
                                         inside a container.
+                                      type: string
+                                    request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
                                       type: string
                                   required:
                                   - name
@@ -678,10 +628,8 @@ spec:
                                   Claims lists the names of resources, defined in spec.resourceClaims,
                                   that are used by this container.
 
-
                                   This is an alpha field and requires enabling the
                                   DynamicResourceAllocation feature gate.
-
 
                                   This field is immutable. It can only be set for containers.
                                 items:
@@ -693,6 +641,12 @@ spec:
                                         Name must match the name of one entry in pod.spec.resourceClaims of
                                         the Pod where this field is used. It makes that resource available
                                         inside a container.
+                                      type: string
+                                    request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
                                       type: string
                                   required:
                                   - name
@@ -772,10 +726,13 @@ spec:
                           key.
                         properties:
                           name:
+                            default: ""
                             description: |-
                               Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
@@ -789,21 +746,15 @@ spec:
                           profile as invalid configurations can be catastrophic. An example custom profile
                           looks like this:
 
-
                             ciphers:
-
 
                               - ECDHE-ECDSA-CHACHA20-POLY1305
 
-
                               - ECDHE-RSA-CHACHA20-POLY1305
-
 
                               - ECDHE-RSA-AES128-GCM-SHA256
 
-
                               - ECDHE-ECDSA-AES128-GCM-SHA256
-
 
                             minTLSVersion: VersionTLS11
                         nullable: true
@@ -813,7 +764,6 @@ spec:
                               ciphers is used to specify the cipher algorithms that are negotiated
                               during the TLS handshake.  Operators may remove entries their operands
                               do not support.  For example, to use DES-CBC3-SHA  (yaml):
-
 
                                 ciphers:
                                   - DES-CBC3-SHA
@@ -826,9 +776,7 @@ spec:
                               that is negotiated during the TLS handshake. For example, to use TLS
                               versions 1.1, 1.2 and 1.3 (yaml):
 
-
                                 minTLSVersion: VersionTLS11
-
 
                               NOTE: currently the highest minTLSVersion allowed is VersionTLS12
                             enum:
@@ -842,48 +790,33 @@ spec:
                         description: |-
                           intermediate is a TLS security profile based on:
 
-
                           https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
-
 
                           and looks like this (yaml):
 
-
                             ciphers:
-
 
                               - TLS_AES_128_GCM_SHA256
 
-
                               - TLS_AES_256_GCM_SHA384
-
 
                               - TLS_CHACHA20_POLY1305_SHA256
 
-
                               - ECDHE-ECDSA-AES128-GCM-SHA256
-
 
                               - ECDHE-RSA-AES128-GCM-SHA256
 
-
                               - ECDHE-ECDSA-AES256-GCM-SHA384
-
 
                               - ECDHE-RSA-AES256-GCM-SHA384
 
-
                               - ECDHE-ECDSA-CHACHA20-POLY1305
-
 
                               - ECDHE-RSA-CHACHA20-POLY1305
 
-
                               - DHE-RSA-AES128-GCM-SHA256
 
-
                               - DHE-RSA-AES256-GCM-SHA384
-
 
                             minTLSVersion: VersionTLS12
                         nullable: true
@@ -892,24 +825,17 @@ spec:
                         description: |-
                           modern is a TLS security profile based on:
 
-
                           https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
-
 
                           and looks like this (yaml):
 
-
                             ciphers:
-
 
                               - TLS_AES_128_GCM_SHA256
 
-
                               - TLS_AES_256_GCM_SHA384
 
-
                               - TLS_CHACHA20_POLY1305_SHA256
-
 
                             minTLSVersion: VersionTLS13
                         nullable: true
@@ -918,102 +844,69 @@ spec:
                         description: |-
                           old is a TLS security profile based on:
 
-
                           https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility
-
 
                           and looks like this (yaml):
 
-
                             ciphers:
-
 
                               - TLS_AES_128_GCM_SHA256
 
-
                               - TLS_AES_256_GCM_SHA384
-
 
                               - TLS_CHACHA20_POLY1305_SHA256
 
-
                               - ECDHE-ECDSA-AES128-GCM-SHA256
-
 
                               - ECDHE-RSA-AES128-GCM-SHA256
 
-
                               - ECDHE-ECDSA-AES256-GCM-SHA384
-
 
                               - ECDHE-RSA-AES256-GCM-SHA384
 
-
                               - ECDHE-ECDSA-CHACHA20-POLY1305
-
 
                               - ECDHE-RSA-CHACHA20-POLY1305
 
-
                               - DHE-RSA-AES128-GCM-SHA256
-
 
                               - DHE-RSA-AES256-GCM-SHA384
 
-
                               - DHE-RSA-CHACHA20-POLY1305
-
 
                               - ECDHE-ECDSA-AES128-SHA256
 
-
                               - ECDHE-RSA-AES128-SHA256
-
 
                               - ECDHE-ECDSA-AES128-SHA
 
-
                               - ECDHE-RSA-AES128-SHA
-
 
                               - ECDHE-ECDSA-AES256-SHA384
 
-
                               - ECDHE-RSA-AES256-SHA384
-
 
                               - ECDHE-ECDSA-AES256-SHA
 
-
                               - ECDHE-RSA-AES256-SHA
-
 
                               - DHE-RSA-AES128-SHA256
 
-
                               - DHE-RSA-AES256-SHA256
-
 
                               - AES128-GCM-SHA256
 
-
                               - AES256-GCM-SHA384
-
 
                               - AES128-SHA256
 
-
                               - AES256-SHA256
-
 
                               - AES128-SHA
 
-
                               - AES256-SHA
 
-
                               - DES-CBC3-SHA
-
 
                             minTLSVersion: VersionTLS10
                         nullable: true
@@ -1024,14 +917,11 @@ spec:
                           the ability to specify individual TLS security profile parameters.
                           Old, Intermediate and Modern are TLS security profiles based on:
 
-
                           https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations
-
 
                           The profiles are intent based, so they may change over time as new ciphers are developed and existing ciphers
                           are found to be insecure.  Depending on precisely which ciphers are available to a process, the list may be
                           reduced.
-
 
                           Note that the Modern profile is currently not supported because it is not
                           yet well adopted by common software libraries.
@@ -1078,16 +968,8 @@ spec:
             properties:
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -1128,12 +1010,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -14,3 +14,4 @@ annotations:
   operators.operatorframework.io.test.config.v1: tests/scorecard/
   # OCP compatibility labels
   com.redhat.openshift.versions: v4.15-v4.17
+  features.operators.openshift.io/fips-compliant: "true"

--- a/config/crd/bases/ols.openshift.io_olsconfigs.yaml
+++ b/config/crd/bases/ols.openshift.io_olsconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: olsconfigs.ols.openshift.io
 spec:
   group: ols.openshift.io
@@ -56,10 +56,13 @@ spec:
                             provider credentials
                           properties:
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -111,21 +114,15 @@ spec:
                                 profile as invalid configurations can be catastrophic. An example custom profile
                                 looks like this:
 
-
                                   ciphers:
-
 
                                     - ECDHE-ECDSA-CHACHA20-POLY1305
 
-
                                     - ECDHE-RSA-CHACHA20-POLY1305
-
 
                                     - ECDHE-RSA-AES128-GCM-SHA256
 
-
                                     - ECDHE-ECDSA-AES128-GCM-SHA256
-
 
                                   minTLSVersion: VersionTLS11
                               nullable: true
@@ -135,7 +132,6 @@ spec:
                                     ciphers is used to specify the cipher algorithms that are negotiated
                                     during the TLS handshake.  Operators may remove entries their operands
                                     do not support.  For example, to use DES-CBC3-SHA  (yaml):
-
 
                                       ciphers:
                                         - DES-CBC3-SHA
@@ -148,9 +144,7 @@ spec:
                                     that is negotiated during the TLS handshake. For example, to use TLS
                                     versions 1.1, 1.2 and 1.3 (yaml):
 
-
                                       minTLSVersion: VersionTLS11
-
 
                                     NOTE: currently the highest minTLSVersion allowed is VersionTLS12
                                   enum:
@@ -164,48 +158,33 @@ spec:
                               description: |-
                                 intermediate is a TLS security profile based on:
 
-
                                 https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
-
 
                                 and looks like this (yaml):
 
-
                                   ciphers:
-
 
                                     - TLS_AES_128_GCM_SHA256
 
-
                                     - TLS_AES_256_GCM_SHA384
-
 
                                     - TLS_CHACHA20_POLY1305_SHA256
 
-
                                     - ECDHE-ECDSA-AES128-GCM-SHA256
-
 
                                     - ECDHE-RSA-AES128-GCM-SHA256
 
-
                                     - ECDHE-ECDSA-AES256-GCM-SHA384
-
 
                                     - ECDHE-RSA-AES256-GCM-SHA384
 
-
                                     - ECDHE-ECDSA-CHACHA20-POLY1305
-
 
                                     - ECDHE-RSA-CHACHA20-POLY1305
 
-
                                     - DHE-RSA-AES128-GCM-SHA256
 
-
                                     - DHE-RSA-AES256-GCM-SHA384
-
 
                                   minTLSVersion: VersionTLS12
                               nullable: true
@@ -214,24 +193,17 @@ spec:
                               description: |-
                                 modern is a TLS security profile based on:
 
-
                                 https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
-
 
                                 and looks like this (yaml):
 
-
                                   ciphers:
-
 
                                     - TLS_AES_128_GCM_SHA256
 
-
                                     - TLS_AES_256_GCM_SHA384
 
-
                                     - TLS_CHACHA20_POLY1305_SHA256
-
 
                                   minTLSVersion: VersionTLS13
                               nullable: true
@@ -240,102 +212,69 @@ spec:
                               description: |-
                                 old is a TLS security profile based on:
 
-
                                 https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility
-
 
                                 and looks like this (yaml):
 
-
                                   ciphers:
-
 
                                     - TLS_AES_128_GCM_SHA256
 
-
                                     - TLS_AES_256_GCM_SHA384
-
 
                                     - TLS_CHACHA20_POLY1305_SHA256
 
-
                                     - ECDHE-ECDSA-AES128-GCM-SHA256
-
 
                                     - ECDHE-RSA-AES128-GCM-SHA256
 
-
                                     - ECDHE-ECDSA-AES256-GCM-SHA384
-
 
                                     - ECDHE-RSA-AES256-GCM-SHA384
 
-
                                     - ECDHE-ECDSA-CHACHA20-POLY1305
-
 
                                     - ECDHE-RSA-CHACHA20-POLY1305
 
-
                                     - DHE-RSA-AES128-GCM-SHA256
-
 
                                     - DHE-RSA-AES256-GCM-SHA384
 
-
                                     - DHE-RSA-CHACHA20-POLY1305
-
 
                                     - ECDHE-ECDSA-AES128-SHA256
 
-
                                     - ECDHE-RSA-AES128-SHA256
-
 
                                     - ECDHE-ECDSA-AES128-SHA
 
-
                                     - ECDHE-RSA-AES128-SHA
-
 
                                     - ECDHE-ECDSA-AES256-SHA384
 
-
                                     - ECDHE-RSA-AES256-SHA384
-
 
                                     - ECDHE-ECDSA-AES256-SHA
 
-
                                     - ECDHE-RSA-AES256-SHA
-
 
                                     - DHE-RSA-AES128-SHA256
 
-
                                     - DHE-RSA-AES256-SHA256
-
 
                                     - AES128-GCM-SHA256
 
-
                                     - AES256-GCM-SHA384
-
 
                                     - AES128-SHA256
 
-
                                     - AES256-SHA256
-
 
                                     - AES128-SHA
 
-
                                     - AES256-SHA
 
-
                                     - DES-CBC3-SHA
-
 
                                   minTLSVersion: VersionTLS10
                               nullable: true
@@ -346,14 +285,11 @@ spec:
                                 the ability to specify individual TLS security profile parameters.
                                 Old, Intermediate and Modern are TLS security profiles based on:
 
-
                                 https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations
-
 
                                 The profiles are intent based, so they may change over time as new ciphers are developed and existing ciphers
                                 are found to be insecure.  Depending on precisely which ciphers are available to a process, the list may be
                                 reduced.
-
 
                                 Note that the Modern profile is currently not supported because it is not
                                 yet well adopted by common software libraries.
@@ -380,6 +316,9 @@ spec:
                           pattern: ^https?://.*$
                           type: string
                       required:
+                      - credentialsSecretRef
+                      - models
+                      - name
                       - type
                       type: object
                       x-kubernetes-validations:
@@ -402,10 +341,13 @@ spec:
                       between OLS service and LLM Provider
                     properties:
                       name:
+                        default: ""
                         description: |-
                           Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
@@ -463,10 +405,8 @@ spec:
                                   Claims lists the names of resources, defined in spec.resourceClaims,
                                   that are used by this container.
 
-
                                   This is an alpha field and requires enabling the
                                   DynamicResourceAllocation feature gate.
-
 
                                   This field is immutable. It can only be set for containers.
                                 items:
@@ -478,6 +418,12 @@ spec:
                                         Name must match the name of one entry in pod.spec.resourceClaims of
                                         the Pod where this field is used. It makes that resource available
                                         inside a container.
+                                      type: string
+                                    request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
                                       type: string
                                   required:
                                   - name
@@ -579,10 +525,8 @@ spec:
                                   Claims lists the names of resources, defined in spec.resourceClaims,
                                   that are used by this container.
 
-
                                   This is an alpha field and requires enabling the
                                   DynamicResourceAllocation feature gate.
-
 
                                   This field is immutable. It can only be set for containers.
                                 items:
@@ -594,6 +538,12 @@ spec:
                                         Name must match the name of one entry in pod.spec.resourceClaims of
                                         the Pod where this field is used. It makes that resource available
                                         inside a container.
+                                      type: string
+                                    request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
                                       type: string
                                   required:
                                   - name
@@ -678,10 +628,8 @@ spec:
                                   Claims lists the names of resources, defined in spec.resourceClaims,
                                   that are used by this container.
 
-
                                   This is an alpha field and requires enabling the
                                   DynamicResourceAllocation feature gate.
-
 
                                   This field is immutable. It can only be set for containers.
                                 items:
@@ -693,6 +641,12 @@ spec:
                                         Name must match the name of one entry in pod.spec.resourceClaims of
                                         the Pod where this field is used. It makes that resource available
                                         inside a container.
+                                      type: string
+                                    request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
                                       type: string
                                   required:
                                   - name
@@ -772,10 +726,13 @@ spec:
                           key.
                         properties:
                           name:
+                            default: ""
                             description: |-
                               Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
@@ -789,21 +746,15 @@ spec:
                           profile as invalid configurations can be catastrophic. An example custom profile
                           looks like this:
 
-
                             ciphers:
-
 
                               - ECDHE-ECDSA-CHACHA20-POLY1305
 
-
                               - ECDHE-RSA-CHACHA20-POLY1305
-
 
                               - ECDHE-RSA-AES128-GCM-SHA256
 
-
                               - ECDHE-ECDSA-AES128-GCM-SHA256
-
 
                             minTLSVersion: VersionTLS11
                         nullable: true
@@ -813,7 +764,6 @@ spec:
                               ciphers is used to specify the cipher algorithms that are negotiated
                               during the TLS handshake.  Operators may remove entries their operands
                               do not support.  For example, to use DES-CBC3-SHA  (yaml):
-
 
                                 ciphers:
                                   - DES-CBC3-SHA
@@ -826,9 +776,7 @@ spec:
                               that is negotiated during the TLS handshake. For example, to use TLS
                               versions 1.1, 1.2 and 1.3 (yaml):
 
-
                                 minTLSVersion: VersionTLS11
-
 
                               NOTE: currently the highest minTLSVersion allowed is VersionTLS12
                             enum:
@@ -842,48 +790,33 @@ spec:
                         description: |-
                           intermediate is a TLS security profile based on:
 
-
                           https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
-
 
                           and looks like this (yaml):
 
-
                             ciphers:
-
 
                               - TLS_AES_128_GCM_SHA256
 
-
                               - TLS_AES_256_GCM_SHA384
-
 
                               - TLS_CHACHA20_POLY1305_SHA256
 
-
                               - ECDHE-ECDSA-AES128-GCM-SHA256
-
 
                               - ECDHE-RSA-AES128-GCM-SHA256
 
-
                               - ECDHE-ECDSA-AES256-GCM-SHA384
-
 
                               - ECDHE-RSA-AES256-GCM-SHA384
 
-
                               - ECDHE-ECDSA-CHACHA20-POLY1305
-
 
                               - ECDHE-RSA-CHACHA20-POLY1305
 
-
                               - DHE-RSA-AES128-GCM-SHA256
 
-
                               - DHE-RSA-AES256-GCM-SHA384
-
 
                             minTLSVersion: VersionTLS12
                         nullable: true
@@ -892,24 +825,17 @@ spec:
                         description: |-
                           modern is a TLS security profile based on:
 
-
                           https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
-
 
                           and looks like this (yaml):
 
-
                             ciphers:
-
 
                               - TLS_AES_128_GCM_SHA256
 
-
                               - TLS_AES_256_GCM_SHA384
 
-
                               - TLS_CHACHA20_POLY1305_SHA256
-
 
                             minTLSVersion: VersionTLS13
                         nullable: true
@@ -918,102 +844,69 @@ spec:
                         description: |-
                           old is a TLS security profile based on:
 
-
                           https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility
-
 
                           and looks like this (yaml):
 
-
                             ciphers:
-
 
                               - TLS_AES_128_GCM_SHA256
 
-
                               - TLS_AES_256_GCM_SHA384
-
 
                               - TLS_CHACHA20_POLY1305_SHA256
 
-
                               - ECDHE-ECDSA-AES128-GCM-SHA256
-
 
                               - ECDHE-RSA-AES128-GCM-SHA256
 
-
                               - ECDHE-ECDSA-AES256-GCM-SHA384
-
 
                               - ECDHE-RSA-AES256-GCM-SHA384
 
-
                               - ECDHE-ECDSA-CHACHA20-POLY1305
-
 
                               - ECDHE-RSA-CHACHA20-POLY1305
 
-
                               - DHE-RSA-AES128-GCM-SHA256
-
 
                               - DHE-RSA-AES256-GCM-SHA384
 
-
                               - DHE-RSA-CHACHA20-POLY1305
-
 
                               - ECDHE-ECDSA-AES128-SHA256
 
-
                               - ECDHE-RSA-AES128-SHA256
-
 
                               - ECDHE-ECDSA-AES128-SHA
 
-
                               - ECDHE-RSA-AES128-SHA
-
 
                               - ECDHE-ECDSA-AES256-SHA384
 
-
                               - ECDHE-RSA-AES256-SHA384
-
 
                               - ECDHE-ECDSA-AES256-SHA
 
-
                               - ECDHE-RSA-AES256-SHA
-
 
                               - DHE-RSA-AES128-SHA256
 
-
                               - DHE-RSA-AES256-SHA256
-
 
                               - AES128-GCM-SHA256
 
-
                               - AES256-GCM-SHA384
-
 
                               - AES128-SHA256
 
-
                               - AES256-SHA256
-
 
                               - AES128-SHA
 
-
                               - AES256-SHA
 
-
                               - DES-CBC3-SHA
-
 
                             minTLSVersion: VersionTLS10
                         nullable: true
@@ -1024,14 +917,11 @@ spec:
                           the ability to specify individual TLS security profile parameters.
                           Old, Intermediate and Modern are TLS security profiles based on:
 
-
                           https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations
-
 
                           The profiles are intent based, so they may change over time as new ciphers are developed and existing ciphers
                           are found to be insecure.  Depending on precisely which ciphers are available to a process, the list may be
                           reduced.
-
 
                           Note that the Modern profile is currently not supported because it is not
                           yet well adopted by common software libraries.
@@ -1078,16 +968,8 @@ spec:
             properties:
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -1128,12 +1010,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,6 +5,15 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -37,22 +46,6 @@ rules:
   - delete
   - get
   - update
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
 - apiGroups:
   - ols.openshift.io
   resources:
@@ -103,6 +96,21 @@ metadata:
   namespace: openshift-lightspeed
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - apps
   resources:
   - deployments
@@ -115,68 +123,9 @@ rules:
   - update
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - monitoring.coreos.com
   resources:
   - prometheusrules
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
   - servicemonitors
   verbs:
   - create

--- a/hack/update_bundle.sh
+++ b/hack/update_bundle.sh
@@ -160,7 +160,7 @@ ${YQ} eval -i '.spec.relatedImages='"${RELATED_IMAGES}" ${CSV_FILE}
 # add compatibility labels to the annotations file
 ${YQ} eval -i '.annotations."com.redhat.openshift.versions"="v4.15-v4.17"' ${ANNOTATION_FILE}
 ${YQ} eval -i '(.annotations."com.redhat.openshift.versions" | key) head_comment="OCP compatibility labels"' ${ANNOTATION_FILE}
-
+${YQ} eval -i '.annotations."features.operators.openshift.io/fips-compliant"="true"' ${ANNOTATION_FILE}
 # use UBI image as base image for bundle image
 : "${BASE_IMAGE:=registry.redhat.io/ubi9/ubi-minimal:9.5}"
 sed -i 's|^FROM scratch|FROM '"${BASE_IMAGE}"'|' ${BUNDLE_DOCKERFILE}


### PR DESCRIPTION
## Description

add FIPS-compliant annotation in bundle.

This PR is based on https://github.com/openshift/lightspeed-operator/pull/572 that regenerate bundle manifests using controller-tools 0.16. If we merge this PR, we can close the PR #572 

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes # [OLS-1270](https://issues.redhat.com//browse/OLS-1270)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
