### PR TITLE
Update related_images.json for OLS 1.0.4

### DIFF
--- a/hack/snapshot_to_image_list.sh
+++ b/hack/snapshot_to_image_list.sh
@@ -133,7 +133,7 @@ if [ "${USE_REGISTRY}" = "preview" ]; then
     OPERATOR_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator|'"${OPERATOR_IMAGE_BASE}"'|g' <<<${OPERATOR_IMAGE})
     CONSOLE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console|'"${CONSOLE_IMAGE_BASE}"'|g' <<<${CONSOLE_IMAGE})
     SERVICE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service|'"${SERVICE_IMAGE_BASE}"'|g' <<<${SERVICE_IMAGE})
-    MCP_SERVER_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/openshift-mcp-server|'"${MCP_SERVER_IMAGE_BASE}"'|g' <<<${MCP_SERVER_IMAGE})
+    MCP_SERVER_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/openshift-mcp-server|'"${MCP_SERVER_IMAGE_BASE}"'|g' <<<${MCP_SERVER_IMAGE})
     POSTGRES_IMAGE=$(sed "s|quay\.io.*/lightspeed-postgresql|registry.redhat.io/rhel9/postgresql-16|g" <<<"${POSTGRES_IMAGE}")
 
     if [ -n "${BUNDLE_SNAPSHOT_REF}" ]; then
@@ -151,7 +151,7 @@ if [ "${USE_REGISTRY}" = "stable" ]; then
     OPERATOR_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator|'"${OPERATOR_IMAGE_BASE}"'|g' <<<${OPERATOR_IMAGE})
     CONSOLE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console|'"${CONSOLE_IMAGE_BASE}"'|g' <<<${CONSOLE_IMAGE})
     SERVICE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service|'"${SERVICE_IMAGE_BASE}"'|g' <<<${SERVICE_IMAGE})
-    MCP_SERVER_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/openshift-mcp-server|'"${MCP_SERVER_IMAGE_BASE}"'|g' <<<${MCP_SERVER_IMAGE})
+    MCP_SERVER_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/openshift-mcp-server|'"${MCP_SERVER_IMAGE_BASE}"'|g' <<<${MCP_SERVER_IMAGE})
     POSTGRES_IMAGE=$(sed "s|quay\.io.*/lightspeed-postgresql|registry.redhat.io/rhel9/postgresql-16|g" <<<"${POSTGRES_IMAGE}")
 
     if [ -n "${BUNDLE_SNAPSHOT_REF}" ]; then

--- a/related_images.json
+++ b/related_images.json
@@ -1,27 +1,31 @@
 [
   {
     "name": "lightspeed-service-api",
-    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9@sha256:9c431e08e357524067ddb2573f30aa80a834c768649b6c649967e845beb57a79",
-    "revision": "47df8a57894d54abaddbcbab9d923c03ce19c0e1"
+    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9@sha256:3907578c627487dfc9cf79785bbaebdc261d50c290205c22d7acfb0966dcab87",
+    "revision": "8bb4d0bd84a3c7203af7c13a5b8031e3079b4c03"
   },
   {
     "name": "lightspeed-console-plugin",
-    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:2d1ea9f7a2dfc013fc4b330c01b5a8452cd7cb4d2ff8d21ec917488b79fe2504",
-    "revision": "076f10c2a123478566be9ad2598ccc3a60032bd8"
+    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:3cc6d0cd4bd6f717079735b82d182d788a5d6f3cf2d4132409770bc36d21a5a0",
+    "revision": "f7603f2359b67c5cf080e508d32984a5be07c947"
   },
   {
     "name": "lightspeed-operator",
-    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:a5c4be119038771a3d8aa65f6c1409ea2afec029e9f5bd8e54fb1f89237c3198",
-    "revision": "b4f30d6ce50dde60d095a3a6ecc9814a2566b9a2"
+    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:442dad8a7c5566b44a1563eae9eb41ef42a1a8c8c613e28d0dc1a813797c970b",
+    "revision": "7b6bcfad54b050add976cb7b1007f522fe9dd35b"
+  },
+  {
+    "name": "openshift-mcp-server",
+    "image": "registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9@sha256:878ece2c5bd7989eada22b65affdf4d57424cd2494b7109ec22deb80bdc1ed89",
+    "revision": "157fbf7a7349269dc68ee70b2c1b25dc9276ed6e"
+  },
+  {
+    "name": "lightspeed-postgresql",
+    "image": "registry.redhat.io/rhel9/postgresql-16@sha256:6d2cab6cb6366b26fcf4591fe22aa5e8212a3836c34c896bb65977a8e50d658b"
   },
   {
     "name": "lightspeed-operator-bundle",
-    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-operator-bundle@sha256:a556e86058237d8afab41a4dc320c487645d8a1824ae68a0c2adb32ae6f72d7f",
-    "revision": "f42434020d190c202d048fa35831d53326c04d4c"
-  },
-  {
-    "name": "mcp-server",
-    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/openshift-mcp-server@sha256:3a035744b772104c6c592acf8a813daced19362667ed6dab73a00d17eb9c3a43",
-    "revision": ""
+    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-operator-bundle@sha256:5cd26d148756f19305bd8443a365060d34204981e9f58f2235418174362b5080",
+    "revision": "07605d584375a2011d39c7dcc2165ad13e945ac0"
   }
 ]


### PR DESCRIPTION
## Description

Updated related_images.json for OLS 1.0.4
Fixed hack/snapshot_to_image_list.sh to handle the MCP server image correctly - Konflux seems to have changed the image naming scheme where the application name is not used anymore.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # https://issues.redhat.com/browse/OLS-2024
- Closes # 

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
