### PR TITLE
OLS-1775: Postgres reconciliation on certificate rotation.

### DIFF
--- a/internal/controller/olsconfig_controller.go
+++ b/internal/controller/olsconfig_controller.go
@@ -447,8 +447,14 @@ func (r *OLSConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.Secret{}).
 		Owns(&corev1.PersistentVolumeClaim{}).
 		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(watchers.SecretWatcherFilter)).
+		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
+			return watchers.PostgresCAWatcherFilter(r, ctx, obj)
+		})).
 		Watches(&corev1.ConfigMap{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
 			return watchers.ConfigMapWatcherFilter(r, ctx, obj, r.Options.UseLCore)
+		})).
+		Watches(&corev1.ConfigMap{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
+			return watchers.PostgresCAWatcherFilter(r, ctx, obj)
 		})).
 		Owns(&consolev1.ConsolePlugin{}).
 		Owns(&monv1.ServiceMonitor{}).

--- a/internal/controller/postgres/assets.go
+++ b/internal/controller/postgres/assets.go
@@ -249,16 +249,16 @@ func UpdatePostgresDeployment(r reconciler.Reconciler, ctx context.Context, exis
 	// Validate deployment annotations.
 	if existingDeployment.Annotations == nil ||
 		existingDeployment.Annotations[utils.PostgresConfigHashKey] != r.GetStateCache()[utils.PostgresConfigHashStateCacheKey] ||
-		existingDeployment.Annotations[utils.PostgresSecretHashKey] != r.GetStateCache()[utils.PostgresSecretHashStateCacheKey] {
-		utils.UpdateDeploymentAnnotations(existingDeployment, map[string]string{
+		existingDeployment.Annotations[utils.PostgresSecretHashKey] != r.GetStateCache()[utils.PostgresSecretHashStateCacheKey] ||
+		existingDeployment.Annotations[utils.PostgresCAHashKey] != r.GetStateCache()[utils.PostgresCAHashStateCacheKey] {
+		annotations := map[string]string{
 			utils.PostgresConfigHashKey: r.GetStateCache()[utils.PostgresConfigHashStateCacheKey],
 			utils.PostgresSecretHashKey: r.GetStateCache()[utils.PostgresSecretHashStateCacheKey],
-		})
+			utils.PostgresCAHashKey:     r.GetStateCache()[utils.PostgresCAHashStateCacheKey],
+		}
+		utils.UpdateDeploymentAnnotations(existingDeployment, annotations)
 		// update the deployment template annotation triggers the rolling update
-		utils.UpdateDeploymentTemplateAnnotations(existingDeployment, map[string]string{
-			utils.PostgresConfigHashKey: r.GetStateCache()[utils.PostgresConfigHashStateCacheKey],
-			utils.PostgresSecretHashKey: r.GetStateCache()[utils.PostgresSecretHashStateCacheKey],
-		})
+		utils.UpdateDeploymentTemplateAnnotations(existingDeployment, annotations)
 
 		if _, err := utils.SetDeploymentContainerEnvs(existingDeployment, desiredDeployment.Spec.Template.Spec.Containers[0].Env, utils.PostgresDeploymentName); err != nil {
 			return err

--- a/internal/controller/utils/constants.go
+++ b/internal/controller/utils/constants.go
@@ -167,6 +167,12 @@ const (
 	// PostgresSecretHashKey is the key of the hash value of OLS Postgres secret
 	// #nosec G101
 	PostgresSecretHashKey = "hash/postgres-secret"
+	// PostgresCAHashKey is the key of the hash value of the OLS Postgres CA certificate
+	PostgresCAHashKey = "hash/postgres-ca"
+	// PostgresServiceCACertKeyName is the data key name for the service CA certificate in the ConfigMap
+	PostgresServiceCACertKeyName = "service-ca.crt"
+	// PostgresTLSCertKeyName is the data key name for the TLS certificate in the Secret
+	PostgresTLSCertKeyName = "tls.crt"
 	// PostgresServiceName is the name of OLS application Postgres server service
 	PostgresServiceName = "lightspeed-postgres-server"
 	// PostgresSecretName is the name of OLS application Postgres secret
@@ -253,6 +259,7 @@ ssl_ca_file = '/etc/certs/cm-olspostgresca/service-ca.crt'
 	OperatorDeploymentName          = "lightspeed-operator-controller-manager"
 	OLSDefaultCacheType             = "postgres"
 	PostgresConfigHashStateCacheKey = "olspostgresconfig-hash"
+	PostgresCAHashStateCacheKey     = "olspostgresca-hash"
 	// #nosec G101
 	PostgresSecretHashStateCacheKey = "olspostgressecret-hash"
 	// OperatorNetworkPolicyName is the name of the network policy for the operator

--- a/internal/controller/watchers/watchers.go
+++ b/internal/controller/watchers/watchers.go
@@ -106,3 +106,24 @@ func ConfigMapWatcherFilter(r reconciler.Reconciler, ctx context.Context, obj cl
 		}},
 	}
 }
+
+// PostgresCAWatcherFilter is a filter function for watching PostgreSQL CA certificate resources.
+// It watches for changes to ConfigMap with the PostgreSQL CA certificate bundle and
+// Secret with the PostgreSQL serving certificate. It returns reconcile requests for the
+// OLSConfig resource when these resources change.
+func PostgresCAWatcherFilter(r reconciler.Reconciler, ctx context.Context, obj client.Object) []reconcile.Request {
+	// Only watch resources in the operator's namespace
+	if obj.GetNamespace() != r.GetNamespace() {
+		return nil
+	}
+
+	name := obj.GetName()
+	if name != utils.OLSCAConfigMap && name != utils.PostgresCertsSecretName {
+		return nil
+	}
+	return []reconcile.Request{
+		{NamespacedName: types.NamespacedName{
+			Name: utils.OLSConfigName,
+		}},
+	}
+}


### PR DESCRIPTION
## Description
Functionality has been added in order to ensure that the reconciliation happens in the postgres pod by watching the config for deletion of ca certs. This will allow the e2e test to run successfully.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue [OLS-1775](https://issues.redhat.com/browse/OLS-1775)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
    * Build an operator image  with changes.
    * Deployed the image, applied an olsconfig with postgres cache settings.
    * Put in a request to the OLS service, and confimed entry in cache table.
    * Deleted signing key using ` oc delete secret/signing-key -n openshift-service-ca`
    * Waited for deployments to restart and the service to become available. ( takes more than 5 mins).
    *  Put in a new request to the service.
    * Confirmed contents of both requests and also the successful PVC mount in new pod, confiming complete reconciliation.

