### PR TITLE
OLS-1956: Change the ImagePullPolicy for BYOK images to PullAlways

### DIFF
--- a/internal/controller/ols_app_server_assets_test.go
+++ b/internal/controller/ols_app_server_assets_test.go
@@ -950,7 +950,7 @@ var _ = Describe("App server assets", func() {
 							MountPath: RAGVolumeMountPath,
 						},
 					},
-					ImagePullPolicy: corev1.PullIfNotPresent,
+					ImagePullPolicy: corev1.PullAlways,
 				},
 				corev1.Container{
 					Name:    "rag-1",
@@ -962,7 +962,7 @@ var _ = Describe("App server assets", func() {
 							MountPath: RAGVolumeMountPath,
 						},
 					},
-					ImagePullPolicy: corev1.PullIfNotPresent,
+					ImagePullPolicy: corev1.PullAlways,
 				},
 			))
 		})

--- a/internal/controller/ols_app_server_deployment.go
+++ b/internal/controller/ols_app_server_deployment.go
@@ -279,7 +279,7 @@ func (r *OLSConfigReconciler) generateOLSDeployment(cr *olsv1alpha1.OLSConfig) (
 						{
 							Name:            "lightspeed-service-api",
 							Image:           r.Options.LightspeedServiceImage,
-							ImagePullPolicy: corev1.PullIfNotPresent,
+							ImagePullPolicy: corev1.PullAlways,
 							Ports:           ports,
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: &[]bool{false}[0],
@@ -347,7 +347,7 @@ func (r *OLSConfigReconciler) generateOLSDeployment(cr *olsv1alpha1.OLSConfig) (
 	telemetryContainer := corev1.Container{
 		Name:            "lightspeed-service-user-data-collector",
 		Image:           r.Options.LightspeedServiceImage,
-		ImagePullPolicy: corev1.PullIfNotPresent,
+		ImagePullPolicy: corev1.PullAlways,
 		SecurityContext: &corev1.SecurityContext{
 			AllowPrivilegeEscalation: &[]bool{false}[0],
 			ReadOnlyRootFilesystem:   &[]bool{true}[0],

--- a/internal/controller/rag.go
+++ b/internal/controller/rag.go
@@ -25,7 +25,7 @@ func (r *OLSConfigReconciler) generateRAGInitContainers(cr *olsv1alpha1.OLSConfi
 		initContainers = append(initContainers, corev1.Container{
 			Name:            ragName,
 			Image:           rag.Image,
-			ImagePullPolicy: corev1.PullIfNotPresent,
+			ImagePullPolicy: corev1.PullAlways,
 			Command:         []string{"sh", "-c", fmt.Sprintf("mkdir -p %s && cp -a %s/. %s", path.Join(RAGVolumeMountPath, ragName), rag.IndexPath, path.Join(RAGVolumeMountPath, ragName))},
 			VolumeMounts: []corev1.VolumeMount{
 				{

--- a/internal/controller/rag_test.go
+++ b/internal/controller/rag_test.go
@@ -53,7 +53,7 @@ var _ = Describe("App server assets", func() {
 			Expect(initContainers[0]).To(MatchFields(IgnoreExtras, Fields{
 				"Name":            Equal("rag-0"),
 				"Image":           Equal("rag-image-1"),
-				"ImagePullPolicy": Equal(corev1.PullIfNotPresent),
+				"ImagePullPolicy": Equal(corev1.PullAlways),
 				"Command":         Equal([]string{"sh", "-c", "mkdir -p /rag-data/rag-0 && cp -a /path/to/index-1/. /rag-data/rag-0"}),
 				"VolumeMounts": ConsistOf(corev1.VolumeMount{
 					Name:      RAGVolumeName,
@@ -63,7 +63,7 @@ var _ = Describe("App server assets", func() {
 			Expect(initContainers[1]).To(MatchFields(IgnoreExtras, Fields{
 				"Name":            Equal("rag-1"),
 				"Image":           Equal("rag-image-2"),
-				"ImagePullPolicy": Equal(corev1.PullIfNotPresent),
+				"ImagePullPolicy": Equal(corev1.PullAlways),
 				"Command":         Equal([]string{"sh", "-c", "mkdir -p /rag-data/rag-1 && cp -a /path/to/index-2/. /rag-data/rag-1"}),
 				"VolumeMounts": ConsistOf(corev1.VolumeMount{
 					Name:      RAGVolumeName,


### PR DESCRIPTION
## Description

For BYOK images with floating tags, such as `latest`, the OLS can not reload even after a restart because of the hardcoded ImagePullPolicy of PullIfNotPresent. Changing the ImagePullPolicy to PullAlways resolved this issue. Now the BYOK images will always be pulled from the container registry every time OLS starts.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes # https://issues.redhat.com/browse/OLS-1956

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
