### PR TITLE
OLS-1915: added a BYOK e2e test

### DIFF
--- a/test/e2e/byok_test.go
+++ b/test/e2e/byok_test.go
@@ -1,0 +1,57 @@
+package e2e
+
+import (
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	olsv1alpha1 "github.com/openshift/lightspeed-operator/api/v1alpha1"
+)
+
+var _ = Describe("BYOK", Ordered, Label("BYOK"), func() {
+	var env *OLSTestEnvironment
+	var err error
+
+	BeforeAll(func() {
+		By("Setting up OLS test environment with RAG configuration")
+		env, err = SetupOLSTestEnvironment(func(cr *olsv1alpha1.OLSConfig) {
+			cr.Spec.OLSConfig.RAG = []olsv1alpha1.RAGSpec{
+				{
+					Image: "quay.io/openshift-lightspeed-test/assisted-installer-guide:2025-1",
+				},
+			}
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterAll(func() {
+		By("Cleaning up OLS test environment with CR deletion")
+		err = CleanupOLSTestEnvironmentWithCRDeletion(env, "byok_test")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should query the BYOK database", func() {
+		By("Testing OLS service activation")
+		secret, err := TestOLSServiceActivation(env)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Testing HTTPS POST on /v1/query endpoint by OLS user")
+		reqBody := []byte(`{"query": "what CPU architectures does the assisted installer support?"}`)
+		resp, body, err := TestHTTPSQueryEndpoint(env, secret, reqBody)
+		fmt.Println("httpsClient.PostJson", map[string]string{"Authorization": "Bearer " + env.SAToken})
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		fmt.Println(string(body))
+
+		Expect(string(body)).To(
+			And(
+				ContainSubstring("x86_64"),
+				ContainSubstring("arm64"),
+				ContainSubstring("ppc64le"),
+				ContainSubstring("s390x"),
+			),
+		)
+	})
+})


### PR DESCRIPTION
## Description

Added an e2e test to verify that specifying only the image is now sufficient for BYOK images.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # https://issues.redhat.com/browse/OLS-1915
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
