### PR TITLE
Remove debug output of SA token from the BYOK e2e test

### DIFF
--- a/test/e2e/byok_test.go
+++ b/test/e2e/byok_test.go
@@ -39,7 +39,6 @@ var _ = Describe("BYOK", Ordered, Label("BYOK"), func() {
 		By("Testing HTTPS POST on /v1/query endpoint by OLS user")
 		reqBody := []byte(`{"query": "what CPU architectures does the assisted installer support?"}`)
 		resp, body, err := TestHTTPSQueryEndpoint(env, secret, reqBody)
-		fmt.Println("httpsClient.PostJson", map[string]string{"Authorization": "Bearer " + env.SAToken})
 		Expect(err).NotTo(HaveOccurred())
 		defer resp.Body.Close()
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))


### PR DESCRIPTION
## Description

Remove debug output of SA token from the BYOK e2e test to prevent test output from being quarantined by GitLeaks

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
