### PR TITLE
OLS-1915: In OLSConfig.spec.ols.rag, make indexPath and indexID optional

### DIFF
--- a/api/v1alpha1/olsconfig_types.go
+++ b/api/v1alpha1/olsconfig_types.go
@@ -125,13 +125,11 @@ type Storage struct {
 // RAGSpec defines how to retrieve a RAG databases.
 type RAGSpec struct {
 	// The path to the RAG database inside of the container image
-	// +kubebuilder:validation:Required
-	// +required
+	// +kubebuilder:default:="/rag/vector_db"
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Index Path in the Image"
 	IndexPath string `json:"indexPath,omitempty"`
 	// The Index ID of the RAG database
-	// +kubebuilder:validation:Required
-	// +required
+	// +kubebuilder:default:="vector_db_index"
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Index ID"
 	IndexID string `json:"indexID,omitempty"`
 	// The URL of the container image to use as a RAG source

--- a/bundle/manifests/ols.openshift.io_olsconfigs.yaml
+++ b/bundle/manifests/ols.openshift.io_olsconfigs.yaml
@@ -910,16 +910,16 @@ spec:
                             RAG source
                           type: string
                         indexID:
+                          default: vector_db_index
                           description: The Index ID of the RAG database
                           type: string
                         indexPath:
+                          default: /rag/vector_db
                           description: The path to the RAG database inside of the
                             container image
                           type: string
                       required:
                       - image
-                      - indexID
-                      - indexPath
                       type: object
                     type: array
                   storage:

--- a/config/crd/bases/ols.openshift.io_olsconfigs.yaml
+++ b/config/crd/bases/ols.openshift.io_olsconfigs.yaml
@@ -910,16 +910,16 @@ spec:
                             RAG source
                           type: string
                         indexID:
+                          default: vector_db_index
                           description: The Index ID of the RAG database
                           type: string
                         indexPath:
+                          default: /rag/vector_db
                           description: The path to the RAG database inside of the
                             container image
                           type: string
                       required:
                       - image
-                      - indexID
-                      - indexPath
                       type: object
                     type: array
                   storage:

--- a/docs/olsconfig-ols-openshift-io-v1alpha1.adoc
+++ b/docs/olsconfig-ols-openshift-io-v1alpha1.adoc
@@ -464,6 +464,7 @@ Type::
 
 Required::
   - `defaultModel`
+  - `defaultProvider`
 
 
 
@@ -1347,8 +1348,6 @@ Type::
 
 Required::
   - `image`
-  - `indexID`
-  - `indexPath`
 
 
 

--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -72,6 +72,21 @@ const (
 	// ConditionTimeoutEnvVar is the environment variable containing the condition check timeout in seconds
 	ConditionTimeoutEnvVar = "CONDITION_TIMEOUT"
 
+	// ServiceAnnotationKeyTLSSecret is the annotation key for TLS secret
+	ServiceAnnotationKeyTLSSecret = "service.beta.openshift.io/serving-cert-secret-name"
+	// TestSAName is the name of the test service account
+	TestSAName = "test-sa"
+	// TestSAOutsiderName is the name of the test service account for outsider tests
+	TestSAOutsiderName = "test-sa-outsider"
+	// QueryAccessClusterRole is the cluster role for query access
+	QueryAccessClusterRole = "lightspeed-operator-query-access"
+	// AppMetricsAccessClusterRole is the cluster role for app metrics access
+	AppMetricsAccessClusterRole = "lightspeed-operator-ols-metrics-reader"
+	// OLSRouteName is the name of the OLS route
+	OLSRouteName = "ols-route"
+	// InClusterHost is the in-cluster host for the lightspeed app server
+	InClusterHost = "lightspeed-app-server.openshift-lightspeed.svc.cluster.local"
+
 	// TestCACert is for testing additional CA certificate
 	TestCACert = `-----BEGIN CERTIFICATE-----
 MIIEMDCCAxigAwIBAgIJANqb7HHzA7AZMA0GCSqGSIb3DQEBCwUAMIGkMQswCQYD

--- a/test/e2e/rapidast_test.go
+++ b/test/e2e/rapidast_test.go
@@ -2,169 +2,57 @@ package e2e
 
 import (
 	"fmt"
-	"io"
 	"net/http"
-
 	"os"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	olsv1alpha1 "github.com/openshift/lightspeed-operator/api/v1alpha1"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = Describe("TLS activation - application", Ordered, Label("Rapidast"), func() {
-	const serviceAnnotationKeyTLSSecret = "service.beta.openshift.io/serving-cert-secret-name"
-	const testSAName = "test-sa"
-	const testSAOutsiderName = "test-sa-outsider"
-	const queryAccessClusterRole = "lightspeed-operator-query-access"
-	const appMetricsAccessClusterRole = "lightspeed-operator-ols-metrics-reader"
-	const olsRouteName = "ols-route"
-	var cr *olsv1alpha1.OLSConfig
+var _ = Describe("Rapidast", Ordered, Label("Rapidast"), func() {
+	var env *OLSTestEnvironment
 	var err error
-	var client *Client
-	var cleanUpFuncs []func()
-	var forwardHost string
-	var saToken string
 
 	BeforeAll(func() {
-		client, err = GetClient(nil)
+		By("Setting up OLS test environment")
+		env, err = SetupOLSTestEnvironment(nil)
 		Expect(err).NotTo(HaveOccurred())
-		By("Creating a OLSConfig CR")
-		cr, err = generateOLSConfig()
-		Expect(err).NotTo(HaveOccurred())
-		err = client.Create(cr)
-		Expect(err).NotTo(HaveOccurred())
-
-		var cleanUp func()
-
-		By("create a service account for OLS user")
-		cleanUp, err := client.CreateServiceAccount(OLSNameSpace, testSAName)
-		Expect(err).NotTo(HaveOccurred())
-		cleanUpFuncs = append(cleanUpFuncs, cleanUp)
-
-		By("create a role binding for OLS user accessing query API")
-		cleanUp, err = client.CreateClusterRoleBinding(OLSNameSpace, testSAName, queryAccessClusterRole)
-		Expect(err).NotTo(HaveOccurred())
-		cleanUpFuncs = append(cleanUpFuncs, cleanUp)
-
-		By("fetch the service account tokens")
-		saToken, err = client.GetServiceAccountToken(OLSNameSpace, testSAName)
-		Expect(err).NotTo(HaveOccurred())
-
-		By("wait for application server deployment rollout")
-		deployment := &appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      AppServerDeploymentName,
-				Namespace: OLSNameSpace,
-			},
-		}
-		err = client.WaitForDeploymentRollout(deployment)
-		Expect(err).NotTo(HaveOccurred())
-
-		By("forwarding the HTTPS port to a local port")
-
-		forwardHost, cleanUp, err = client.ForwardPort(AppServerServiceName, OLSNameSpace, AppServerServiceHTTPSPort)
-		Expect(err).NotTo(HaveOccurred())
-		cleanUpFuncs = append(cleanUpFuncs, cleanUp)
 	})
 
 	AfterAll(func() {
-		err = mustGather("rapidast_test")
+		By("Cleaning up OLS test environment with CR deletion")
+		err = CleanupOLSTestEnvironmentWithCRDeletion(env, "rapidast_test")
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("should activate TLS on service HTTPS port", func() {
-		By("Wait for the application service created")
-		service := &corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      AppServerServiceName,
-				Namespace: OLSNameSpace,
-			},
-		}
-		err = client.WaitForServiceCreated(service)
+	It("should activate OLS on service HTTPS port", func() {
+		By("Testing OLS service activation")
+		secret, err := TestOLSServiceActivation(env)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("check the secret holding TLS certificates is created")
-		secretName, ok := service.ObjectMeta.Annotations[serviceAnnotationKeyTLSSecret]
-		Expect(ok).To(BeTrue())
-		secret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      secretName,
-				Namespace: OLSNameSpace,
-			},
-		}
-		err = client.WaitForSecretCreated(secret)
-		Expect(err).NotTo(HaveOccurred())
-
-		By("check the deployment has the certificate secret mounted")
-		deployment := &appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      AppServerDeploymentName,
-				Namespace: OLSNameSpace,
-			},
-		}
-		err = client.Get(deployment)
-		Expect(err).NotTo(HaveOccurred())
-		secretVolumeDefaultMode := int32(420)
-		Expect(deployment.Spec.Template.Spec.Volumes).To(ContainElement(corev1.Volume{
-			Name: "secret-" + AppServerTLSSecretName,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName:  secretName,
-					DefaultMode: &secretVolumeDefaultMode,
-				},
-			},
-		}))
-
-		By("check HTTPS Post on /v1/query endpoint by OLS user")
-		const inClusterHost = "lightspeed-app-server.openshift-lightspeed.svc.cluster.local"
-		certificate, ok := secret.Data["tls.crt"]
-		Expect(ok).To(BeTrue())
-		httpsClient := NewHTTPSClient(forwardHost, inClusterHost, certificate, nil, nil)
-		authHeader := map[string]string{"Authorization": "Bearer " + saToken}
+		By("Testing HTTPS POST on /v1/query endpoint by OLS user")
 		reqBody := []byte(`{"query": "write a deployment yaml for the mongodb image"}`)
-		var resp *http.Response
-		resp, err = httpsClient.PostJson("/v1/query", reqBody, authHeader)
-		fmt.Println("httpsClient.PostJson", authHeader)
+		resp, body, err := TestHTTPSQueryEndpoint(env, secret, reqBody)
+		fmt.Println("httpsClient.PostJson", map[string]string{"Authorization": "Bearer " + env.SAToken})
 		Expect(err).NotTo(HaveOccurred())
 		defer resp.Body.Close()
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
-		body, err := io.ReadAll(resp.Body)
 		fmt.Println(string(body))
-
-		Expect(err).NotTo(HaveOccurred())
 		Expect(body).NotTo(BeEmpty())
 
-		// Get console url from Environment
-		consoleURL := os.Getenv("CONSOLE_URL")
-		Expect(consoleURL).To(ContainSubstring(".apps"))
-		//create ols application host url
-		//trim everything before the first dot and append it to ols-route
-		index := strings.Index(consoleURL, ".apps")
-		hostURL := olsRouteName + consoleURL[index:]
-
-		By("Create a route for the OLS application")
-		_, err = client.createRoute(olsRouteName, OLSNameSpace, hostURL)
+		By("Creating a route for the OLS application")
+		err = CreateOLSRoute(env.Client)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Update ols-rapidast-config-updated.yaml with host and token")
-		config_content, err := os.ReadFile("../../ols-rapidast-config.yaml")
-		if err != nil {
-			fmt.Println("Error reading file:", err)
-			return
-		}
+		By("Updating ols-rapidast-config-updated.yaml with host and token")
+		// Get console URL from Environment and create host URL
+		consoleURL := os.Getenv("CONSOLE_URL")
+		Expect(consoleURL).To(ContainSubstring(".apps"))
+		index := strings.Index(consoleURL, ".apps")
+		hostURL := OLSRouteName + consoleURL[index:]
 
-		newContent := strings.Replace(string(config_content), "$HOST", hostURL, -1)
-		newContent = strings.Replace(newContent, "$BEARER_TOKEN", saToken, -1)
-		err = os.WriteFile("../../ols-rapidast-config-updated.yaml", []byte(newContent), 0644)
-		if err != nil {
-			fmt.Println("Error writing file:", err)
-			return
-		}
-
+		err = UpdateRapidastConfig(hostURL, env.SAToken)
+		Expect(err).NotTo(HaveOccurred())
 	})
 })


### PR DESCRIPTION
## Description

- Made the BYOK portion of the OLSConfig require just the image, as in
```
  ols: 
    rag: 
    - image: quay.io/foobar/assisted-installer-guide:2025-1
    - image: quay.io/barfoo/acme-ocp-sop:123
```
, default indexPath to `/rag/vector_db` and indexID to `vector_db_index`.
This corresponds to how the BYOK tool generates custom RAG images.
- Added an E2E test of BYOK.
- The https://github.com/openshift/lightspeed-operator/pull/845/commits/f6230a186de8638a998e5413150633552df5bb71 commit is AI-generated.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes # https://issues.redhat.com/browse/OLS-1915

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
