### PR TITLE
Update the docs on default values of ContextWindowSize and MaxTokensForResponse in the CRD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ IMAGE_TAG_BASE ?= quay.io/openshift-lightspeed/lightspeed-operator
 
 # BUNDLE_TAG defines the version of the bundle.
 # You can use it as an arg. (E.g make update-bundle-catalog BUNDLE_TAG=0.0.1)
-BUNDLE_TAG ?= 1.0.4
+BUNDLE_TAG ?= 1.0.5
 
 # set the base image for docker files
 # You can use it as an arg.  (E.g make update-bundle-catalog BASE_IMG=registry.redhat.io/ubi9/ubi-minimal)

--- a/api/v1alpha1/olsconfig_types.go
+++ b/api/v1alpha1/olsconfig_types.go
@@ -316,7 +316,7 @@ type QueryFiltersSpec struct {
 
 // ModelParametersSpec
 type ModelParametersSpec struct {
-	// Max tokens for response
+	// Max tokens for response. The default is 2048 tokens.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Max Tokens For Response"
 	MaxTokensForResponse int `json:"maxTokensForResponse,omitempty"`
 }
@@ -332,7 +332,7 @@ type ModelSpec struct {
 	// +kubebuilder:validation:Pattern=`^https?://.*$`
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="URL"
 	URL string `json:"url,omitempty"`
-	// Defines the model's context window size. Default is specific to provider/model.
+	// Defines the model's context window size, in tokens. The default is 128k tokens.
 	// +kubebuilder:validation:Minimum=1024
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Context Window Size"
 	ContextWindowSize uint `json:"contextWindowSize,omitempty"`

--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
       ]
     capabilities: Basic Install
     console.openshift.io/operator-monitoring-default: "true"
-    createdAt: "2025-08-28T16:37:51Z"
+    createdAt: "2025-09-11T16:54:39Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -97,7 +97,7 @@ spec:
           - description: List of models from the provider
             displayName: Models
             path: llm.providers[0].models
-          - description: Defines the model's context window size. Default is specific to provider/model.
+          - description: Defines the model's context window size, in tokens. The default is 128k tokens.
             displayName: Context Window Size
             path: llm.providers[0].models[0].contextWindowSize
           - description: Model name
@@ -106,7 +106,7 @@ spec:
           - description: Model API parameters
             displayName: Parameters
             path: llm.providers[0].models[0].parameters
-          - description: Max tokens for response
+          - description: Max tokens for response. The default is 2048 tokens.
             displayName: Max Tokens For Response
             path: llm.providers[0].models[0].parameters.maxTokensForResponse
           - description: Model API URL

--- a/bundle/manifests/ols.openshift.io_olsconfigs.yaml
+++ b/bundle/manifests/ols.openshift.io_olsconfigs.yaml
@@ -85,8 +85,8 @@ spec:
                               its parameters.
                             properties:
                               contextWindowSize:
-                                description: Defines the model's context window size.
-                                  Default is specific to provider/model.
+                                description: Defines the model's context window size,
+                                  in tokens. The default is 128k tokens.
                                 minimum: 1024
                                 type: integer
                               name:
@@ -96,7 +96,8 @@ spec:
                                 description: Model API parameters
                                 properties:
                                   maxTokensForResponse:
-                                    description: Max tokens for response
+                                    description: Max tokens for response. The default
+                                      is 2048 tokens.
                                     type: integer
                                 type: object
                               url:
@@ -147,6 +148,7 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 minTLSVersion:
                                   description: |-
                                     minTLSVersion is used to specify the minimal version of the TLS protocol
@@ -1104,6 +1106,7 @@ spec:
                             items:
                               type: string
                             type: array
+                            x-kubernetes-list-type: atomic
                           minTLSVersion:
                             description: |-
                               minTLSVersion is used to specify the minimal version of the TLS protocol

--- a/config/crd/bases/ols.openshift.io_olsconfigs.yaml
+++ b/config/crd/bases/ols.openshift.io_olsconfigs.yaml
@@ -85,8 +85,8 @@ spec:
                               its parameters.
                             properties:
                               contextWindowSize:
-                                description: Defines the model's context window size.
-                                  Default is specific to provider/model.
+                                description: Defines the model's context window size,
+                                  in tokens. The default is 128k tokens.
                                 minimum: 1024
                                 type: integer
                               name:
@@ -96,7 +96,8 @@ spec:
                                 description: Model API parameters
                                 properties:
                                   maxTokensForResponse:
-                                    description: Max tokens for response
+                                    description: Max tokens for response. The default
+                                      is 2048 tokens.
                                     type: integer
                                 type: object
                               url:
@@ -147,6 +148,7 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 minTLSVersion:
                                   description: |-
                                     minTLSVersion is used to specify the minimal version of the TLS protocol
@@ -1104,6 +1106,7 @@ spec:
                             items:
                               type: string
                             type: array
+                            x-kubernetes-list-type: atomic
                           minTLSVersion:
                             description: |-
                               minTLSVersion is used to specify the minimal version of the TLS protocol

--- a/config/manifests/bases/lightspeed-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/lightspeed-operator.clusterserviceversion.yaml
@@ -64,8 +64,8 @@ spec:
       - description: List of models from the provider
         displayName: Models
         path: llm.providers[0].models
-      - description: Defines the model's context window size. Default is specific
-          to provider/model.
+      - description: Defines the model's context window size, in tokens. The default
+          is 128k tokens.
         displayName: Context Window Size
         path: llm.providers[0].models[0].contextWindowSize
       - description: Model name
@@ -74,7 +74,7 @@ spec:
       - description: Model API parameters
         displayName: Parameters
         path: llm.providers[0].models[0].parameters
-      - description: Max tokens for response
+      - description: Max tokens for response. The default is 2048 tokens.
         displayName: Max Tokens For Response
         path: llm.providers[0].models[0].parameters.maxTokensForResponse
       - description: Model API URL

--- a/docs/olsconfig-ols-openshift-io-v1alpha1.adoc
+++ b/docs/olsconfig-ols-openshift-io-v1alpha1.adoc
@@ -251,7 +251,7 @@ Required::
 
 | `contextWindowSize`
 | `integer`
-| Defines the model's context window size. Default is specific to provider/model.
+| Defines the model's context window size, in tokens. The default is 128k tokens.
 
 | `name`
 | `string`
@@ -285,7 +285,7 @@ Type::
 
 | `maxTokensForResponse`
 | `integer`
-| Max tokens for response
+| Max tokens for response. The default is 2048 tokens.
 
 |===
 == .spec.llm.providers[].tlsSecurityProfile


### PR DESCRIPTION
## Description

Update the docs on default values of ContextWindowSize and MaxTokensForResponse in the CRD.
The docs change reflects https://github.com/openshift/lightspeed-service/blob/a9fa2293fca65f9d46d26fa16f123cd04cc3d1b1/ols/app/models/config.py#L38 and https://github.com/openshift/lightspeed-service/blob/a9fa2293fca65f9d46d26fa16f123cd04cc3d1b1/ols/app/models/config.py#L26.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
