### PR TITLE
OLS-1734: conf: disable building image index for bundle as

### DIFF
--- a/.tekton/ols-bundle-pull-request.yaml
+++ b/.tekton/ols-bundle-pull-request.yaml
@@ -41,7 +41,8 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
+  - name: build-image-index
+    value: "false"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.

--- a/.tekton/ols-bundle-push.yaml
+++ b/.tekton/ols-bundle-push.yaml
@@ -39,7 +39,8 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
+  - name: build-image-index
+    value: "false"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.


### PR DESCRIPTION


## Description

Konflux enforce new enterprise policy that multi-arch index is not allowed for bundle images. we are disabling the image index build as instructed in : https://groups.google.com/u/1/a/redhat.com/g/konflux-announce/c/nfJ58NkZXTE

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
