### PR TITLE
OLS-1333: Fix e2e tls_test test flakyness

### DIFF
--- a/test/e2e/client.go
+++ b/test/e2e/client.go
@@ -361,8 +361,13 @@ func (c *Client) CreateServiceAccount(namespace, serviceAccount string) (func(),
 	}
 
 	err := c.Create(sa)
+
 	if err != nil {
-		return nil, err
+		if k8serrors.IsAlreadyExists(err) {
+			logf.Log.Error(err, "Error ServiceAccount for test already exists")
+		} else {
+			return nil, err
+		}
 	}
 
 	return func() {

--- a/test/e2e/tls_test.go
+++ b/test/e2e/tls_test.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = Describe("TLS activation - application", Ordered, func() {
+var _ = Describe("TLS activation - application", FlakeAttempts(5), Ordered, func() {
 	const serviceAnnotationKeyTLSSecret = "service.beta.openshift.io/serving-cert-secret-name"
 	const testSAName = "test-sa"
 	const testSAOutsiderName = "test-sa-outsider"
@@ -168,7 +168,7 @@ var _ = Describe("TLS activation - application", Ordered, func() {
 	})
 })
 
-var _ = Describe("TLS activation - operator", Ordered, func() {
+var _ = Describe("TLS activation - operator", FlakeAttempts(5), Ordered, func() {
 	const serviceAnnotationKeyTLSSecret = "service.beta.openshift.io/serving-cert-secret-name"
 	const operatorServiceName = "lightspeed-operator-controller-manager-service"
 	const operatorServicePort = 8443
@@ -249,7 +249,7 @@ var _ = Describe("TLS activation - operator", Ordered, func() {
 			},
 		}))
 
-		By("check HTTPS Get on /metrics endpoint")
+		By("check HTTPS Get on /metrics endpoint: fetch TLS secret")
 		const inClusterHost = "lightspeed-operator-controller-manager-service.openshift-lightspeed.svc"
 		prometheusTLSSecret := corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -263,6 +263,7 @@ var _ = Describe("TLS activation - operator", Ordered, func() {
 		Expect(ok).To(BeTrue())
 		clientKey, ok := prometheusTLSSecret.Data["tls.key"]
 		Expect(ok).To(BeTrue())
+		By("check HTTPS Get on /metrics endpoint: fetch TLS CA bundle")
 		prometheusTLSCABundle := corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "serving-certs-ca-bundle",
@@ -274,8 +275,8 @@ var _ = Describe("TLS activation - operator", Ordered, func() {
 		caCert, ok := prometheusTLSCABundle.Data["service-ca.crt"]
 		Expect(ok).To(BeTrue())
 
+		By("check HTTPS Get on /metrics endpoint: connect over https")
 		httpsClient := NewHTTPSClient(forwardHost, inClusterHost, []byte(caCert), clientCert, clientKey)
-
 		err = httpsClient.waitForHTTPSGetStatus("/metrics", http.StatusOK)
 		Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
## Description
[OLS-1333](https://issues.redhat.com//browse/OLS-1333): Fix e2e tls_test test flakyness
- retry whole tls_test in case of test failure (use Ginkgo's FlakyAttempts construction)
- fix issue with ServiceAccount on clusterbot ROSA clusters - not able to delete (ignore error if service account already exist)
- minor fixes when the cleanup functions are executed

## Type of change

- [x] Refactor
- [x] Bug fix

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.
