### PR TITLE
OLS-1392: add option introspectionEnabled

### DIFF
--- a/api/v1alpha1/olsconfig_types.go
+++ b/api/v1alpha1/olsconfig_types.go
@@ -91,6 +91,10 @@ type OLSSpec struct {
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="TLS Security Profile",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
 	TLSSecurityProfile *configv1.TLSSecurityProfile `json:"tlsSecurityProfile,omitempty"`
+	// Enable introspection features
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Introspection Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	IntrospectionEnabled bool `json:"introspectionEnabled,omitempty"`
 }
 
 // DeploymentConfig defines the schema for overriding deployment of OLS instance.

--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
       ]
     capabilities: Basic Install
     console.openshift.io/operator-monitoring-default: "true"
-    createdAt: "2025-01-07T15:40:12Z"
+    createdAt: "2025-02-19T12:34:53Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -203,6 +203,11 @@ spec:
             path: ols.deployment.replicas
             x-descriptors:
               - urn:alm:descriptor:com.tectonic.ui:podCount
+          - description: Enable introspection features
+            displayName: Introspection Enabled
+            path: ols.introspectionEnabled
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
           - description: 'Log level. Valid options are DEBUG, INFO, WARNING, ERROR and CRITICAL. Default: "INFO".'
             displayName: Log level
             path: ols.logLevel

--- a/bundle/manifests/ols.openshift.io_olsconfigs.yaml
+++ b/bundle/manifests/ols.openshift.io_olsconfigs.yaml
@@ -689,6 +689,9 @@ spec:
                         minimum: 0
                         type: integer
                     type: object
+                  introspectionEnabled:
+                    description: Enable introspection features
+                    type: boolean
                   logLevel:
                     default: INFO
                     description: 'Log level. Valid options are DEBUG, INFO, WARNING,

--- a/config/crd/bases/ols.openshift.io_olsconfigs.yaml
+++ b/config/crd/bases/ols.openshift.io_olsconfigs.yaml
@@ -689,6 +689,9 @@ spec:
                         minimum: 0
                         type: integer
                     type: object
+                  introspectionEnabled:
+                    description: Enable introspection features
+                    type: boolean
                   logLevel:
                     default: INFO
                     description: 'Log level. Valid options are DEBUG, INFO, WARNING,

--- a/config/manifests/bases/lightspeed-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/lightspeed-operator.clusterserviceversion.yaml
@@ -172,6 +172,11 @@ spec:
         path: ols.deployment.replicas
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:podCount
+      - description: Enable introspection features
+        displayName: Introspection Enabled
+        path: ols.introspectionEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: 'Log level. Valid options are DEBUG, INFO, WARNING, ERROR and
           CRITICAL. Default: "INFO".'
         displayName: Log level

--- a/internal/controller/ols_app_server_assets.go
+++ b/internal/controller/ols_app_server_assets.go
@@ -221,6 +221,7 @@ func (r *OLSConfigReconciler) generateOLSConfigMap(ctx context.Context, cr *olsv
 			TranscriptsDisabled: cr.Spec.OLSConfig.UserDataCollection.TranscriptsDisabled || !dataCollectorEnabled,
 			TranscriptsStorage:  "/app-root/ols-user-data/transcripts",
 		},
+		IntrospectionEnabled: cr.Spec.OLSConfig.IntrospectionEnabled,
 	}
 
 	if cr.Spec.OLSConfig.AdditionalCAConfigMapRef != nil {

--- a/internal/controller/ols_app_server_assets_test.go
+++ b/internal/controller/ols_app_server_assets_test.go
@@ -134,6 +134,7 @@ var _ = Describe("App server assets", func() {
 						TranscriptsDisabled: false,
 						TranscriptsStorage:  "/app-root/ols-user-data/transcripts",
 					},
+					IntrospectionEnabled: false,
 				},
 				LLMProviders: []ProviderConfig{
 					{
@@ -244,6 +245,19 @@ var _ = Describe("App server assets", func() {
 				"name": Equal("rhelai_vllm"),
 				"type": Equal("rhelai_vllm"),
 			}))))
+		})
+
+		It("should generate configmap with introspectionEnabled", func() {
+			cr.Spec.OLSConfig.IntrospectionEnabled = true
+			cm, err := r.generateOLSConfigMap(context.TODO(), cr)
+			Expect(err).NotTo(HaveOccurred())
+
+			var olsConfigMap map[string]interface{}
+			err = yaml.Unmarshal([]byte(cm.Data[OLSConfigFilename]), &olsConfigMap)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(olsConfigMap).To(HaveKeyWithValue("ols_config", MatchKeys(Options(IgnoreExtras), Keys{
+				"introspection_enabled": Equal(true),
+			})))
 		})
 
 		It("should generate the OLS deployment", func() {

--- a/internal/controller/types.go
+++ b/internal/controller/types.go
@@ -97,6 +97,8 @@ type OLSConfig struct {
 	ExtraCAs []string `json:"extra_ca,omitempty"`
 	// Path to the directory containing the certificates bundle in the app server container.
 	CertificateDirectory string `json:"certificate_directory,omitempty"`
+	// Enable Introspection features
+	IntrospectionEnabled bool `json:"introspection_enabled,omitempty"`
 }
 
 type LoggingConfig struct {


### PR DESCRIPTION
## Description

add new field `introspectionEnabled` to OLSConfig CRD. 

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes # [OLS-1392](https://issues.redhat.com//browse/OLS-1392)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
