### PR TITLE
Fix the LLM list markdown in the operator description

### DIFF
--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -272,9 +272,9 @@ spec:
 
     To configure the OpenShift Lightspeed Operator, you need a Large Language Model (LLM) . You can host the LLM using RHELAI or RHOAI or use one of the models from the following Software-as-a-Service providers:
 
-    OpenAI
-    Microsoft Azure OpenAI
-    IBM WatsonX
+    - OpenAI
+    - Microsoft Azure OpenAI
+    - IBM WatsonX
 
     For more information, see [About OpenShift Lightspeed](https://docs.openshift.com/lightspeed/1.0tp1/about/ols-about-openshift-lightspeed.html) in the official product documentation.
 

--- a/config/manifests/bases/lightspeed-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/lightspeed-operator.clusterserviceversion.yaml
@@ -243,9 +243,9 @@ spec:
 
     To configure the OpenShift Lightspeed Operator, you need a Large Language Model (LLM) . You can host the LLM using RHELAI or RHOAI or use one of the models from the following Software-as-a-Service providers:
 
-    OpenAI
-    Microsoft Azure OpenAI
-    IBM WatsonX
+    - OpenAI
+    - Microsoft Azure OpenAI
+    - IBM WatsonX
 
     For more information, see [About OpenShift Lightspeed](https://docs.openshift.com/lightspeed/1.0tp1/about/ols-about-openshift-lightspeed.html) in the official product documentation.
 

--- a/lightspeed-catalog-4.17/index.yaml
+++ b/lightspeed-catalog-4.17/index.yaml
@@ -281,9 +281,9 @@ properties:
 
         To configure the OpenShift Lightspeed Operator, you need a Large Language Model (LLM) . You can host the LLM using RHELAI or RHOAI or use one of the models from the following Software-as-a-Service providers:
 
-        OpenAI
-        Microsoft Azure OpenAI
-        IBM WatsonX
+        - OpenAI
+        - Microsoft Azure OpenAI
+        - IBM WatsonX
 
         For more information, see [About OpenShift Lightspeed](https://docs.openshift.com/lightspeed/1.0tp1/about/ols-about-openshift-lightspeed.html) in the official product documentation.
 


### PR DESCRIPTION
## Description

Corrected the list of LLMs in the operator description so that the operator details page renders the LLMs as an unnumbered list.

Before:
OpenAI Microsoft Azure OpenAI IBM WatsonX

After:
- OpenAI
- Microsoft Azure OpenAI
- IBM WatsonX

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
