### PR TITLE
OLS-1823: Create OLSConfig with BYOK index first before OCP index

### DIFF
--- a/internal/controller/ols_app_server_assets.go
+++ b/internal/controller/ols_app_server_assets.go
@@ -241,12 +241,8 @@ func (r *OLSConfigReconciler) generateOLSConfigMap(ctx context.Context, cr *olsv
 		}
 	}
 
-	// OCP reference document is always available
-	ocpReferenceIndex := ReferenceIndex{
-		ProductDocsIndexPath: "/app-root/vector_db/ocp_product_docs/" + major + "." + minor,
-		ProductDocsIndexId:   "ocp-product-docs-" + major + "_" + minor,
-	}
-	referenceIndexes := []ReferenceIndex{ocpReferenceIndex}
+	referenceIndexes := []ReferenceIndex{}
+	// OLS-1823: prioritize BYOK content by listing it ahead of the OCP docs
 	// Custom reference document is optional
 	for i, index := range cr.Spec.OLSConfig.RAG {
 		referenceIndex := ReferenceIndex{
@@ -255,6 +251,12 @@ func (r *OLSConfigReconciler) generateOLSConfigMap(ctx context.Context, cr *olsv
 		}
 		referenceIndexes = append(referenceIndexes, referenceIndex)
 	}
+	// OCP documentation is always available
+	ocpReferenceIndex := ReferenceIndex{
+		ProductDocsIndexPath: "/app-root/vector_db/ocp_product_docs/" + major + "." + minor,
+		ProductDocsIndexId:   "ocp-product-docs-" + major + "_" + minor,
+	}
+	referenceIndexes = append(referenceIndexes, ocpReferenceIndex)
 
 	olsConfig := OLSConfig{
 		DefaultModel:    cr.Spec.OLSConfig.DefaultModel,

--- a/internal/controller/ols_app_server_assets_test.go
+++ b/internal/controller/ols_app_server_assets_test.go
@@ -995,8 +995,8 @@ var _ = Describe("App server assets", func() {
 				ProductDocsIndexPath: "/app-root/vector_db/ocp_product_docs/" + major + "." + minor,
 			}
 
-			Expect(olsconfigGenerated.OLSConfig.ReferenceContent.Indexes).To(ConsistOf(
-				ocpIndex,
+			// OLS-1823: prioritize BYOK content over OCP docs
+			Expect(olsconfigGenerated.OLSConfig.ReferenceContent.Indexes).To(Equal([]ReferenceIndex{
 				ReferenceIndex{
 					ProductDocsIndexId:   "ocp-product-docs-4_15",
 					ProductDocsIndexPath: RAGVolumeMountPath + "/rag-0",
@@ -1005,7 +1005,8 @@ var _ = Describe("App server assets", func() {
 					ProductDocsIndexId:   "ansible-docs-2_18",
 					ProductDocsIndexPath: RAGVolumeMountPath + "/rag-1",
 				},
-			))
+				ocpIndex,
+			}))
 
 			By("additional RAG indexes are removed")
 			cr.Spec.OLSConfig.RAG = []olsv1alpha1.RAGSpec{}


### PR DESCRIPTION
## Description

OLS-1823: Create OLSConfig with BYOK index first before OCP index.
Make sure the BYOK content is ahead of the OCP docs in the list of RAG databases.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes # OLS-1823

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
