### PR TITLE
OLS-1921: Updating snapshot to image list to add postgres image.

### DIFF
--- a/hack/snapshot_to_image_list.sh
+++ b/hack/snapshot_to_image_list.sh
@@ -122,6 +122,8 @@ CONSOLE_IMAGE=$(${JQ} -r '.spec.components[]| select(.name=="lightspeed-console"
 CONSOLE_REVISION=$(${JQ} -r '.spec.components[]| select(.name=="lightspeed-console") | .source.git.revision' "${TMP_SNAPSHOT_JSON}")
 SERVICE_IMAGE=$(${JQ} -r '.spec.components[]| select(.name=="lightspeed-service") | .containerImage' "${TMP_SNAPSHOT_JSON}")
 SERVICE_REVISION=$(${JQ} -r '.spec.components[]| select(.name=="lightspeed-service") | .source.git.revision' "${TMP_SNAPSHOT_JSON}")
+POSTGRES_IMAGE=$(${JQ} -r '.spec.components[] | select(.name=="lightspeed-postgresql") | .containerImage' "${TMP_SNAPSHOT_JSON}")
+POSTGRES_REVISION=$(${JQ} -r '.spec.components[] | select(.name=="lightspeed-postgresql") | .source.git.revision' "${TMP_SNAPSHOT_JSON}")
 if [ "${USE_REGISTRY}" = "preview" ]; then
     OPERATOR_IMAGE_BASE="registry.redhat.io/openshift-lightspeed-tech-preview/lightspeed-rhel9-operator"
     CONSOLE_IMAGE_BASE="registry.redhat.io/openshift-lightspeed-tech-preview/lightspeed-console-plugin-rhel9"
@@ -130,6 +132,7 @@ if [ "${USE_REGISTRY}" = "preview" ]; then
     OPERATOR_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator|'"${OPERATOR_IMAGE_BASE}"'|g' <<<${OPERATOR_IMAGE})
     CONSOLE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console|'"${CONSOLE_IMAGE_BASE}"'|g' <<<${CONSOLE_IMAGE})
     SERVICE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service|'"${SERVICE_IMAGE_BASE}"'|g' <<<${SERVICE_IMAGE})
+    POSTGRES_IMAGE=$(sed "s|quay\.io.*/lightspeed-postgresql|registry.redhat.io/rhel9/postgresql-16|g" <<<"${POSTGRES_IMAGE}")
 
     if [ -n "${BUNDLE_SNAPSHOT_REF}" ]; then
         BUNDLE_IMAGE_BASE="registry.redhat.io/openshift-lightspeed-tech-preview/lightspeed-operator-bundle"
@@ -145,11 +148,34 @@ if [ "${USE_REGISTRY}" = "stable" ]; then
     OPERATOR_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator|'"${OPERATOR_IMAGE_BASE}"'|g' <<<${OPERATOR_IMAGE})
     CONSOLE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console|'"${CONSOLE_IMAGE_BASE}"'|g' <<<${CONSOLE_IMAGE})
     SERVICE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service|'"${SERVICE_IMAGE_BASE}"'|g' <<<${SERVICE_IMAGE})
+    POSTGRES_IMAGE=$(sed "s|quay\.io.*/lightspeed-postgresql|registry.redhat.io/rhel9/postgresql-16|g" <<<"${POSTGRES_IMAGE}")
 
     if [ -n "${BUNDLE_SNAPSHOT_REF}" ]; then
         BUNDLE_IMAGE_BASE="registry.redhat.io/openshift-lightspeed/lightspeed-operator-bundle"
         BUNDLE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols-bundle|'"${BUNDLE_IMAGE_BASE}"'|g' <<<${BUNDLE_IMAGE})
     fi
+fi
+
+if [ -z "${POSTGRES_IMAGE}" ] || [ "${POSTGRES_IMAGE}" == "null" ]; then
+    if [ -f "${OUTPUT_FILE}" ]; then
+        POSTGRES_IMAGE=$(jq -r '.[] | select(.name == "lightspeed-postgresql") | .image' "${OUTPUT_FILE}")
+    fi
+fi
+
+if [ -z "${POSTGRES_IMAGE}" ] || [ "${POSTGRES_IMAGE}" == "null" ]; then
+    DEFAULT_POSTGRES_IMAGE=$(grep -o 'PostgresServerImageDefault = "registry[^"]*"' "${SCRIPT_DIR}/../internal/controller/constants.go" | sed 's/PostgresServerImageDefault = "\(.*\)"/\1/')
+    POSTGRES_IMAGE="${DEFAULT_POSTGRES_IMAGE}"
+    echo "Using default PostgreSQL image: ${POSTGRES_IMAGE}"
+fi
+
+if [ -z "${POSTGRES_REVISION}" ] || [ "${POSTGRES_REVISION}" == "null" ]; then
+    if [ -f "${OUTPUT_FILE}" ]; then
+        POSTGRES_REVISION=$(jq -r '.[] | select(.name == "lightspeed-postgresql") | .revision' "${OUTPUT_FILE}")
+    fi
+fi
+
+if [ -z "${POSTGRES_REVISION}" ] || [ "${POSTGRES_REVISION}" == "null" ]; then
+    POSTGRES_REVISION="unknown"
 fi
 
 RELATED_IMAGES=$(
@@ -169,6 +195,11 @@ RELATED_IMAGES=$(
     "name": "lightspeed-operator",
     "image": "${OPERATOR_IMAGE}",
     "revision": "${OPERATOR_REVISION}"
+  },
+  {
+    "name": "lightspeed-postgresql",
+    "image": "${POSTGRES_IMAGE}",
+    "revision": "${POSTGRES_REVISION}"
   }
 ]
 EOF


### PR DESCRIPTION
## Description
Updating snapshot_to_image_list script to add information about postgres image to related_images so that it can be adapted during mirroring.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue [# OLS1921](https://issues.redhat.com/browse/OLS-1921)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
The changes can be verified by running the script over a snapshot/bundle pair to check if related_images.json is updated.

- How were the fix/results from this change verified? Please provide relevant screenshots or results.
Results were verified by manually checking the script with snapshot/bundle changes.
