### PR TITLE
feat: ClusterRole query-access added get verb to /ls-access.

### DIFF
--- a/bundle/manifests/lightspeed-operator-query-access_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/lightspeed-operator-query-access_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -15,3 +15,7 @@ rules:
   - /ols-access
   verbs:
   - get
+- nonResourceURLs:
+  - /ls-access
+  verbs:
+  - get

--- a/config/user-access/query_access_clusterrole.yaml
+++ b/config/user-access/query_access_clusterrole.yaml
@@ -14,3 +14,8 @@ rules:
       - "/ols-access"
     verbs:
       - "get"
+  # prepare transition to use Lightspeed Core
+  - nonResourceURLs:
+      - "/ls-access"
+    verbs:
+      - "get"


### PR DESCRIPTION
## Description

Lightspeed Core uses nonResourceUrl /ls-access for autorizaiton. Here we add this nonResourceUrl to the cluster role that will be used to grant access to Openshift Lightspeed. 

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # [OLS-2027](https://issues.redhat.com//browse/OLS-2027)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
