### PR TITLE
Update the Konflux task-buildah-remote-oci-ta task to the latest version

### DIFF
--- a/.tekton/ols-bundle-pull-request.yaml
+++ b/.tekton/ols-bundle-pull-request.yaml
@@ -251,7 +251,7 @@ spec:
         - name: name
           value: buildah-remote-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:e8f69168ea59919288c7a943347bd68184f762d405ead56f4a5e0fcc851115c6
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:800047c639e0fd8b0eff0110cb5c3ba00abe1de2af02bb9a92084f2c7bb2e87d
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/ols-bundle-push.yaml
+++ b/.tekton/ols-bundle-push.yaml
@@ -249,7 +249,7 @@ spec:
         - name: name
           value: buildah-remote-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:e8f69168ea59919288c7a943347bd68184f762d405ead56f4a5e0fcc851115c6
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:800047c639e0fd8b0eff0110cb5c3ba00abe1de2af02bb9a92084f2c7bb2e87d
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
## Description

Update the Konflux task-buildah-remote-oci-ta task to the latest version to work around the "Mismatched SBOM formats: cyclonedx X spdx" build-image error.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [] Configuration Update
- [x] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
