### PR TITLE
fix: MCP config should export settings for one transport only

### DIFF
--- a/internal/controller/ols_app_server_assets_test.go
+++ b/internal/controller/ols_app_server_assets_test.go
@@ -328,6 +328,8 @@ var _ = Describe("App server assets", func() {
 					"header1": "value1",
 				},
 			}))
+			Expect(appSrvConfigFile.MCPServers[0].SSE).To(BeNil())
+
 			Expect(appSrvConfigFile.MCPServers[1].Name).To(Equal("testMCP2"))
 			Expect(appSrvConfigFile.MCPServers[1].Transport).To(Equal(SSE))
 			Expect(appSrvConfigFile.MCPServers[1].SSE).To(Equal(&StreamableHTTPTransportConfig{
@@ -338,6 +340,7 @@ var _ = Describe("App server assets", func() {
 					"header2": "value2",
 				},
 			}))
+			Expect(appSrvConfigFile.MCPServers[1].StreamableHTTP).To(BeNil())
 		})
 
 		It("should not generate configmap with additional MCP server if feature gate is missing", func() {


### PR DESCRIPTION
## Description

In the generated olsconfig config map, MCP server config should have either the `sse` field or the `streamable_http` field, not both. 

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes # [OLS-2071](https://issues.redhat.com//browse/OLS-2071)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
