### PR TITLE
fix: make the directory release-konflux/ when creating release objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -409,4 +409,5 @@ update-bundle-catalog: opm yq
 # Genarate release objects for Konflux builds
 .PHONY: konflux-release
 konflux-release: kustomize yq
+	mkdir -p release-konflux
 	$(KUSTOMIZE) build hack/release-konflux | $(YQ) -s '"release-konflux/" + .metadata.name'


### PR DESCRIPTION
## Description

some yq version cannot create the directory

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
