### PR TITLE
 OLS-1827: Adding UI description for quota type.

### DIFF
--- a/api/v1alpha1/olsconfig_types.go
+++ b/api/v1alpha1/olsconfig_types.go
@@ -158,7 +158,7 @@ type LimiterConfig struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Limiter Name"
 	Name string `json:"name"`
 	// Type of the limiter
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Limiter Type"
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Limiter Type. Accepted Values: cluster_limiter, user_limiter."
 	Type string `json:"type"`
 	// Initial value of the token quota
 	// +kubebuilder:validation:Minimum=0

--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -281,7 +281,7 @@ spec:
             displayName: Token Quota Increase Step
             path: ols.quotaHandlersConfig.limitersConfig[0].quotaIncrease
           - description: Type of the limiter
-            displayName: Limiter Type
+            displayName: 'Limiter Type. Accepted Values: cluster_limiter, user_limiter.'
             path: ols.quotaHandlersConfig.limitersConfig[0].type
           - description: RAG databases
             displayName: RAG Databases


### PR DESCRIPTION
## Description

In order to give information about the two allowed types for the quota limiter, the description of that field has been changed.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue : [OLS-1827](https://issues.redhat.com/browse/OLS-1827)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
To test the fix, the description on the UI for the OLSConfig CR can be manually checked.

- How were the fix/results from this change verified? Please provide relevant screenshots or results.
<img width="874" height="111" alt="image" src="https://github.com/user-attachments/assets/f14a9916-6aab-4660-910d-3d82b07cc8e4" />
## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
