### PR TITLE
Adding quota type to CR Info UI.

### DIFF
--- a/api/v1alpha1/olsconfig_types.go
+++ b/api/v1alpha1/olsconfig_types.go
@@ -157,7 +157,7 @@ type LimiterConfig struct {
 	// Name of the limiter
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Limiter Name"
 	Name string `json:"name"`
-	// Type of the limiter
+	// Type of the limiter. Valid values are "user_limiter" and "cluster_limiter"
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Limiter Type"
 	Type string `json:"type"`
 	// Initial value of the token quota

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -24,7 +24,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=lightspeed-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
 LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.33.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.36.1
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 
@@ -52,10 +52,10 @@ LABEL io.k8s.description="Red Hat OpenShift Lightspeed - AI assistant for managi
 LABEL io.k8s.display-name="Openshift Lightspeed"
 LABEL io.openshift.tags="openshift,lightspeed,ai,assistant"
 LABEL name=openshift-lightspeed
-LABEL release=1.0.1
+LABEL release=0.0.1
 LABEL url="https://github.com/openshift/lightspeed-operator"
 LABEL vendor="Red Hat, Inc."
-LABEL version=1.0.1
+LABEL version=0.0.1
 LABEL summary="Red Hat OpenShift Lightspeed"
 
 # OCP compatibility labels

--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
       ]
     capabilities: Basic Install
     console.openshift.io/operator-monitoring-default: "true"
-    createdAt: "2025-07-09T07:45:59Z"
+    createdAt: "2025-07-14T21:19:09Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -52,10 +52,10 @@ metadata:
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-lightspeed
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus", "OpenShift Kubernetes Engine", "OpenShift Virtualization Engine"]'
-    operators.operatorframework.io/builder: operator-sdk-v1.33.0
+    operators.operatorframework.io/builder: operator-sdk-v1.36.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/openshift/lightspeed-operator
-  name: lightspeed-operator.v1.0.1
+  name: lightspeed-operator.v0.0.1
   namespace: openshift-lightspeed
 spec:
   apiservicedefinitions: {}
@@ -240,7 +240,9 @@ spec:
           - description: The configmap holding proxy CA certificate
             displayName: Proxy CA Certificate
             path: ols.proxyConfig.proxyCACertificate
-          - description: Proxy URL, e.g. https://proxy.example.com:8080 If not specified, the cluster wide proxy will be used, though env var "https_proxy".
+          - description: |-
+              Proxy URL, e.g. https://proxy.example.com:8080
+              If not specified, the cluster wide proxy will be used, though env var "https_proxy".
             displayName: Proxy URL
             path: ols.proxyConfig.proxyURL
           - description: Query filters
@@ -280,7 +282,7 @@ spec:
           - description: Token quota increase step
             displayName: Token Quota Increase Step
             path: ols.quotaHandlersConfig.limitersConfig[0].quotaIncrease
-          - description: Type of the limiter
+          - description: Type of the limiter. Valid values are "user_limiter" and "cluster_limiter"
             displayName: Limiter Type
             path: ols.quotaHandlersConfig.limitersConfig[0].type
           - description: RAG databases
@@ -664,7 +666,7 @@ spec:
   provider:
     name: Red Hat, Inc
     url: https://github.com/openshift/lightspeed-service
-  version: 1.0.1
+  version: 0.0.1
   relatedImages:
     - name: lightspeed-service-api
       image: quay.io/openshift-lightspeed/lightspeed-service-api:latest

--- a/bundle/manifests/ols.openshift.io_olsconfigs.yaml
+++ b/bundle/manifests/ols.openshift.io_olsconfigs.yaml
@@ -886,7 +886,11 @@ spec:
                               minimum: 0
                               type: integer
                             type:
-                              description: Type of the limiter
+                              description: Type of the limiter. Valid values are "user_limiter"
+                                and "cluster_limiter"
+                              enum:
+                              - user_limiter
+                              - cluster_limiter
                               type: string
                           required:
                           - initialQuota

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: lightspeed-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
   operators.operatorframework.io.bundle.channel.default.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.33.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.36.1
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
   # Annotations for testing.

--- a/config/crd/bases/ols.openshift.io_olsconfigs.yaml
+++ b/config/crd/bases/ols.openshift.io_olsconfigs.yaml
@@ -886,7 +886,11 @@ spec:
                               minimum: 0
                               type: integer
                             type:
-                              description: Type of the limiter
+                              description: Type of the limiter. Valid values are "user_limiter"
+                                and "cluster_limiter"
+                              enum:
+                              - user_limiter
+                              - cluster_limiter
                               type: string
                           required:
                           - initialQuota

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,32 +1,28 @@
 # Adds namespace to all resources.
 namespace: openshift-lightspeed
-
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
 namePrefix: lightspeed-operator-
-
 # Labels to add to all resources and selectors.
 #labels:
 #- includeSelectors: true
 #  pairs:
 #    someName: someValue
-
 resources:
-- ../crd
-- ../rbac
-- ../manager
-- ../user-access
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
-# crd/kustomization.yaml
-#- ../webhook
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-#- ../certmanager
-# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-- ../prometheus
-
+  - ../crd
+  - ../rbac
+  - ../manager
+  - ../user-access
+  # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
+  # crd/kustomization.yaml
+  #- ../webhook
+  # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
+  #- ../certmanager
+  # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
+  - ../prometheus
 patches:
   # set image of lightspeed-service-api
   # todo: sync with the release version of openshift/lightspeed-service-api
@@ -48,7 +44,6 @@ patches:
       version: v1
       kind: Deployment
       name: controller-manager
-
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- manager_webhook_patch.yaml

--- a/config/manifests/bases/lightspeed-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/lightspeed-operator.clusterserviceversion.yaml
@@ -211,8 +211,9 @@ spec:
       - description: The configmap holding proxy CA certificate
         displayName: Proxy CA Certificate
         path: ols.proxyConfig.proxyCACertificate
-      - description: Proxy URL, e.g. https://proxy.example.com:8080 If not specified,
-          the cluster wide proxy will be used, though env var "https_proxy".
+      - description: |-
+          Proxy URL, e.g. https://proxy.example.com:8080
+          If not specified, the cluster wide proxy will be used, though env var "https_proxy".
         displayName: Proxy URL
         path: ols.proxyConfig.proxyURL
       - description: Query filters
@@ -252,7 +253,7 @@ spec:
       - description: Token quota increase step
         displayName: Token Quota Increase Step
         path: ols.quotaHandlersConfig.limitersConfig[0].quotaIncrease
-      - description: Type of the limiter
+      - description: Type of the limiter. Valid values are "user_limiter" and "cluster_limiter"
         displayName: Limiter Type
         path: ols.quotaHandlersConfig.limitersConfig[0].type
       - description: RAG databases


### PR DESCRIPTION
## Description

In order to give information about the two allowed types for the quota limiter, the description of that field has been changed.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue : [OLS-1827](https://issues.redhat.com/browse/OLS-1827)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
To test the fix, the description on the UI for the OLSConfig CR can be manually checked.

- How were the fix/results from this change verified? Please provide relevant screenshots or results.
<img width="874" height="111" alt="image" src="https://github.com/user-attachments/assets/f14a9916-6aab-4660-910d-3d82b07cc8e4" />

