### PR TITLE
OLS-1333 test: increase prometheus query timeout to 95s

### DIFF
--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Prometheus Metrics", Ordered, func() {
 
 	It("should have operator metrics in Prometheus", func() {
 		By("verify Prometheus is working correctly by querying prometheus' own metrics")
-		err = prometheusClient.WaitForQueryReturnGreaterEqualOne("topk(1,prometheus_build_info)", DefaultClientTimeout)
+		err = prometheusClient.WaitForQueryReturnGreaterEqualOne("topk(1,prometheus_build_info)", DefaultPrometheusQueryTimeout)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("verify prometheus scrapes metrics from operator, this should happen every 60 seconds")
@@ -105,7 +105,7 @@ var _ = Describe("Prometheus Metrics", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("fetching the operator metrics from Prometheus")
-		err = prometheusClient.WaitForQueryReturnGreaterEqualOne("count(controller_runtime_reconcile_total{namespace=\"openshift-lightspeed\"})", DefaultClientTimeout)
+		err = prometheusClient.WaitForQueryReturnGreaterEqualOne("count(controller_runtime_reconcile_total{namespace=\"openshift-lightspeed\"})", DefaultPrometheusQueryTimeout)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/test/e2e/prometheus_client.go
+++ b/test/e2e/prometheus_client.go
@@ -28,6 +28,10 @@ type PrometheusClient struct {
 	rt http.RoundTripper
 }
 
+// DefaultPollInterval is the default interval for polling Prometheus metrics.
+// Prometheus metrics are typically scraped every 30 seconds. This is enough for 3 scrapes.
+const DefaultPrometheusQueryTimeout = 95 * time.Second
+
 // NewPrometheusClientFromRoute creates and returns a new PrometheusClient from the given OpenShift route.
 func NewPrometheusClientFromRoute(
 	ctx context.Context,


### PR DESCRIPTION
## Description

increase prometheus query timeout to 95s so that it has time for 3 scrapes, making metrics test less flaky.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # [OLS-1333](https://issues.redhat.com//browse/OLS-1333)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
