### PR TITLE
OLS-1734 fix: call python3.11 to start MCP servers

### DIFF
--- a/internal/controller/ols_app_server_assets.go
+++ b/internal/controller/ols_app_server_assets.go
@@ -338,7 +338,7 @@ func (r *OLSConfigReconciler) generateOLSConfigMap(ctx context.Context, cr *olsv
 				Name:      "openshift",
 				Transport: "stdio",
 				Stdio: &StdioTransportConfig{
-					Command: "python",
+					Command: "python3.11",
 					Args: []string{
 						"./mcp_local/openshift.py",
 					},

--- a/internal/controller/ols_app_server_assets_test.go
+++ b/internal/controller/ols_app_server_assets_test.go
@@ -277,7 +277,7 @@ var _ = Describe("App server assets", func() {
 				"Name":      Equal("openshift"),
 				"Transport": Equal(Stdio),
 				"Stdio": PointTo(MatchFields(IgnoreExtras, Fields{
-					"Command": Equal("python"),
+					"Command": Equal("python3.11"),
 					"Args":    ContainElement("./mcp_local/openshift.py"),
 				})),
 			})))


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # [OLS-1734](https://issues.redhat.com//browse/OLS-1734)
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
