### PR TITLE
OLS-1333 test: reduce version conflicts when updating resources

### DIFF
--- a/test/e2e/autocorrection_test.go
+++ b/test/e2e/autocorrection_test.go
@@ -13,6 +13,7 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 )
 
 var _ = Describe("Automatic correction against modifications on managed resources", Ordered, func() {
@@ -80,8 +81,21 @@ var _ = Describe("Automatic correction against modifications on managed resource
 		err = client.WaitForObjectCreated(deployment)
 		Expect(err).NotTo(HaveOccurred())
 		originDeployment := deployment.DeepCopy()
-		deployment.Spec.Replicas = Ptr(1 + *deployment.Spec.Replicas)
-		err = client.Update(deployment)
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			deployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ConsolePluginDeploymentName,
+					Namespace: OLSNameSpace,
+				},
+			}
+			err = client.Get(deployment)
+			if err != nil {
+				return fmt.Errorf("wait for deployment to be created: %w", err)
+			}
+
+			deployment.Spec.Replicas = Ptr(1 + *deployment.Spec.Replicas)
+			return client.Update(deployment)
+		})
 		Expect(err).NotTo(HaveOccurred())
 		var lastErr error
 		err = wait.PollUntilContextTimeout(client.ctx, DefaultPollInterval, DefaultPollTimeout, true, func(ctx context.Context) (bool, error) {
@@ -105,11 +119,23 @@ var _ = Describe("Automatic correction against modifications on managed resource
 		err = client.Get(service)
 		Expect(err).NotTo(HaveOccurred())
 		originService := service.DeepCopy()
-		service.Spec.Ports[0].Name = "wrong-port-name"
-		service.Spec.Selector = map[string]string{
-			"wrong": "label",
-		}
-		err = client.Update(service)
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			service := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ConsolePluginServiceName,
+					Namespace: OLSNameSpace,
+				},
+			}
+			err = client.Get(service)
+			if err != nil {
+				return fmt.Errorf("get service: %w", err)
+			}
+			service.Spec.Ports[0].Name = "wrong-port-name"
+			service.Spec.Selector = map[string]string{
+				"wrong": "label",
+			}
+			return client.Update(service)
+		})
 		Expect(err).NotTo(HaveOccurred())
 		err = wait.PollUntilContextTimeout(client.ctx, DefaultPollInterval, DefaultPollTimeout, true, func(ctx context.Context) (bool, error) {
 			err := client.Get(service)
@@ -132,8 +158,19 @@ var _ = Describe("Automatic correction against modifications on managed resource
 		err = client.Get(consoleplugin)
 		Expect(err).NotTo(HaveOccurred())
 		originConsolePlugin := consoleplugin.DeepCopy()
-		consoleplugin.Spec.DisplayName = "New Console Plugin Name"
-		err = client.Update(consoleplugin)
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			consoleplugin := &consolev1.ConsolePlugin{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: ConsoleUIPluginName,
+				},
+			}
+			err = client.Get(consoleplugin)
+			if err != nil {
+				return fmt.Errorf("get consoleplugin: %w", err)
+			}
+			consoleplugin.Spec.DisplayName = "New Console Plugin Name"
+			return client.Update(consoleplugin)
+		})
 		Expect(err).NotTo(HaveOccurred())
 		err = wait.PollUntilContextTimeout(client.ctx, DefaultPollInterval, DefaultPollTimeout, true, func(ctx context.Context) (bool, error) {
 			err := client.Get(consoleplugin)
@@ -156,8 +193,20 @@ var _ = Describe("Automatic correction against modifications on managed resource
 		err = client.Get(configmap)
 		Expect(err).NotTo(HaveOccurred())
 		originConfigMap := configmap.DeepCopy()
-		configmap.Data["nginx.conf"] = "new-config"
-		err = client.Update(configmap)
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			configmap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ConsoleUIConfigMapName,
+					Namespace: OLSNameSpace,
+				},
+			}
+			err = client.Get(configmap)
+			if err != nil {
+				return fmt.Errorf("get console configmap: %w", err)
+			}
+			configmap.Data["nginx.conf"] = "new-config"
+			return client.Update(configmap)
+		})
 		Expect(err).NotTo(HaveOccurred())
 		err = wait.PollUntilContextTimeout(client.ctx, DefaultPollInterval, DefaultPollTimeout, true, func(ctx context.Context) (bool, error) {
 			err := client.Get(configmap)


### PR DESCRIPTION
## Description

This fixes the problem when updating resources for testing the reconciliation, test behave flakiness with version conflict errors during updates.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # [OLS-1333](https://issues.redhat.com//browse/OLS-1333)
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
