### PR TITLE
OLS-1770: Add writable volumes to the operand Deployments to compensate for read-only root fs

### DIFF
--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -499,6 +499,7 @@ spec:
                         cpu: 10m
                         memory: 64Mi
                     securityContext:
+                      readOnlyRootFilesystem: true
                       allowPrivilegeEscalation: false
                       capabilities:
                         drop:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -75,6 +75,7 @@ spec:
         imagePullPolicy: Always
         name: manager
         securityContext:
+          readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
           capabilities:
             drop:

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -178,7 +178,11 @@ const (
 	// PostgresDataVolume is the name of Postgres data volume
 	PostgresDataVolume = "postgres-data"
 	// PostgresDataVolumeMountPath is the path of Postgres data volume mount
-	PostgresDataVolumeMountPath = "/var/lib/pgsql/data"
+	PostgresDataVolumeMountPath = "/var/lib/pgsql"
+	// PostgreVarRunVolumeName is the data volume name for the /var/run/postgresql writable mount
+	PostgresVarRunVolumeName = "lightspeed-postgres-var-run"
+	// PostgresVarRunVolumeMountPath is the path of Postgres data volume mount
+	PostgresVarRunVolumeMountPath = "/var/run/postgresql"
 	// PostgresServicePort is the port number of the OLS Postgres server service
 	PostgresServicePort = 5432
 	// PostgresSharedBuffers is the share buffers value for Postgres cache
@@ -215,6 +219,11 @@ ssl_ca_file = '/etc/certs/cm-olspostgresca/service-ca.crt'
 
 	// PostgresDefaultPVCSize is the default size of the PVC for the OLS Postgres server
 	PostgresDefaultPVCSize = "1Gi"
+
+	// TmpVolume is the data volume name for the /tmp writable mount
+	TmpVolumeName = "tmp-writable-volume"
+	// TmpVolumeMountPath is the path of the /tmp writable mount
+	TmpVolumeMountPath = "/tmp"
 
 	/*** state cache keys ***/
 	// OLSAppTLSHashStateCacheKey is the key of the hash value of the OLS App TLS certificates

--- a/internal/controller/ols_app_postgres_assets.go
+++ b/internal/controller/ols_app_postgres_assets.go
@@ -192,6 +192,10 @@ func (r *OLSConfigReconciler) generatePostgresDeployment(cr *olsv1alpha1.OLSConf
 									Protocol:      corev1.ProtocolTCP,
 								},
 							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: &[]bool{false}[0],
+								ReadOnlyRootFilesystem:   &[]bool{true}[0],
+							},
 							VolumeMounts: volumeMounts,
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{

--- a/internal/controller/ols_app_postgres_assets.go
+++ b/internal/controller/ols_app_postgres_assets.go
@@ -111,7 +111,21 @@ func (r *OLSConfigReconciler) generatePostgresDeployment(cr *olsv1alpha1.OLSConf
 		}
 	}
 
-	volumes := []corev1.Volume{tlsCertsVolume, bootstrapVolume, configVolume, dataVolume, getPostgresCAConfigVolume()}
+	varRunVolume := corev1.Volume{
+		Name: PostgresVarRunVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+
+	tmpVolume := corev1.Volume{
+		Name: TmpVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+
+	volumes := []corev1.Volume{tlsCertsVolume, bootstrapVolume, configVolume, dataVolume, getPostgresCAConfigVolume(), varRunVolume, tmpVolume}
 	postgresTLSVolumeMount := corev1.VolumeMount{
 		Name:      "secret-" + PostgresCertsSecretName,
 		MountPath: OLSAppCertsMountRoot,
@@ -132,7 +146,24 @@ func (r *OLSConfigReconciler) generatePostgresDeployment(cr *olsv1alpha1.OLSConf
 		Name:      PostgresDataVolume,
 		MountPath: PostgresDataVolumeMountPath,
 	}
-	volumeMounts := []corev1.VolumeMount{postgresTLSVolumeMount, bootstrapVolumeMount, configVolumeMount, dataVolumeMount, getPostgresCAVolumeMount(path.Join(OLSAppCertsMountRoot, PostgresCAVolume))}
+	varRunVolumeMount := corev1.VolumeMount{
+		Name:      PostgresVarRunVolumeName,
+		MountPath: PostgresVarRunVolumeMountPath,
+	}
+	tmpVolumeMount := corev1.VolumeMount{
+		Name:      TmpVolumeName,
+		MountPath: TmpVolumeMountPath,
+	}
+
+	volumeMounts := []corev1.VolumeMount{
+		postgresTLSVolumeMount,
+		bootstrapVolumeMount,
+		configVolumeMount,
+		dataVolumeMount,
+		getPostgresCAVolumeMount(path.Join(OLSAppCertsMountRoot, PostgresCAVolume)),
+		varRunVolumeMount,
+		tmpVolumeMount,
+	}
 	deployment := appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      PostgresDeploymentName,

--- a/internal/controller/ols_app_postgres_assets_test.go
+++ b/internal/controller/ols_app_postgres_assets_test.go
@@ -100,6 +100,14 @@ var _ = Describe("App postgres server assets", func() {
 				MountPath: path.Join(OLSAppCertsMountRoot, PostgresCAVolume),
 				ReadOnly:  true,
 			},
+			{
+				Name:      PostgresVarRunVolumeName,
+				MountPath: PostgresVarRunVolumeMountPath,
+			},
+			{
+				Name:      TmpVolumeName,
+				MountPath: TmpVolumeMountPath,
+			},
 		}))
 		expectedVolumes := []corev1.Volume{
 			{
@@ -145,14 +153,28 @@ var _ = Describe("App postgres server assets", func() {
 				},
 			})
 		}
-		expectedVolumes = append(expectedVolumes, corev1.Volume{
-			Name: PostgresCAVolume,
-			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{Name: OLSCAConfigMap},
+		expectedVolumes = append(expectedVolumes,
+			corev1.Volume{
+				Name: PostgresCAVolume,
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: OLSCAConfigMap},
+					},
 				},
 			},
-		})
+			corev1.Volume{
+				Name: PostgresVarRunVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+			corev1.Volume{
+				Name: TmpVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+		)
 		Expect(dep.Spec.Template.Spec.Volumes).To(Equal(expectedVolumes))
 	}
 

--- a/internal/controller/ols_app_server_assets_test.go
+++ b/internal/controller/ols_app_server_assets_test.go
@@ -339,6 +339,10 @@ var _ = Describe("App server assets", func() {
 					ReadOnly:  true,
 					MountPath: path.Join(OLSAppCertsMountRoot, PostgresCertsSecretName, PostgresCAVolume),
 				},
+				{
+					Name:      TmpVolumeName,
+					MountPath: TmpVolumeMountPath,
+				},
 			}))
 			Expect(dep.Spec.Template.Spec.Containers[0].Resources).To(Equal(corev1.ResourceRequirements{
 				Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("4Gi")},
@@ -386,6 +390,10 @@ var _ = Describe("App server assets", func() {
 					Name:      "cm-olspostgresca",
 					ReadOnly:  true,
 					MountPath: path.Join(OLSAppCertsMountRoot, PostgresCertsSecretName, PostgresCAVolume),
+				},
+				{
+					Name:      TmpVolumeName,
+					MountPath: TmpVolumeMountPath,
 				},
 			}))
 			Expect(dep.Spec.Template.Spec.Containers[1].Resources).To(Equal(corev1.ResourceRequirements{
@@ -444,6 +452,12 @@ var _ = Describe("App server assets", func() {
 						EmptyDir: &corev1.EmptyDirVolumeSource{},
 					},
 				},
+				{
+					Name: TmpVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
 			}))
 			Expect(dep.Spec.Selector.MatchLabels).To(Equal(generateAppServerSelectorLabels()))
 
@@ -497,6 +511,10 @@ var _ = Describe("App server assets", func() {
 					ReadOnly:  true,
 					MountPath: "/etc/certs/lightspeed-postgres-certs/cm-olspostgresca",
 				},
+				{
+					Name:      TmpVolumeName,
+					MountPath: TmpVolumeMountPath,
+				},
 			}))
 			Expect(dep.Spec.Template.Spec.Volumes).To(ConsistOf([]corev1.Volume{
 				{
@@ -541,6 +559,12 @@ var _ = Describe("App server assets", func() {
 						ConfigMap: &corev1.ConfigMapVolumeSource{
 							LocalObjectReference: corev1.LocalObjectReference{Name: OLSCAConfigMap},
 						},
+					},
+				},
+				{
+					Name: TmpVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
 					},
 				},
 			}))
@@ -596,6 +620,10 @@ var _ = Describe("App server assets", func() {
 					MountPath: "/etc/certs/lightspeed-postgres-certs/cm-olspostgresca",
 					ReadOnly:  true,
 				},
+				{
+					Name:      TmpVolumeName,
+					MountPath: TmpVolumeMountPath,
+				},
 			}))
 			Expect(dep.Spec.Template.Spec.Volumes).To(ConsistOf([]corev1.Volume{
 				{
@@ -640,6 +668,12 @@ var _ = Describe("App server assets", func() {
 						ConfigMap: &corev1.ConfigMapVolumeSource{
 							LocalObjectReference: corev1.LocalObjectReference{Name: OLSCAConfigMap},
 						},
+					},
+				},
+				{
+					Name: TmpVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
 					},
 				},
 			}))
@@ -829,6 +863,10 @@ var _ = Describe("App server assets", func() {
 					Name:      "cm-olspostgresca",
 					ReadOnly:  true,
 					MountPath: path.Join(OLSAppCertsMountRoot, PostgresCertsSecretName, PostgresCAVolume),
+				},
+				{
+					Name:      TmpVolumeName,
+					MountPath: TmpVolumeMountPath,
 				},
 			}))
 			Expect(deployment.Spec.Template.Spec.Volumes).To(ContainElement(
@@ -1182,6 +1220,10 @@ user_data_collector_config: {}
 					ReadOnly:  true,
 					MountPath: path.Join(OLSAppCertsMountRoot, PostgresCertsSecretName, PostgresCAVolume),
 				},
+				{
+					Name:      TmpVolumeName,
+					MountPath: TmpVolumeMountPath,
+				},
 			}))
 			Expect(dep.Spec.Template.Spec.Volumes).To(ConsistOf([]corev1.Volume{
 				{
@@ -1221,6 +1263,12 @@ user_data_collector_config: {}
 				},
 				{
 					Name: "ols-user-data",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+				{
+					Name: TmpVolumeName,
 					VolumeSource: corev1.VolumeSource{
 						EmptyDir: &corev1.EmptyDirVolumeSource{},
 					},

--- a/internal/controller/ols_app_server_deployment.go
+++ b/internal/controller/ols_app_server_deployment.go
@@ -283,6 +283,7 @@ func (r *OLSConfigReconciler) generateOLSDeployment(cr *olsv1alpha1.OLSConfig) (
 							Ports:           ports,
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: &[]bool{false}[0],
+								ReadOnlyRootFilesystem:   &[]bool{true}[0],
 							},
 							VolumeMounts: volumeMounts,
 							Env: append(getProxyEnvVars(), corev1.EnvVar{
@@ -349,6 +350,7 @@ func (r *OLSConfigReconciler) generateOLSDeployment(cr *olsv1alpha1.OLSConfig) (
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		SecurityContext: &corev1.SecurityContext{
 			AllowPrivilegeEscalation: &[]bool{false}[0],
+			ReadOnlyRootFilesystem:   &[]bool{true}[0],
 		},
 		VolumeMounts: volumeMounts,
 		Env: []corev1.EnvVar{

--- a/internal/controller/ols_app_server_deployment.go
+++ b/internal/controller/ols_app_server_deployment.go
@@ -181,6 +181,15 @@ func (r *OLSConfigReconciler) generateOLSDeployment(cr *olsv1alpha1.OLSConfig) (
 	// Postgres CA volume
 	volumes = append(volumes, getPostgresCAConfigVolume())
 
+	volumes = append(volumes,
+		corev1.Volume{
+			Name: TmpVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+	)
+
 	// mount the volumes of api keys secrets and OLS config map to the container
 	volumeMounts := []corev1.VolumeMount{}
 	for secretName, mountPath := range secretMounts {
@@ -232,7 +241,13 @@ func (r *OLSConfigReconciler) generateOLSDeployment(cr *olsv1alpha1.OLSConfig) (
 		volumeMounts = append(volumeMounts, ragVolumeMounts)
 	}
 
-	volumeMounts = append(volumeMounts, getPostgresCAVolumeMount(path.Join(OLSAppCertsMountRoot, PostgresCertsSecretName, PostgresCAVolume)))
+	volumeMounts = append(volumeMounts,
+		getPostgresCAVolumeMount(path.Join(OLSAppCertsMountRoot, PostgresCertsSecretName, PostgresCAVolume)),
+		corev1.VolumeMount{
+			Name:      TmpVolumeName,
+			MountPath: TmpVolumeMountPath,
+		},
+	)
 
 	initContainers := []corev1.Container{}
 	if cr.Spec.OLSConfig.RAG != nil && len(cr.Spec.OLSConfig.RAG) > 0 {

--- a/internal/controller/ols_console_ui_assets.go
+++ b/internal/controller/ols_console_ui_assets.go
@@ -139,6 +139,10 @@ func (r *OLSConfigReconciler) generateConsoleUIDeployment(cr *olsv1alpha1.OLSCon
 									Protocol:      corev1.ProtocolTCP,
 								},
 							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: &[]bool{false}[0],
+								ReadOnlyRootFilesystem:   &[]bool{true}[0],
+							},
 							ImagePullPolicy: corev1.PullAlways,
 							Env:             getProxyEnvVars(),
 							Resources:       *resources,

--- a/internal/controller/ols_console_ui_assets.go
+++ b/internal/controller/ols_console_ui_assets.go
@@ -38,13 +38,19 @@ func getConsoleUIResources(cr *olsv1alpha1.OLSConfig) *corev1.ResourceRequiremen
 
 func (r *OLSConfigReconciler) generateConsoleUIConfigMap(cr *olsv1alpha1.OLSConfig) (*corev1.ConfigMap, error) {
 	nginxConfig := `
+			pid       /tmp/nginx/nginx.pid;
 			error_log /dev/stdout info;
 			events {}
 			http {
-				access_log         /dev/stdout;
-				include            /etc/nginx/mime.types;
-				default_type       application/octet-stream;
-				keepalive_timeout  65;
+				client_body_temp_path /tmp/nginx/client_body;
+				proxy_temp_path       /tmp/nginx/proxy;
+				fastcgi_temp_path     /tmp/nginx/fastcgi;
+				uwsgi_temp_path       /tmp/nginx/uwsgi;
+				scgi_temp_path        /tmp/nginx/scgi;
+				access_log            /dev/stdout;
+				include               /etc/nginx/mime.types;
+				default_type          application/octet-stream;
+				keepalive_timeout     65;
 				server {
 					listen              9443 ssl;
 					listen              [::]:9443 ssl;
@@ -148,6 +154,10 @@ func (r *OLSConfigReconciler) generateConsoleUIDeployment(cr *olsv1alpha1.OLSCon
 									SubPath:   "nginx.conf",
 									ReadOnly:  true,
 								},
+								{
+									Name:      "nginx-temp",
+									MountPath: "/tmp/nginx",
+								},
 							},
 						},
 					},
@@ -170,6 +180,12 @@ func (r *OLSConfigReconciler) generateConsoleUIDeployment(cr *olsv1alpha1.OLSCon
 									},
 									DefaultMode: &volumeDefaultMode,
 								},
+							},
+						},
+						{
+							Name: "nginx-temp",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
 						},
 					},


### PR DESCRIPTION
## Description

This PR brings back the original commit (https://github.com/openshift/lightspeed-operator/pull/736) with the r/o root fs (thus undoing https://github.com/openshift/lightspeed-operator/pull/744), and adds writable volumes to the operand Deployments where needed.
It weakly depends on https://github.com/openshift/lightspeed-console/pull/759.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes # https://issues.redhat.com/browse/OLS-1552

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
