### PR TITLE
Fix for 'go vet' breakage: the cancel function returned by context.WithCancel should be called

### DIFF
--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -21,7 +21,8 @@ func hashBytes(sourceStr []byte) (string, error) { // nolint:unused
 }
 
 func WriteResourceToFile(client *Client, clusterDir string, filename string, resource string) error {
-	ctx, _ := context.WithCancel(client.ctx)
+	ctx, cancel := context.WithCancel(client.ctx)
+	defer cancel()
 	// Create file and file handler
 	f, err := os.OpenFile(clusterDir+"/"+filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
@@ -38,7 +39,8 @@ func WriteResourceToFile(client *Client, clusterDir string, filename string, res
 }
 
 func WriteLogsToFile(client *Client, clusterDir string) error {
-	ctx, _ := context.WithCancel(client.ctx)
+	ctx, cancel := context.WithCancel(client.ctx)
+	defer cancel()
 	// Create file and file handler
 
 	// Execute command and write output to file


### PR DESCRIPTION
## Description

Fix for mainline break in test/unit

```
go vet ./...
...
test/e2e/utils.go:24:7: the cancel function returned by context.WithCancel should be called, not discarded, to avoid a context leak
test/e2e/utils.go:41:7: the cancel function returned by context.WithCancel should be called, not discarded, to avoid a context leak
```

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
