### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for lightspeed-operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN mkdir /licenses
 COPY LICENSE /licenses/.
 LABEL name="openshift-lightspeed/lightspeed-rhel9-operator" \
       com.redhat.component="openshift-lightspeed" \
+      cpe="cpe:/a:redhat:openshift_lightspeed:1::el9" \
       io.k8s.display-name="OpenShift Lightspeed Operator" \
       summary="OpenShift Lightspeed Operator manages the AI-powered OpenShift Assistant Service." \
       description="OpenShift Lightspeed Operator manages the AI-powered OpenShift Assistant Service and Openshift Console plugin extention." \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
