### PR TITLE
OLS-1870: Verify OLS service can continue to run after Postgres pod restart

### DIFF
--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -126,4 +126,7 @@ zl/HHk484IkzlQsPpTLWPFp5LBk=
 	CertBundleVolumeName = "cert-bundle"
 	// CertBundleDir is the path of the volume for the certificate bundle
 	CertBundleDir = "cert-bundle"
+
+	// PostgresDeploymentName is the name of OLS application Postgres deployment
+	PostgresDeploymentName = "lightspeed-postgres-server"
 )

--- a/test/e2e/postgres_restart_test.go
+++ b/test/e2e/postgres_restart_test.go
@@ -1,0 +1,126 @@
+package e2e
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func invokeOLS(env *OLSTestEnvironment, secret *corev1.Secret, query string, expected_success bool) {
+	reqBody := []byte(`{"query": "` + query + `"}`)
+	resp, body, err := TestHTTPSQueryEndpoint(env, secret, reqBody)
+	Expect(err).NotTo(HaveOccurred())
+	defer resp.Body.Close()
+	fmt.Println(GinkgoWriter, string(body))
+	Expect(resp.StatusCode == http.StatusOK).To(Equal(expected_success))
+}
+
+func waitForPodsToDisappear(env *OLSTestEnvironment, namespace, labelKey, labelValue string) error {
+	listOpts := []client.ListOption{
+		client.InNamespace(namespace),
+		client.MatchingLabels{labelKey: labelValue},
+	}
+	// Give up after 5 minutes
+	for i := 0; i < 60; i++ {
+		var podList corev1.PodList
+		if err := env.Client.List(&podList, listOpts...); err != nil {
+			return err
+		}
+		if len(podList.Items) == 0 {
+			return nil
+		}
+		for _, pod := range podList.Items {
+			fmt.Fprintf(GinkgoWriter, "Pod %s phase: %s\n", pod.Name, pod.Status.Phase)
+		}
+		time.Sleep(5 * time.Second)
+	}
+	return fmt.Errorf(
+		"timed out waiting for deletion of the pods with label key %s and value %s in namespace %s",
+		labelKey, labelValue, namespace)
+}
+
+func shutdownPostgres(env *OLSTestEnvironment) {
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      PostgresDeploymentName,
+			Namespace: OLSNameSpace,
+		},
+	}
+	err := env.Client.Get(deployment)
+	Expect(err).NotTo(HaveOccurred())
+	deployment.Spec.Replicas = Ptr(int32(0))
+	err = env.Client.Update(deployment)
+	Expect(err).NotTo(HaveOccurred())
+	err = env.Client.WaitForDeploymentCondition(deployment, func(dep *appsv1.Deployment) (bool, error) {
+		fmt.Println(GinkgoWriter, dep.Status)
+		if dep.Status.AvailableReplicas > 0 {
+			return false, fmt.Errorf("got %d available replicas", dep.Status.AvailableReplicas)
+		}
+		return true, nil
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	err = waitForPodsToDisappear(env, OLSNameSpace, "app.kubernetes.io/component", "postgres-server")
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func startPostgres(env *OLSTestEnvironment) {
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      PostgresDeploymentName,
+			Namespace: OLSNameSpace,
+		},
+	}
+	err := env.Client.Get(deployment)
+	Expect(err).NotTo(HaveOccurred())
+	deployment.Spec.Replicas = Ptr(int32(1))
+	err = env.Client.Update(deployment)
+	Expect(err).NotTo(HaveOccurred())
+	err = env.Client.WaitForDeploymentRollout(deployment)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+var _ = Describe("Postgres restart", Ordered, Label("Postgres restart"), func() {
+	var env *OLSTestEnvironment
+	var err error
+
+	BeforeAll(func() {
+		By("Setting up OLS test environment")
+		env, err = SetupOLSTestEnvironment(nil)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterAll(func() {
+		By("Cleaning up OLS test environment with CR deletion")
+		err = CleanupOLSTestEnvironmentWithCRDeletion(env, "postgres_restart_test")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should bounce Postgres and reestablish connection with it", func() {
+		By("Testing OLS service activation")
+		secret, err := TestOLSServiceActivation(env)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Testing HTTPS POST on /v1/query endpoint by OLS user - should pass")
+		invokeOLS(env, secret, "how do I stop a VM?", true)
+
+		By("shut down Postgres")
+		shutdownPostgres(env)
+
+		By("Testing HTTPS POST on /v1/query endpoint by OLS user - should fail")
+		invokeOLS(env, secret, "how do I stop a VM?", false)
+
+		By("bring Postgres back up")
+		startPostgres(env)
+
+		By("Testing HTTPS POST on /v1/query endpoint by OLS user")
+		invokeOLS(env, secret, "how do I stop a VM?", true)
+	})
+})


### PR DESCRIPTION
## Description

Added an e2e test that verifies the fix for https://issues.redhat.com//browse/OLS-1835 (https://github.com/openshift/lightspeed-service/pull/2548), where the OLS service would not reconnect to Postgres after losing its connection to it.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # https://issues.redhat.com//browse/OLS-1835
- Closes # https://issues.redhat.com/browse/OLS-1870

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
