### PR TITLE
OLS-1956: In OLSConfig.spec.ols.rag, add a field for ImagePullPolicy

### DIFF
--- a/api/v1alpha1/olsconfig_types.go
+++ b/api/v1alpha1/olsconfig_types.go
@@ -137,6 +137,10 @@ type RAGSpec struct {
 	// +required
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Image"
 	Image string `json:"image,omitempty"`
+	// Image pull policy for the RAG container image
+	// +kubebuilder:default="Always"
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Image Pull Policy"
+	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 }
 
 // QuotaHandlersConfig defines the token quota configuration

--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
       ]
     capabilities: Basic Install
     console.openshift.io/operator-monitoring-default: "true"
-    createdAt: "2025-07-09T07:45:59Z"
+    createdAt: "2025-07-24T00:34:29Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -55,7 +55,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/openshift/lightspeed-operator
-  name: lightspeed-operator.v1.0.2
+  name: lightspeed-operator.v0.0.1
   namespace: openshift-lightspeed
 spec:
   apiservicedefinitions: {}
@@ -291,6 +291,9 @@ spec:
           - description: The URL of the container image to use as a RAG source
             displayName: Image
             path: ols.rag[0].image
+          - description: Image pull policy for the RAG container image
+            displayName: Image Pull Policy
+            path: ols.rag[0].imagePullPolicy
           - description: The Index ID of the RAG database
             displayName: Index ID
             path: ols.rag[0].indexID
@@ -664,7 +667,7 @@ spec:
   provider:
     name: Red Hat, Inc
     url: https://github.com/openshift/lightspeed-service
-  version: 1.0.2
+  version: 0.0.1
   relatedImages:
     - name: lightspeed-service-api
       image: quay.io/openshift-lightspeed/lightspeed-service-api:latest

--- a/bundle/manifests/ols.openshift.io_olsconfigs.yaml
+++ b/bundle/manifests/ols.openshift.io_olsconfigs.yaml
@@ -911,6 +911,10 @@ spec:
                           description: The URL of the container image to use as a
                             RAG source
                           type: string
+                        imagePullPolicy:
+                          default: IfNotPresent
+                          description: Image pull policy for the RAG container image
+                          type: string
                         indexID:
                           default: vector_db_index
                           description: The Index ID of the RAG database

--- a/config/crd/bases/ols.openshift.io_olsconfigs.yaml
+++ b/config/crd/bases/ols.openshift.io_olsconfigs.yaml
@@ -911,6 +911,10 @@ spec:
                           description: The URL of the container image to use as a
                             RAG source
                           type: string
+                        imagePullPolicy:
+                          default: Always
+                          description: Image pull policy for the RAG container image
+                          type: string
                         indexID:
                           default: vector_db_index
                           description: The Index ID of the RAG database

--- a/config/manifests/bases/lightspeed-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/lightspeed-operator.clusterserviceversion.yaml
@@ -253,7 +253,7 @@ spec:
         displayName: Token Quota Increase Step
         path: ols.quotaHandlersConfig.limitersConfig[0].quotaIncrease
       - description: Type of the limiter
-        displayName: Limiter Type
+        displayName: 'Limiter Type. Accepted Values: cluster_limiter, user_limiter.'
         path: ols.quotaHandlersConfig.limitersConfig[0].type
       - description: RAG databases
         displayName: RAG Databases
@@ -263,6 +263,9 @@ spec:
       - description: The URL of the container image to use as a RAG source
         displayName: Image
         path: ols.rag[0].image
+      - description: Image pull policy for the RAG container image
+        displayName: Image Pull Policy
+        path: ols.rag[0].imagePullPolicy
       - description: The Index ID of the RAG database
         displayName: Index ID
         path: ols.rag[0].indexID

--- a/docs/olsconfig-ols-openshift-io-v1alpha1.adoc
+++ b/docs/olsconfig-ols-openshift-io-v1alpha1.adoc
@@ -652,6 +652,10 @@ Type::
 | `object`
 | Data Collector container settings.
 
+| `database`
+| `object`
+| Database container settings.
+
 | `replicas`
 | `integer`
 | Defines the number of desired OLS pods. Default: "1"
@@ -1144,6 +1148,189 @@ If empty, everything from the claim is made available, otherwise
 only the result of this request.
 
 |===
+== .spec.ols.deployment.database
+Description::
++
+--
+Database container settings.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `nodeSelector`
+| `object (string)`
+| 
+
+| `resources`
+| `object`
+| ResourceRequirements describes the compute resource requirements.
+
+| `tolerations`
+| `array`
+| 
+
+
+|===
+== .spec.ols.deployment.database.resources
+Description::
++
+--
+ResourceRequirements describes the compute resource requirements.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `claims`
+| `array`
+| Claims lists the names of resources, defined in spec.resourceClaims,
+that are used by this container.
+
+This is an alpha field and requires enabling the
+DynamicResourceAllocation feature gate.
+
+This field is immutable. It can only be set for containers.
+
+| `limits`
+| `integer-or-string`
+| Limits describes the maximum amount of compute resources allowed.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+| `requests`
+| `integer-or-string`
+| Requests describes the minimum amount of compute resources required.
+If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+otherwise to an implementation-defined value. Requests cannot exceed Limits.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+|===
+== .spec.ols.deployment.database.resources.claims
+Description::
++
+--
+Claims lists the names of resources, defined in spec.resourceClaims,
+that are used by this container.
+
+This is an alpha field and requires enabling the
+DynamicResourceAllocation feature gate.
+
+This field is immutable. It can only be set for containers.
+--
+
+Type::
+  `array`
+
+
+
+
+== .spec.ols.deployment.database.resources.claims[]
+Description::
++
+--
+ResourceClaim references one entry in PodSpec.ResourceClaims.
+--
+
+Type::
+  `object`
+
+Required::
+  - `name`
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `name`
+| `string`
+| Name must match the name of one entry in pod.spec.resourceClaims of
+the Pod where this field is used. It makes that resource available
+inside a container.
+
+| `request`
+| `string`
+| Request is the name chosen for a request in the referenced claim.
+If empty, everything from the claim is made available, otherwise
+only the result of this request.
+
+|===
+== .spec.ols.deployment.database.tolerations
+Description::
++
+--
+
+--
+
+Type::
+  `array`
+
+
+
+
+== .spec.ols.deployment.database.tolerations[]
+Description::
++
+--
+The pod this Toleration is attached to tolerates any taint that matches
+the triple <key,value,effect> using the matching operator <operator>.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `effect`
+| `string`
+| Effect indicates the taint effect to match. Empty means match all taint effects.
+When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+| `key`
+| `string`
+| Key is the taint key that the toleration applies to. Empty means match all taint keys.
+If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+
+| `operator`
+| `string`
+| Operator represents a key's relationship to the value.
+Valid operators are Exists and Equal. Defaults to Equal.
+Exists is equivalent to wildcard for value, so that a pod can
+tolerate all taints of a particular category.
+
+| `tolerationSeconds`
+| `integer`
+| TolerationSeconds represents the period of time the toleration (which must be
+of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+it is not set, which means tolerate the taint forever (do not evict). Zero and
+negative values will be treated as 0 (evict immediately) by the system.
+
+| `value`
+| `string`
+| Value is the taint value the toleration matches to.
+If the operator is Exists, the value should be empty, otherwise just a regular string.
+
+|===
 == .spec.ols.proxyConfig
 Description::
 +
@@ -1358,6 +1545,10 @@ Required::
 | `image`
 | `string`
 | The URL of the container image to use as a RAG source
+
+| `imagePullPolicy`
+| `string`
+| Image pull policy for the RAG container image
 
 | `indexID`
 | `string`

--- a/internal/controller/rag.go
+++ b/internal/controller/rag.go
@@ -25,7 +25,7 @@ func (r *OLSConfigReconciler) generateRAGInitContainers(cr *olsv1alpha1.OLSConfi
 		initContainers = append(initContainers, corev1.Container{
 			Name:            ragName,
 			Image:           rag.Image,
-			ImagePullPolicy: corev1.PullIfNotPresent,
+			ImagePullPolicy: rag.ImagePullPolicy,
 			Command:         []string{"sh", "-c", fmt.Sprintf("mkdir -p %s && cp -a %s/. %s", path.Join(RAGVolumeMountPath, ragName), rag.IndexPath, path.Join(RAGVolumeMountPath, ragName))},
 			VolumeMounts: []corev1.VolumeMount{
 				{

--- a/internal/controller/rag_test.go
+++ b/internal/controller/rag_test.go
@@ -32,14 +32,16 @@ var _ = Describe("App server assets", func() {
 			}
 			cr.Spec.OLSConfig.RAG = []olsv1alpha1.RAGSpec{
 				{
-					Image:     "rag-image-1",
-					IndexPath: "/path/to/index-1",
-					IndexID:   "index-id-1",
+					Image:           "rag-image-1",
+					IndexPath:       "/path/to/index-1",
+					IndexID:         "index-id-1",
+					ImagePullPolicy: corev1.PullAlways, // Simulate CRD default
 				},
 				{
-					Image:     "rag-image-2",
-					IndexPath: "/path/to/index-2",
-					IndexID:   "index-id-2",
+					Image:           "rag-image-2",
+					IndexPath:       "/path/to/index-2",
+					IndexID:         "index-id-2",
+					ImagePullPolicy: corev1.PullAlways, // Simulate CRD default
 				},
 			}
 		})
@@ -47,7 +49,35 @@ var _ = Describe("App server assets", func() {
 		AfterEach(func() {
 		})
 
-		It("should generate initContainer for each RAG", func() {
+		It("should generate initContainer for each RAG with default ImagePullPolicy", func() {
+			initContainers := r.generateRAGInitContainers(cr)
+			Expect(initContainers).To(HaveLen(2))
+			Expect(initContainers[0]).To(MatchFields(IgnoreExtras, Fields{
+				"Name":            Equal("rag-0"),
+				"Image":           Equal("rag-image-1"),
+				"ImagePullPolicy": Equal(corev1.PullAlways),
+				"Command":         Equal([]string{"sh", "-c", "mkdir -p /rag-data/rag-0 && cp -a /path/to/index-1/. /rag-data/rag-0"}),
+				"VolumeMounts": ConsistOf(corev1.VolumeMount{
+					Name:      RAGVolumeName,
+					MountPath: "/rag-data",
+				}),
+			}))
+			Expect(initContainers[1]).To(MatchFields(IgnoreExtras, Fields{
+				"Name":            Equal("rag-1"),
+				"Image":           Equal("rag-image-2"),
+				"ImagePullPolicy": Equal(corev1.PullAlways),
+				"Command":         Equal([]string{"sh", "-c", "mkdir -p /rag-data/rag-1 && cp -a /path/to/index-2/. /rag-data/rag-1"}),
+				"VolumeMounts": ConsistOf(corev1.VolumeMount{
+					Name:      RAGVolumeName,
+					MountPath: "/rag-data",
+				}),
+			}))
+		})
+
+		It("should generate initContainer with custom ImagePullPolicy", func() {
+			cr.Spec.OLSConfig.RAG[0].ImagePullPolicy = corev1.PullIfNotPresent
+			cr.Spec.OLSConfig.RAG[1].ImagePullPolicy = corev1.PullNever
+
 			initContainers := r.generateRAGInitContainers(cr)
 			Expect(initContainers).To(HaveLen(2))
 			Expect(initContainers[0]).To(MatchFields(IgnoreExtras, Fields{
@@ -63,7 +93,7 @@ var _ = Describe("App server assets", func() {
 			Expect(initContainers[1]).To(MatchFields(IgnoreExtras, Fields{
 				"Name":            Equal("rag-1"),
 				"Image":           Equal("rag-image-2"),
-				"ImagePullPolicy": Equal(corev1.PullIfNotPresent),
+				"ImagePullPolicy": Equal(corev1.PullNever),
 				"Command":         Equal([]string{"sh", "-c", "mkdir -p /rag-data/rag-1 && cp -a /path/to/index-2/. /rag-data/rag-1"}),
 				"VolumeMounts": ConsistOf(corev1.VolumeMount{
 					Name:      RAGVolumeName,


### PR DESCRIPTION
## Description

Add a field for ImagePullPolicy in OLSConfig.spec.ols.rag with default of "Always".

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes # https://issues.redhat.com/browse/OLS-1956

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
