### PR TITLE
OLS-2024: OLS 1.0.4. Consistent use of openshift-mcp-server, operator changes

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -61,10 +61,10 @@ var (
 	setupLog = ctrl.Log.WithName("setup")
 	// The default images of operands
 	defaultImages = map[string]string{
-		"lightspeed-service": controller.OLSAppServerImageDefault,
-		"postgres-image":     controller.PostgresServerImageDefault,
-		"console-plugin":     controller.ConsoleUIImageDefault,
-		"mcp-server":         controller.MCPServerImageDefault,
+		"lightspeed-service":         controller.OLSAppServerImageDefault,
+		"postgres-image":             controller.PostgresServerImageDefault,
+		"console-plugin":             controller.ConsoleUIImageDefault,
+		"openshift-mcp-server-image": controller.OpenShiftMCPServerImageDefault,
 	}
 )
 
@@ -81,7 +81,7 @@ func init() {
 
 // overrideImages overides the default images with the images provided by the user
 // if an images is not provided, the default is used.
-func overrideImages(serviceImage string, consoleImage string, postgresImage string, mcpServerImage string) map[string]string {
+func overrideImages(serviceImage string, consoleImage string, postgresImage string, openshiftMCPServerImage string) map[string]string {
 	res := defaultImages
 	if serviceImage != "" {
 		res["lightspeed-service"] = serviceImage
@@ -92,8 +92,8 @@ func overrideImages(serviceImage string, consoleImage string, postgresImage stri
 	if postgresImage != "" {
 		res["postgres-image"] = postgresImage
 	}
-	if mcpServerImage != "" {
-		res["mcp-server"] = mcpServerImage
+	if openshiftMCPServerImage != "" {
+		res["openshift-mcp-server-image"] = openshiftMCPServerImage
 	}
 	return res
 }
@@ -124,7 +124,7 @@ func main() {
 	var consoleImage string
 	var namespace string
 	var postgresImage string
-	var mcpServerImage string
+	var openshiftMCPServerImage string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -140,7 +140,7 @@ func main() {
 	flag.StringVar(&consoleImage, "console-image", controller.ConsoleUIImageDefault, "The image of the console-plugin container.")
 	flag.StringVar(&namespace, "namespace", "", "The namespace where the operator is deployed.")
 	flag.StringVar(&postgresImage, "postgres-image", controller.PostgresServerImageDefault, "The image of the PostgreSQL server.")
-	flag.StringVar(&mcpServerImage, "mcp-server-image", controller.MCPServerImageDefault, "The image of the MCP server container.")
+	flag.StringVar(&openshiftMCPServerImage, "openshift-mcp-server-image", controller.OpenShiftMCPServerImageDefault, "The image of the OpenShift MCP server container.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -153,7 +153,7 @@ func main() {
 		namespace = getWatchNamespace()
 	}
 
-	imagesMap := overrideImages(serviceImage, consoleImage, postgresImage, mcpServerImage)
+	imagesMap := overrideImages(serviceImage, consoleImage, postgresImage, openshiftMCPServerImage)
 	setupLog.Info("Images setting loaded", "images", listImages())
 	setupLog.Info("Starting the operator", "metricsAddr", metricsAddr, "probeAddr", probeAddr, "reconcilerIntervalMinutes", reconcilerIntervalMinutes, "certDir", certDir, "certName", certName, "keyName", keyName, "namespace", namespace)
 
@@ -259,7 +259,7 @@ func main() {
 			LightspeedServiceImage:         imagesMap["lightspeed-service"],
 			ConsoleUIImage:                 imagesMap["console-plugin"],
 			LightspeedServicePostgresImage: imagesMap["postgres-image"],
-			MCPServerImage:                 imagesMap["mcp-server"],
+			OpenShiftMCPServerImage:        imagesMap["openshift-mcp-server-image"],
 			Namespace:                      namespace,
 			ReconcileInterval:              time.Duration(reconcilerIntervalMinutes) * time.Minute, // #nosec G115
 		},

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -254,13 +254,13 @@ ssl_ca_file = '/etc/certs/cm-olspostgresca/service-ca.crt'
 	// MetricsReaderServiceAccountName is the name of the service account for the metrics reader
 	MetricsReaderServiceAccountName = "lightspeed-operator-metrics-reader"
 	// MCP server image
-	MCPServerImageDefault = "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/openshift-mcp-server@sha256:3a035744b772104c6c592acf8a813daced19362667ed6dab73a00d17eb9c3a43"
+	OpenShiftMCPServerImageDefault = "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/openshift-mcp-server@sha256:3a035744b772104c6c592acf8a813daced19362667ed6dab73a00d17eb9c3a43"
 	// MCP server URL
-	MCPServerURL = "http://localhost:%d/mcp"
+	OpenShiftMCPServerURL = "http://localhost:%d/mcp"
 	// MCP server port
-	MCPServerPort = 8080
+	OpenShiftMCPServerPort = 8080
 	// MCP server timeout, sec
-	MCPServerTimeout = 60
+	OpenShiftMCPServerTimeout = 60
 	// MCP server SSE read timeout, sec
-	MCPServerHTTPReadTimeout = 30
+	OpenShiftMCPServerHTTPReadTimeout = 30
 )

--- a/internal/controller/ols_app_server_assets.go
+++ b/internal/controller/ols_app_server_assets.go
@@ -341,9 +341,9 @@ func (r *OLSConfigReconciler) generateOLSConfigMap(ctx context.Context, cr *olsv
 				Name:      "openshift",
 				Transport: StreamableHTTP,
 				StreamableHTTP: &StreamableHTTPTransportConfig{
-					URL:            fmt.Sprintf(MCPServerURL, MCPServerPort),
-					Timeout:        MCPServerTimeout,
-					SSEReadTimeout: MCPServerHTTPReadTimeout,
+					URL:            fmt.Sprintf(OpenShiftMCPServerURL, OpenShiftMCPServerPort),
+					Timeout:        OpenShiftMCPServerTimeout,
+					SSEReadTimeout: OpenShiftMCPServerHTTPReadTimeout,
 				},
 			},
 		}

--- a/internal/controller/ols_app_server_deployment.go
+++ b/internal/controller/ols_app_server_deployment.go
@@ -378,21 +378,21 @@ func (r *OLSConfigReconciler) generateOLSDeployment(cr *olsv1alpha1.OLSConfig) (
 	}
 	deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, telemetryContainer)
 
-	// Add MCP sidecar container if introspection is enabled
+	// Add OpenShift MCP server sidecar container if introspection is enabled
 	if cr.Spec.OLSConfig.IntrospectionEnabled {
-		mcpSidecarContainer := corev1.Container{
-			Name:            "openshift-mcp",
-			Image:           r.Options.MCPServerImage,
+		openshiftMCPServerSidecarContainer := corev1.Container{
+			Name:            "openshift-mcp-server",
+			Image:           r.Options.OpenShiftMCPServerImage,
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			SecurityContext: &corev1.SecurityContext{
 				AllowPrivilegeEscalation: &[]bool{false}[0],
 				ReadOnlyRootFilesystem:   &[]bool{true}[0],
 			},
 			VolumeMounts: volumeMounts,
-			Command:      []string{"/openshift-mcp-server", "--read-only", "--port", fmt.Sprintf("%d", MCPServerPort)},
+			Command:      []string{"/openshift-mcp-server", "--read-only", "--port", fmt.Sprintf("%d", OpenShiftMCPServerPort)},
 			Resources:    *mcp_server_resources,
 		}
-		deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, mcpSidecarContainer)
+		deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, openshiftMCPServerSidecarContainer)
 	}
 
 	return &deployment, nil

--- a/internal/controller/olsconfig_controller.go
+++ b/internal/controller/olsconfig_controller.go
@@ -62,7 +62,7 @@ type OLSConfigReconcilerOptions struct {
 	LightspeedServiceImage         string
 	LightspeedServicePostgresImage string
 	ConsoleUIImage                 string
-	MCPServerImage                 string
+	OpenShiftMCPServerImage        string
 	Namespace                      string
 	ReconcileInterval              time.Duration
 }


### PR DESCRIPTION
## Description

Use openshift-mcp-server consistently in the operator sources. The bundle changes are in https://github.com/openshift/lightspeed-operator/pull/943.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # https://issues.redhat.com/browse/OLS-2024
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
