### PR TITLE
OLS-1322 - bugfix: Replace BearerTokenSecret with Authorization field in ServiceMonitor

### DIFF
--- a/bundle/manifests/lightspeed-operator-metrics-reader-token_v1_secret.yaml
+++ b/bundle/manifests/lightspeed-operator-metrics-reader-token_v1_secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: metrics-reader
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/name: service-account-token
+    app.kubernetes.io/part-of: lightspeed-operator
+  name: lightspeed-operator-metrics-reader-token
+type: kubernetes.io/service-account-token

--- a/bundle/manifests/lightspeed-operator-metrics-reader_v1_serviceaccount.yaml
+++ b/bundle/manifests/lightspeed-operator-metrics-reader_v1_serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/name: service-account
+    app.kubernetes.io/part-of: lightspeed-operator
+  name: lightspeed-operator-metrics-reader

--- a/bundle/manifests/lightspeed-operator-ols-metrics-reader_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/lightspeed-operator-ols-metrics-reader_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -13,5 +13,5 @@ roleRef:
   name: lightspeed-operator-ols-metrics-reader
 subjects:
 - kind: ServiceAccount
-  name: prometheus-k8s
-  namespace: openshift-monitoring
+  name: lightspeed-operator-metrics-reader
+  namespace: openshift-lightspeed

--- a/bundle/manifests/lightspeed-operator-prometheus-operator_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/lightspeed-operator-prometheus-operator_rbac.authorization.k8s.io_v1_role.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/name: role
+    app.kubernetes.io/part-of: lightspeed-operator
+  name: lightspeed-operator-prometheus-operator
+rules:
+- apiGroups:
+  - ""
+  resourceNames:
+  - lightspeed-operator-metrics-reader-token
+  resources:
+  - secrets
+  verbs:
+  - get
+  - watch
+  - list

--- a/bundle/manifests/lightspeed-operator-prometheus-operator_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle/manifests/lightspeed-operator-prometheus-operator_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/name: rolebinding
+    app.kubernetes.io/part-of: lightspeed-operator
+  name: lightspeed-operator-prometheus-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: lightspeed-operator-prometheus-operator
+subjects:
+- kind: ServiceAccount
+  name: prometheus-operator
+  namespace: openshift-monitoring

--- a/config/prometheus/clusterrole_binding.yaml
+++ b/config/prometheus/clusterrole_binding.yaml
@@ -11,6 +11,7 @@ roleRef:
   kind: ClusterRole
   name: ols-metrics-reader
 subjects:
+
   - kind: ServiceAccount
-    name: prometheus-k8s
-    namespace: openshift-monitoring
+    name: metrics-reader
+    namespace: openshift-lightspeed

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -3,3 +3,5 @@ resources:
   - role_binding.yaml
   - clusterrole.yaml
   - clusterrole_binding.yaml
+  - service-account.yaml
+  - secret-sa-token.yaml

--- a/config/prometheus/role.yaml
+++ b/config/prometheus/role.yaml
@@ -34,3 +34,24 @@ rules:
       - get
       - list
       - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: role
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: lightspeed-operator
+  name: prometheus-operator
+  namespace: openshift-lightspeed
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    resourceNames:
+      - metrics-reader-token
+    verbs:
+      - get
+      - watch
+      - list

--- a/config/prometheus/role_binding.yaml
+++ b/config/prometheus/role_binding.yaml
@@ -15,3 +15,21 @@ subjects:
   - kind: ServiceAccount
     name: prometheus-k8s
     namespace: openshift-monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/name: rolebinding
+    app.kubernetes.io/part-of: lightspeed-operator
+  name: prometheus-operator
+  namespace: openshift-lightspeed
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-operator
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-operator
+    namespace: openshift-monitoring

--- a/config/prometheus/secret-sa-token.yaml
+++ b/config/prometheus/secret-sa-token.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: metrics-reader-token
+  namespace: openshift-lightspeed
+  annotations:
+    kubernetes.io/service-account.name: metrics-reader
+  labels:
+    app.kubernetes.io/name: service-account-token
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: lightspeed-operator

--- a/config/prometheus/service-account.yaml
+++ b/config/prometheus/service-account.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-reader
+  namespace: openshift-lightspeed
+  labels:
+    app.kubernetes.io/name: service-account
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: lightspeed-operator

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -248,4 +248,6 @@ ssl_ca_file = '/etc/certs/cm-olspostgresca/service-ca.crt'
 	OperatorNetworkPolicyName = "lightspeed-operator"
 	// OperatorMetricsPort is the port number of the operator metrics endpoint
 	OperatorMetricsPort = 8443
+	// MetricsReaderServiceAccountTokenSecretName is the name of the secret containing the service account token for the metrics reader
+	MetricsReaderServiceAccountTokenSecretName = "metrics-reader-token" // #nosec G101
 )

--- a/internal/controller/ols_app_server_assets.go
+++ b/internal/controller/ols_app_server_assets.go
@@ -503,7 +503,15 @@ func (r *OLSConfigReconciler) generateServiceMonitor(cr *olsv1alpha1.OLSConfig) 
 							ServerName:         &serverName,
 						},
 					},
-					BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+					Authorization: &monv1.SafeAuthorization{
+						Type: "Bearer",
+						Credentials: &corev1.SecretKeySelector{
+							Key: "token",
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: MetricsReaderServiceAccountTokenSecretName,
+							},
+						},
+					},
 				},
 			},
 			JobLabel: "app.kubernetes.io/name",

--- a/internal/controller/ols_app_server_assets_test.go
+++ b/internal/controller/ols_app_server_assets_test.go
@@ -1308,7 +1308,15 @@ user_data_collector_config: {}
 						CertFile: "/etc/prometheus/secrets/metrics-client-certs/tls.crt",
 						KeyFile:  "/etc/prometheus/secrets/metrics-client-certs/tls.key",
 					},
-					BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+					Authorization: &monv1.SafeAuthorization{
+						Type: "Bearer",
+						Credentials: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: MetricsReaderServiceAccountTokenSecretName,
+							},
+							Key: "token",
+						},
+					},
 				},
 			))
 			Expect(serviceMonitor.Spec.Selector.MatchLabels).To(Equal(generateAppServerSelectorLabels()))

--- a/internal/controller/operator_reconciliator.go
+++ b/internal/controller/operator_reconciliator.go
@@ -52,7 +52,6 @@ func (r *OLSConfigReconciler) generateServiceMonitorForOperator() (*monv1.Servic
 							ServerName:         &serverName,
 						},
 					},
-					BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
 				},
 			},
 			JobLabel: "app.kubernetes.io/name",

--- a/internal/controller/operator_reconciliator_test.go
+++ b/internal/controller/operator_reconciliator_test.go
@@ -120,7 +120,6 @@ var _ = Describe("App server assets", func() {
 									ServerName:         &serverName,
 								},
 							},
-							BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
 						},
 					},
 					JobLabel: "app.kubernetes.io/name",


### PR DESCRIPTION
## Description

Replace BearerTokenSecret with Authorization field in ServiceMonitor.
A new service account is created to access metrics endpoints. All priveledges on service account `prometheus-k8s` is removed, only need pass the token to the SA `prometheus-operator`

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes # [OLS-1322](https://issues.redhat.com//browse/OLS-1322)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
