### PR TITLE
OLS-1449: bugfix: gracefully handle missing apitoken key in the LLM provider secret

### DIFF
--- a/internal/controller/errors.go
+++ b/internal/controller/errors.go
@@ -1,6 +1,7 @@
 package controller
 
 const (
+	ErrCheckLLMCredentials             = "failed to validate LLM provider credential settings"
 	ErrCreateAdditionalCACM            = "failed to create additional CA configmap"
 	ErrCreateAPIConfigmap              = "failed to create OLS configmap"
 	ErrCreateAPIDeployment             = "failed to create OLS deployment"

--- a/internal/controller/ols_app_server_assets_test.go
+++ b/internal/controller/ols_app_server_assets_test.go
@@ -1115,6 +1115,7 @@ func generateRandomSecret() (*corev1.Secret, error) {
 			"client_secret": []byte(passwordHash),
 			"tls.key":       privateKeyPEM,
 			"tls.crt":       certPEM,
+			"apitoken":      []byte("LLM Provider Token"),
 		},
 	}
 

--- a/internal/controller/ols_app_server_reconciliator.go
+++ b/internal/controller/ols_app_server_reconciliator.go
@@ -77,6 +77,11 @@ func (r *OLSConfigReconciler) reconcileAppServer(ctx context.Context, olsconfig 
 }
 
 func (r *OLSConfigReconciler) reconcileOLSConfigMap(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
+	err := r.checkLLMCredentials(ctx, cr)
+	if err != nil {
+		return fmt.Errorf("%s: %w", ErrCheckLLMCredentials, err)
+	}
+
 	cm, err := r.generateOLSConfigMap(ctx, cr)
 	if err != nil {
 		return fmt.Errorf("%s: %w", ErrGenerateAPIConfigmap, err)

--- a/internal/controller/ols_app_server_reconciliator_test.go
+++ b/internal/controller/ols_app_server_reconciliator_test.go
@@ -418,6 +418,18 @@ var _ = Describe("App server reconciliator", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
+		It("should return error when the LLM provider token secret does not have required keys", func() {
+			By("Reconcile after modifying the token secret")
+			secret, _ := generateRandomSecret()
+			// delete the required key "apitoken"
+			delete(secret.Data, "apitoken")
+			err := k8sClient.Update(ctx, secret)
+			Expect(err).NotTo(HaveOccurred())
+			err = reconciler.reconcileAppServer(ctx, cr)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("missing key 'apitoken'"))
+		})
+
 	})
 
 	Context("Referred Secrets", Ordered, func() {

--- a/internal/controller/olsconfig_controller.go
+++ b/internal/controller/olsconfig_controller.go
@@ -148,7 +148,7 @@ func (r *OLSConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	err = r.reconcileConsoleUI(ctx, olsconfig)
 	if err != nil {
 		r.logger.Error(err, "Failed to reconcile console UI")
-		r.updateStatusCondition(ctx, olsconfig, typeCRReconciled, false, "Failed", nil)
+		r.updateStatusCondition(ctx, olsconfig, typeCRReconciled, false, "Failed", err)
 		return ctrl.Result{RequeueAfter: 1 * time.Second}, err
 	}
 	// Update status condition for Console Plugin
@@ -163,7 +163,7 @@ func (r *OLSConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	err = r.reconcileAppServer(ctx, olsconfig)
 	if err != nil {
 		r.logger.Error(err, "Failed to reconcile application server")
-		r.updateStatusCondition(ctx, olsconfig, typeCRReconciled, false, "Failed", nil)
+		r.updateStatusCondition(ctx, olsconfig, typeCRReconciled, false, "Failed", err)
 		return ctrl.Result{RequeueAfter: 1 * time.Second}, err
 	}
 	// Update status condition for API server


### PR DESCRIPTION
## Description

Missing `apitoken` key in the LLM provider secret will not trigger app server reconciliation, avoid crashlooping of the app pod.

OLSConfig CR status field will have the error message when this issue happens.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes # [OLS-1449](https://issues.redhat.com//browse/OLS-1449)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
