### PR TITLE
OLS-1979: Use lightspeed-to-dataverse-exporter

### DIFF
--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -263,4 +263,14 @@ ssl_ca_file = '/etc/certs/cm-olspostgresca/service-ca.crt'
 	MCPServerTimeout = 60
 	// MCP server SSE read timeout, sec
 	MCPServerHTTPReadTimeout = 30
+
+	/*** Data Exporter Constants ***/
+	// ExporterConfigCmName is the name of the exporter configmap
+	ExporterConfigCmName = "lightspeed-exporter-config"
+	// ExporterConfigVolumeName is the name of the volume for exporter configuration
+	ExporterConfigVolumeName = "exporter-config"
+	// ExporterConfigMountPath is the path where exporter config is mounted
+	ExporterConfigMountPath = "/etc/config"
+	// ExporterConfigFilename is the name of the exporter configuration file
+	ExporterConfigFilename = "config.yaml"
 )

--- a/internal/controller/ols_app_server_assets.go
+++ b/internal/controller/ols_app_server_assets.go
@@ -400,6 +400,36 @@ func (r *OLSConfigReconciler) generateOLSConfigMap(ctx context.Context, cr *olsv
 	return &cm, nil
 }
 
+func (r *OLSConfigReconciler) generateExporterConfigMap(cr *olsv1alpha1.OLSConfig) (*corev1.ConfigMap, error) {
+	exporterConfigContent := `service_id: "ols"
+ingress_server_url: "https://console.redhat.com/api/ingress/v1/upload"
+allowed_subdirs:
+ - feedback
+ - transcripts
+
+# Collection settings
+collection_interval: 5
+cleanup_after_send: true
+ingress_connection_timeout: 30`
+
+	cm := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ExporterConfigCmName,
+			Namespace: r.Options.Namespace,
+			Labels:    generateAppServerSelectorLabels(),
+		},
+		Data: map[string]string{
+			ExporterConfigFilename: exporterConfigContent,
+		},
+	}
+
+	if err := controllerutil.SetControllerReference(cr, &cm, r.Scheme); err != nil {
+		return nil, err
+	}
+
+	return &cm, nil
+}
+
 func (r *OLSConfigReconciler) getAdditionalCAFileNames(cr *olsv1alpha1.OLSConfig) ([]string, error) {
 	if cr.Spec.OLSConfig.AdditionalCAConfigMapRef == nil {
 		return nil, nil

--- a/internal/controller/ols_app_server_reconciliator.go
+++ b/internal/controller/ols_app_server_reconciliator.go
@@ -39,6 +39,10 @@ func (r *OLSConfigReconciler) reconcileAppServer(ctx context.Context, olsconfig 
 			Task: r.reconcileOLSConfigMap,
 		},
 		{
+			Name: "reconcile ExporterConfigMap",
+			Task: r.reconcileExporterConfigMap,
+		},
+		{
 			Name: "reconcile Additional CA ConfigMap",
 			Task: r.reconcileOLSAdditionalCAConfigMap,
 		},
@@ -138,6 +142,47 @@ func (r *OLSConfigReconciler) reconcileOLSConfigMap(ctx context.Context, cr *ols
 		return fmt.Errorf("%s: %w", ErrUpdateAPIConfigmap, err)
 	}
 	r.logger.Info("OLS configmap reconciled", "configmap", cm.Name, "hash", cm.Annotations[OLSConfigHashKey])
+	return nil
+}
+
+func (r *OLSConfigReconciler) reconcileExporterConfigMap(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
+	// Only create exporter configmap if data collector is enabled
+	dataCollectorEnabled, err := r.dataCollectorEnabled(cr)
+	if err != nil {
+		return err
+	}
+
+	if !dataCollectorEnabled {
+		r.logger.Info("Data collector not enabled, exporter configmap reconciliation skipped")
+		return nil
+	}
+
+	cm, err := r.generateExporterConfigMap(cr)
+	if err != nil {
+		return fmt.Errorf("failed to generate exporter configmap: %w", err)
+	}
+
+	foundCm := &corev1.ConfigMap{}
+	err = r.Client.Get(ctx, client.ObjectKey{Name: ExporterConfigCmName, Namespace: r.Options.Namespace}, foundCm)
+	if err != nil && errors.IsNotFound(err) {
+		r.logger.Info("creating a new exporter configmap", "configmap", cm.Name)
+		err = r.Create(ctx, cm)
+		if err != nil {
+			return fmt.Errorf("failed to create exporter configmap: %w", err)
+		}
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to get exporter configmap: %w", err)
+	}
+
+	// Update existing configmap
+	foundCm.Data = cm.Data
+	err = r.Update(ctx, foundCm)
+	if err != nil {
+		return fmt.Errorf("failed to update exporter configmap: %w", err)
+	}
+
+	r.logger.Info("Exporter configmap reconciled", "configmap", cm.Name)
 	return nil
 }
 


### PR DESCRIPTION
## Description

Replacement of the current data collection through the ols-service in favor of lightspeed-core/lightspeed-to-dataverse-exporter.

## Type of change

- [x] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
