### PR TITLE
OLS-2774:  fix CVE-2026-27137 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.redhat.io/ubi9/go-toolset:9.7-1774968108 AS builder
+FROM registry.redhat.io/ubi9/go-toolset:9.7-1775042950 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
upgrade builder image to registry.redhat.io/ubi9/go-toolset:9.7-1775042950

## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes https://redhat.atlassian.net/browse/OLS-2774
- Closes https://redhat.atlassian.net/browse/OLS-2775

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
