### PR TITLE
OLS-1333: Fix prometheus metrics test flakyness

### DIFF
--- a/test/e2e/prometheus_client.go
+++ b/test/e2e/prometheus_client.go
@@ -16,6 +16,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // PrometheusClient provides access to the Prometheus, Thanos & Alertmanager API.
@@ -30,7 +31,7 @@ type PrometheusClient struct {
 
 // DefaultPollInterval is the default interval for polling Prometheus metrics.
 // Prometheus metrics are typically scraped every 30 seconds. This is enough for 3 scrapes.
-const DefaultPrometheusQueryTimeout = 95 * time.Second
+const DefaultPrometheusQueryTimeout = 120 * time.Second
 
 // NewPrometheusClientFromRoute creates and returns a new PrometheusClient from the given OpenShift route.
 func NewPrometheusClientFromRoute(
@@ -41,6 +42,8 @@ func NewPrometheusClientFromRoute(
 ) (*PrometheusClient, error) {
 	route, err := routeClient.Routes(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
+
+		logf.Log.Error(err, "Error fetching Prometheus route")
 		return nil, err
 	}
 


### PR DESCRIPTION
## Description
- increase prometheus client timeout to 120 sec
- retry whole metrics_test in case of test failure (use Ginkgo's FlakyAttempts construction)
- fix issue with ClusterRoleBindings on clusterbot ROSA clusters - not able to delete (ignore error if ClusterRoleBindings already exist)
- retry on getting prometheus route in case of networking issue

## Type of change

- [x] Refactor

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.
