### PR TITLE
Add OCP 4.19 operator catalog indexfile

### DIFF
--- a/lightspeed-catalog-4.19/index.yaml
+++ b/lightspeed-catalog-4.19/index.yaml
@@ -6,8 +6,8 @@ icon:
 name: lightspeed-operator
 schema: olm.package
 ---
-image: registry.redhat.io/openshift-lightspeed-tech-preview/lightspeed-operator-bundle@sha256:a2522f874fd4a31c261897c4bf729d8505d4c9adc6aacca7efe244d986c48816
-name: lightspeed-operator.v0.3.5
+image: registry.redhat.io/openshift-lightspeed/lightspeed-operator-bundle@sha256:ad10cdce09322f5a2da43fb1b45d7952808b822a744c9c5a47f42ddd95fe9916
+name: lightspeed-operator.v1.0.0
 package: lightspeed-operator
 properties:
   - type: olm.gvk
@@ -18,7 +18,7 @@ properties:
   - type: olm.package
     value:
       packageName: lightspeed-operator
-      version: 0.3.5
+      version: 1.0.0
   - type: olm.csv.metadata
     value:
       annotations:
@@ -58,7 +58,7 @@ properties:
           ]
         capabilities: Basic Install
         console.openshift.io/operator-monitoring-default: "true"
-        createdAt: "2025-05-20T17:26:43Z"
+        createdAt: "2025-06-12T13:57:35Z"
         features.operators.openshift.io/cnf: "false"
         features.operators.openshift.io/cni: "false"
         features.operators.openshift.io/csi: "false"
@@ -374,18 +374,25 @@ properties:
         url: https://github.com/openshift/lightspeed-service
 relatedImages:
   - name: lightspeed-service-api
-    image: registry.redhat.io/openshift-lightspeed-tech-preview/lightspeed-service-api-rhel9@sha256:273ddd50b516092738eb5cf2ee69d87681e5a8dbfa8bb0a766f47ef3b1df3ffd
+    image: registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9@sha256:21cd7da3674c55e76caf60122a19419b4eda097388f148f8163712b81b4af1d8
   - name: lightspeed-console-plugin
-    image: registry.redhat.io/openshift-lightspeed-tech-preview/lightspeed-console-plugin-rhel9@sha256:07b3e4062afa2159afa5a43be22f62a7137ad793327f4c27da9ba3c44e75a1af
+    image: registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:77dbdaeaf49ac970d7a470960b75d4078efcedc1dd1182414b078bd790ee53ea
   - name: lightspeed-operator
-    image: registry.redhat.io/openshift-lightspeed-tech-preview/lightspeed-rhel9-operator@sha256:ff6c11d247307e4c70a6fd2a0b86ed2396c272520cd2fe3a0afb0f2c15dcc795
+    image: registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:ff6c11d247307e4c70a6fd2a0b86ed2396c272520cd2fe3a0afb0f2c15dcc795
   - name: lightspeed-operator-bundle
-    image: registry.redhat.io/openshift-lightspeed-tech-preview/lightspeed-operator-bundle@sha256:a2522f874fd4a31c261897c4bf729d8505d4c9adc6aacca7efe244d986c48816
+    image: registry.redhat.io/openshift-lightspeed/lightspeed-operator-bundle@sha256:ad10cdce09322f5a2da43fb1b45d7952808b822a744c9c5a47f42ddd95fe9916
 schema: olm.bundle
 ---
 schema: olm.channel
 package: lightspeed-operator
 name: alpha
 entries:
-  - name: lightspeed-operator.v0.3.5
-    skipRange: ">=0.1.0 <0.3.5"
+  - name: lightspeed-operator.v1.0.0
+    skipRange: ">=0.1.0 <1.0.0"
+---
+schema: olm.channel
+package: lightspeed-operator
+name: stable
+entries:
+  - name: lightspeed-operator.v1.0.0
+    skipRange: ">=0.1.0 <1.0.0"


### PR DESCRIPTION
## Description

Add OCP 4.19 operator catalog indexfile .
Generated using command :
` ./hack/snapshot_to_catalog.sh -s ols-vd4zh -b ols-bundle-z8tgw -c lightspeed-catalog-4.19/index.yaml -n alpha,stable -m`

## Type of change

- [ ] Refactor
- [ x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
