### PR TITLE
Add deployment health monitoring for OLS app server

### DIFF
--- a/config/crd/bases/ols.openshift.io_olsconfigs.yaml
+++ b/config/crd/bases/ols.openshift.io_olsconfigs.yaml
@@ -147,6 +147,7 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 minTLSVersion:
                                   description: |-
                                     minTLSVersion is used to specify the minimal version of the TLS protocol
@@ -1104,6 +1105,7 @@ spec:
                             items:
                               type: string
                             type: array
+                            x-kubernetes-list-type: atomic
                           minTLSVersion:
                             description: |-
                               minTLSVersion is used to specify the minimal version of the TLS protocol

--- a/internal/controller/olsconfig_controller.go
+++ b/internal/controller/olsconfig_controller.go
@@ -43,6 +43,7 @@ import (
 // Definitions to manage status conditions
 const (
 	typeApiReady           = "ApiReady"
+	typeDeploymentHealthy  = "DeploymentHealthy"
 	typeCacheReady         = "CacheReady"
 	typeConsolePluginReady = "ConsolePluginReady"
 	typeCRReconciled       = "Reconciled"


### PR DESCRIPTION
## Description

Provide visibility into actual deployment health beyond basic resource existence.

Features:
- Add DeploymentHealthy status condition to distinguish between "deployment exists" vs "deployment is healthy"
- Monitor replica availability (ReadyReplicas vs desired replicas)
- Check deployment conditions for ReplicaFailure and Progressing states
- Provide actionable diagnostic messages with replica counts and failure details
- Integrate health check into app server reconciliation loop

Testing:
- Add comprehensive unit tests covering deployment not found, unhealthy replicas, replica failure conditions, non-progressing deployments, and healthy deployment scenarios
- Use existing test helpers and follow established patterns

This addresses monitoring gaps where status conditions were set based on API operation success rather than actual deployment operational status.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

Jira 1949

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [X] If it is a core feature, I have added thorough tests.

## Testing
Tested locally with automation testing, but not tested in a live environment. Needs QE.