### PR TITLE
OLS-2893 - reenabling proxy test and fixing configmap issue

### DIFF
--- a/internal/controller/appserver/assets_test.go
+++ b/internal/controller/appserver/assets_test.go
@@ -2045,11 +2045,11 @@ var _ = Describe("Helper function unit tests", func() {
 		It("should return error when proxy CA certificate ConfigMap does not exist", func() {
 			cr.Spec.OLSConfig.ProxyConfig = &olsv1alpha1.ProxyConfig{
 				ProxyURL: "http://proxy.example.com:8080",
-			ProxyCACertificateRef: &olsv1alpha1.ProxyCACertConfigMapRef{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: "nonexistent-proxy-ca",
+				ProxyCACertificateRef: &olsv1alpha1.ProxyCACertConfigMapRef{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "nonexistent-proxy-ca",
+					},
 				},
-			},
 			}
 			// Don't create the ConfigMap - validation should fail
 			_, err := buildOLSConfig(testReconcilerInstance, ctx, cr, false)

--- a/internal/controller/appserver/deployment.go
+++ b/internal/controller/appserver/deployment.go
@@ -389,7 +389,7 @@ func GenerateOLSDeployment(r reconciler.Reconciler, cr *olsv1alpha1.OLSConfig) (
 			Annotations: map[string]string{
 				utils.OLSConfigMapResourceVersionAnnotation:                configMapResourceVersion,
 				utils.OpenShiftMCPServerConfigMapResourceVersionAnnotation: mcpConfigMapResourceVersion,
-				utils.ProxyCACertResourceVersionAnnotation:                 proxyCACMResourceVersion,
+				utils.ProxyCACertHashAnnotation:                 proxyCACMResourceVersion,
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -565,7 +565,7 @@ func updateOLSDeployment(r reconciler.Reconciler, ctx context.Context, cr *olsv1
 		r.GetLogger().Info("failed to get Proxy CA certificate hash", "error", err)
 		changed = true
 	} else {
-		storedProxyCACMHash := existingDeployment.Annotations[utils.ProxyCACertResourceVersionAnnotation]
+		storedProxyCACMHash := existingDeployment.Annotations[utils.ProxyCACertHashAnnotation]
 		if storedProxyCACMHash != currentProxyCACMHash {
 			r.GetLogger().Info("Proxy CA certificate content changed, updating deployment")
 			changed = true
@@ -587,7 +587,7 @@ func updateOLSDeployment(r reconciler.Reconciler, ctx context.Context, cr *olsv1
 
 	existingDeployment.Annotations[utils.OLSConfigMapResourceVersionAnnotation] = desiredDeployment.Annotations[utils.OLSConfigMapResourceVersionAnnotation]
 	existingDeployment.Annotations[utils.OpenShiftMCPServerConfigMapResourceVersionAnnotation] = desiredDeployment.Annotations[utils.OpenShiftMCPServerConfigMapResourceVersionAnnotation]
-	existingDeployment.Annotations[utils.ProxyCACertResourceVersionAnnotation] = currentProxyCACMHash
+	existingDeployment.Annotations[utils.ProxyCACertHashAnnotation] = currentProxyCACMHash
 
 	r.GetLogger().Info("updating OLS deployment", "name", existingDeployment.Name)
 

--- a/internal/controller/appserver/deployment.go
+++ b/internal/controller/appserver/deployment.go
@@ -376,9 +376,9 @@ func GenerateOLSDeployment(r reconciler.Reconciler, cr *olsv1alpha1.OLSConfig) (
 	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, fmt.Errorf("failed to get MCP Server ConfigMap resource version: %w", err)
 	}
-	proxyCACMResourceVersion, err := utils.GetProxyCACertResourceVersion(r, ctx, cr)
+	proxyCACMResourceVersion, err := utils.GetProxyCACertHash(r, ctx, cr)
 	if err != nil && !apierrors.IsNotFound(err) {
-		return nil, fmt.Errorf("failed to get Proxy CA ConfigMap resource version: %w", err)
+		return nil, fmt.Errorf("failed to get Proxy CA certificate hash: %w", err)
 	}
 
 	deployment := appsv1.Deployment{
@@ -559,14 +559,15 @@ func updateOLSDeployment(r reconciler.Reconciler, ctx context.Context, cr *olsv1
 		}
 	}
 
-	// Step 4: Check if Proxy CA ConfigMap ResourceVersion has changed
-	currentProxyCACMVersion, err := utils.GetProxyCACertResourceVersion(r, ctx, cr)
+	// Step 4: Check if Proxy CA certificate content has changed
+	currentProxyCACMHash, err := utils.GetProxyCACertHash(r, ctx, cr)
 	if err != nil && !apierrors.IsNotFound(err) {
-		r.GetLogger().Info("failed to get Proxy CA ConfigMap ResourceVersion", "error", err)
+		r.GetLogger().Info("failed to get Proxy CA certificate hash", "error", err)
 		changed = true
 	} else {
-		storedProxyCACMVersion := existingDeployment.Annotations[utils.ProxyCACertResourceVersionAnnotation]
-		if storedProxyCACMVersion != currentProxyCACMVersion {
+		storedProxyCACMHash := existingDeployment.Annotations[utils.ProxyCACertResourceVersionAnnotation]
+		if storedProxyCACMHash != currentProxyCACMHash {
+			r.GetLogger().Info("Proxy CA certificate content changed, updating deployment")
 			changed = true
 		}
 	}
@@ -586,7 +587,7 @@ func updateOLSDeployment(r reconciler.Reconciler, ctx context.Context, cr *olsv1
 
 	existingDeployment.Annotations[utils.OLSConfigMapResourceVersionAnnotation] = desiredDeployment.Annotations[utils.OLSConfigMapResourceVersionAnnotation]
 	existingDeployment.Annotations[utils.OpenShiftMCPServerConfigMapResourceVersionAnnotation] = desiredDeployment.Annotations[utils.OpenShiftMCPServerConfigMapResourceVersionAnnotation]
-	existingDeployment.Annotations[utils.ProxyCACertResourceVersionAnnotation] = currentProxyCACMVersion
+	existingDeployment.Annotations[utils.ProxyCACertResourceVersionAnnotation] = currentProxyCACMHash
 
 	r.GetLogger().Info("updating OLS deployment", "name", existingDeployment.Name)
 

--- a/internal/controller/appserver/deployment.go
+++ b/internal/controller/appserver/deployment.go
@@ -389,7 +389,7 @@ func GenerateOLSDeployment(r reconciler.Reconciler, cr *olsv1alpha1.OLSConfig) (
 			Annotations: map[string]string{
 				utils.OLSConfigMapResourceVersionAnnotation:                configMapResourceVersion,
 				utils.OpenShiftMCPServerConfigMapResourceVersionAnnotation: mcpConfigMapResourceVersion,
-				utils.ProxyCACertHashAnnotation:                 proxyCACMResourceVersion,
+				utils.ProxyCACertHashAnnotation:                            proxyCACMResourceVersion,
 			},
 		},
 		Spec: appsv1.DeploymentSpec{

--- a/internal/controller/lcore/deployment.go
+++ b/internal/controller/lcore/deployment.go
@@ -997,7 +997,7 @@ func generateLCoreServerDeployment(r reconciler.Reconciler, ctx context.Context,
 				utils.LCoreConfigMapResourceVersionAnnotation:              lcoreConfigMapResourceVersion,
 				utils.LlamaStackConfigMapResourceVersionAnnotation:         llamaStackConfigMapResourceVersion,
 				utils.OpenShiftMCPServerConfigMapResourceVersionAnnotation: mcpConfigMapResourceVersion,
-				utils.ProxyCACertHashAnnotation:                 proxyCACMResourceVersion,
+				utils.ProxyCACertHashAnnotation:                            proxyCACMResourceVersion,
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -1276,7 +1276,7 @@ func generateLCoreLibraryDeployment(r reconciler.Reconciler, ctx context.Context
 				utils.LCoreConfigMapResourceVersionAnnotation:              lcoreConfigMapResourceVersion,
 				utils.LlamaStackConfigMapResourceVersionAnnotation:         llamaStackConfigMapResourceVersion,
 				utils.OpenShiftMCPServerConfigMapResourceVersionAnnotation: mcpConfigMapResourceVersion,
-				utils.ProxyCACertHashAnnotation:                 proxyCACMResourceVersion,
+				utils.ProxyCACertHashAnnotation:                            proxyCACMResourceVersion,
 			},
 		},
 		Spec: appsv1.DeploymentSpec{

--- a/internal/controller/lcore/deployment.go
+++ b/internal/controller/lcore/deployment.go
@@ -793,9 +793,9 @@ func generateLCoreServerDeployment(r reconciler.Reconciler, ctx context.Context,
 	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, fmt.Errorf("failed to get MCP Server ConfigMap resource version: %w", err)
 	}
-	proxyCACMResourceVersion, err := utils.GetProxyCACertResourceVersion(r, ctx, cr)
+	proxyCACMResourceVersion, err := utils.GetProxyCACertHash(r, ctx, cr)
 	if err != nil && !apierrors.IsNotFound(err) {
-		return nil, fmt.Errorf("failed to get Proxy CA ConfigMap resource version: %w", err)
+		return nil, fmt.Errorf("failed to get Proxy CA certificate hash: %w", err)
 	}
 
 	// Use helper functions to build common components
@@ -1130,14 +1130,15 @@ func updateLCoreDeployment(r reconciler.Reconciler, ctx context.Context, cr *ols
 		}
 	}
 
-	// Check if Proxy CA ConfigMap ResourceVersion has changed
-	currentProxyCACMVersion, err := utils.GetProxyCACertResourceVersion(r, ctx, cr)
+	// Check if Proxy CA certificate content has changed
+	currentProxyCACMHash, err := utils.GetProxyCACertHash(r, ctx, cr)
 	if err != nil && !apierrors.IsNotFound(err) {
-		r.GetLogger().Info("failed to get Proxy CA ConfigMap ResourceVersion", "error", err)
+		r.GetLogger().Info("failed to get Proxy CA certificate hash", "error", err)
 		changed = true
 	} else {
-		storedProxyCACMVersion := existingDeployment.Annotations[utils.ProxyCACertResourceVersionAnnotation]
-		if storedProxyCACMVersion != currentProxyCACMVersion {
+		storedProxyCACMHash := existingDeployment.Annotations[utils.ProxyCACertResourceVersionAnnotation]
+		if storedProxyCACMHash != currentProxyCACMHash {
+			r.GetLogger().Info("Proxy CA certificate content changed, updating deployment")
 			changed = true
 		}
 	}
@@ -1158,7 +1159,7 @@ func updateLCoreDeployment(r reconciler.Reconciler, ctx context.Context, cr *ols
 	existingDeployment.Annotations[utils.LCoreConfigMapResourceVersionAnnotation] = desiredDeployment.Annotations[utils.LCoreConfigMapResourceVersionAnnotation]
 	existingDeployment.Annotations[utils.LlamaStackConfigMapResourceVersionAnnotation] = desiredDeployment.Annotations[utils.LlamaStackConfigMapResourceVersionAnnotation]
 	existingDeployment.Annotations[utils.OpenShiftMCPServerConfigMapResourceVersionAnnotation] = desiredDeployment.Annotations[utils.OpenShiftMCPServerConfigMapResourceVersionAnnotation]
-	existingDeployment.Annotations[utils.ProxyCACertResourceVersionAnnotation] = currentProxyCACMVersion
+	existingDeployment.Annotations[utils.ProxyCACertResourceVersionAnnotation] = currentProxyCACMHash
 
 	r.GetLogger().Info("updating LCore deployment", "name", existingDeployment.Name)
 
@@ -1195,9 +1196,9 @@ func generateLCoreLibraryDeployment(r reconciler.Reconciler, ctx context.Context
 	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, fmt.Errorf("failed to get MCP Server ConfigMap resource version: %w", err)
 	}
-	proxyCACMResourceVersion, err := utils.GetProxyCACertResourceVersion(r, ctx, cr)
+	proxyCACMResourceVersion, err := utils.GetProxyCACertHash(r, ctx, cr)
 	if err != nil && !apierrors.IsNotFound(err) {
-		return nil, fmt.Errorf("failed to get Proxy CA ConfigMap resource version: %w", err)
+		return nil, fmt.Errorf("failed to get Proxy CA certificate hash: %w", err)
 	}
 
 	// Use helper functions to build common components

--- a/internal/controller/lcore/deployment.go
+++ b/internal/controller/lcore/deployment.go
@@ -997,7 +997,7 @@ func generateLCoreServerDeployment(r reconciler.Reconciler, ctx context.Context,
 				utils.LCoreConfigMapResourceVersionAnnotation:              lcoreConfigMapResourceVersion,
 				utils.LlamaStackConfigMapResourceVersionAnnotation:         llamaStackConfigMapResourceVersion,
 				utils.OpenShiftMCPServerConfigMapResourceVersionAnnotation: mcpConfigMapResourceVersion,
-				utils.ProxyCACertResourceVersionAnnotation:                 proxyCACMResourceVersion,
+				utils.ProxyCACertHashAnnotation:                 proxyCACMResourceVersion,
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -1136,7 +1136,7 @@ func updateLCoreDeployment(r reconciler.Reconciler, ctx context.Context, cr *ols
 		r.GetLogger().Info("failed to get Proxy CA certificate hash", "error", err)
 		changed = true
 	} else {
-		storedProxyCACMHash := existingDeployment.Annotations[utils.ProxyCACertResourceVersionAnnotation]
+		storedProxyCACMHash := existingDeployment.Annotations[utils.ProxyCACertHashAnnotation]
 		if storedProxyCACMHash != currentProxyCACMHash {
 			r.GetLogger().Info("Proxy CA certificate content changed, updating deployment")
 			changed = true
@@ -1159,7 +1159,7 @@ func updateLCoreDeployment(r reconciler.Reconciler, ctx context.Context, cr *ols
 	existingDeployment.Annotations[utils.LCoreConfigMapResourceVersionAnnotation] = desiredDeployment.Annotations[utils.LCoreConfigMapResourceVersionAnnotation]
 	existingDeployment.Annotations[utils.LlamaStackConfigMapResourceVersionAnnotation] = desiredDeployment.Annotations[utils.LlamaStackConfigMapResourceVersionAnnotation]
 	existingDeployment.Annotations[utils.OpenShiftMCPServerConfigMapResourceVersionAnnotation] = desiredDeployment.Annotations[utils.OpenShiftMCPServerConfigMapResourceVersionAnnotation]
-	existingDeployment.Annotations[utils.ProxyCACertResourceVersionAnnotation] = currentProxyCACMHash
+	existingDeployment.Annotations[utils.ProxyCACertHashAnnotation] = currentProxyCACMHash
 
 	r.GetLogger().Info("updating LCore deployment", "name", existingDeployment.Name)
 
@@ -1276,7 +1276,7 @@ func generateLCoreLibraryDeployment(r reconciler.Reconciler, ctx context.Context
 				utils.LCoreConfigMapResourceVersionAnnotation:              lcoreConfigMapResourceVersion,
 				utils.LlamaStackConfigMapResourceVersionAnnotation:         llamaStackConfigMapResourceVersion,
 				utils.OpenShiftMCPServerConfigMapResourceVersionAnnotation: mcpConfigMapResourceVersion,
-				utils.ProxyCACertResourceVersionAnnotation:                 proxyCACMResourceVersion,
+				utils.ProxyCACertHashAnnotation:                 proxyCACMResourceVersion,
 			},
 		},
 		Spec: appsv1.DeploymentSpec{

--- a/internal/controller/lcore/reconciler_test.go
+++ b/internal/controller/lcore/reconciler_test.go
@@ -229,7 +229,7 @@ var _ = Describe("LCore reconciliator", Ordered, func() {
 			cm.Name = proxyCACMName
 			cm.Namespace = utils.OLSNamespaceDefault
 			cm.Data = map[string]string{
-				"ca-bundle.crt": "test-proxy-ca-cert-content",
+				utils.ProxyCACertFileName: "test-proxy-ca-cert-content",
 			}
 			err = k8sClient.Create(ctx, cm)
 			Expect(err).NotTo(HaveOccurred())

--- a/internal/controller/utils/constants.go
+++ b/internal/controller/utils/constants.go
@@ -107,10 +107,8 @@ const (
 	OLSConsoleTLSHashKey = "hash/olsconsoletls"
 	// AdditionalCAHashKey is the key of the hash value of the additional CA certificates in the deployment annotations
 	AdditionalCAHashKey = "hash/additionalca"
-	// ProxyCACertResourceVersionAnnotation is the annotation key for tracking Proxy CA certificate content hash.
-	// Despite the name referencing "ResourceVersion" for backward compatibility, this now stores a SHA256 hash
-	// of the certificate content to ensure deployments only restart when the cert actually changes.
-	ProxyCACertResourceVersionAnnotation = "ols.openshift.io/proxy-ca-configmap-version"
+	// ProxyCACertHashAnnotation is the annotation key for tracking Proxy CA certificate content hash.
+	ProxyCACertHashAnnotation = "ols.openshift.io/proxy-ca-configmap-version"
 	// OLSAppServerContainerPort is the port number of the lightspeed-service-api container exposes
 	OLSAppServerContainerPort = 8443
 	// OLSAppServerServicePort is the port number for OLS application server service.

--- a/internal/controller/utils/constants.go
+++ b/internal/controller/utils/constants.go
@@ -108,7 +108,7 @@ const (
 	// AdditionalCAHashKey is the key of the hash value of the additional CA certificates in the deployment annotations
 	AdditionalCAHashKey = "hash/additionalca"
 	// ProxyCACertHashAnnotation is the annotation key for tracking Proxy CA certificate content hash.
-	ProxyCACertHashAnnotation = "ols.openshift.io/proxy-ca-configmap-version"
+	ProxyCACertHashAnnotation = "ols.openshift.io/proxy-ca-configmap-hash"
 	// OLSAppServerContainerPort is the port number of the lightspeed-service-api container exposes
 	OLSAppServerContainerPort = 8443
 	// OLSAppServerServicePort is the port number for OLS application server service.

--- a/internal/controller/utils/constants.go
+++ b/internal/controller/utils/constants.go
@@ -107,7 +107,9 @@ const (
 	OLSConsoleTLSHashKey = "hash/olsconsoletls"
 	// AdditionalCAHashKey is the key of the hash value of the additional CA certificates in the deployment annotations
 	AdditionalCAHashKey = "hash/additionalca"
-	// ProxyCACertResourceVersionAnnotation is the annotation key for tracking Proxy CA ConfigMap ResourceVersion
+	// ProxyCACertResourceVersionAnnotation is the annotation key for tracking Proxy CA certificate content hash.
+	// Despite the name referencing "ResourceVersion" for backward compatibility, this now stores a SHA256 hash
+	// of the certificate content to ensure deployments only restart when the cert actually changes.
 	ProxyCACertResourceVersionAnnotation = "ols.openshift.io/proxy-ca-configmap-version"
 	// OLSAppServerContainerPort is the port number of the lightspeed-service-api container exposes
 	OLSAppServerContainerPort = 8443

--- a/internal/controller/utils/utils.go
+++ b/internal/controller/utils/utils.go
@@ -18,6 +18,7 @@ package utils
 import (
 	"context"
 	"crypto/sha1" //nolint:gosec
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
@@ -798,9 +799,12 @@ func GetConfigMapResourceVersion(r reconciler.Reconciler, ctx context.Context, c
 	return configMap.ResourceVersion, nil
 }
 
-// GetProxyCACertResourceVersion returns the ResourceVersion of the proxy CA ConfigMap
-// if proxy CA is configured. Returns empty string and nil error if proxy is not configured.
-func GetProxyCACertResourceVersion(r reconciler.Reconciler, ctx context.Context, cr *olsv1alpha1.OLSConfig) (string, error) {
+// GetProxyCACertHash returns a SHA256 hash of the proxy CA certificate content
+// if proxy CA is configured. This ensures deployments only restart when the certificate
+// content actually changes, not just when the ConfigMap ResourceVersion changes
+// (which can happen frequently for service-ca managed ConfigMaps).
+// Returns empty string and nil error if proxy is not configured.
+func GetProxyCACertHash(r reconciler.Reconciler, ctx context.Context, cr *olsv1alpha1.OLSConfig) (string, error) {
 	if cr.Spec.OLSConfig.ProxyConfig == nil {
 		return "", nil
 	}
@@ -808,7 +812,21 @@ func GetProxyCACertResourceVersion(r reconciler.Reconciler, ctx context.Context,
 	if cmName == "" {
 		return "", nil
 	}
-	return GetConfigMapResourceVersion(r, ctx, cmName)
+
+	cm := &corev1.ConfigMap{}
+	err := r.Get(ctx, client.ObjectKey{Name: cmName, Namespace: r.GetNamespace()}, cm)
+	if err != nil {
+		return "", err
+	}
+
+	certKey := GetProxyCACertKey(cr.Spec.OLSConfig.ProxyConfig.ProxyCACertificateRef)
+	certData, ok := cm.Data[certKey]
+	if !ok {
+		return "", fmt.Errorf("proxy CA certificate key %s not found in ConfigMap %s", certKey, cmName)
+	}
+
+	hash := sha256.Sum256([]byte(certData))
+	return hex.EncodeToString(hash[:]), nil
 }
 
 // GetSecretResourceVersion returns the ResourceVersion of a Secret.

--- a/internal/controller/utils/utils_proxy_ca_test.go
+++ b/internal/controller/utils/utils_proxy_ca_test.go
@@ -1,0 +1,224 @@
+package utils
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	olsv1alpha1 "github.com/openshift/lightspeed-operator/api/v1alpha1"
+)
+
+var _ = Describe("GetProxyCACertHash", func() {
+	var (
+		ctx               context.Context
+		testReconciler    *TestReconciler
+		testOLSConfig     *olsv1alpha1.OLSConfig
+		testConfigMap     *corev1.ConfigMap
+		testCertContent   string
+		testConfigMapName string
+		testCertKey       string
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		testCertContent = "-----BEGIN CERTIFICATE-----\nMIIDXTCCAkWgAwIBAgIJAKZ7VZ\n-----END CERTIFICATE-----"
+		testConfigMapName = "test-proxy-ca-cm"
+		testCertKey = ProxyCACertFileName
+
+		testReconciler = NewTestReconciler(k8sClient, logf.Log, scheme.Scheme, OLSNamespaceDefault)
+
+		testOLSConfig = &olsv1alpha1.OLSConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-olsconfig",
+			},
+			Spec: olsv1alpha1.OLSConfigSpec{
+				OLSConfig: olsv1alpha1.OLSSpec{
+					ProxyConfig: &olsv1alpha1.ProxyConfig{
+						ProxyURL: "https://proxy.example.com:8443",
+						ProxyCACertificateRef: &olsv1alpha1.ProxyCACertConfigMapRef{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: testConfigMapName,
+							},
+							Key: testCertKey,
+						},
+					},
+				},
+			},
+		}
+
+		testConfigMap = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testConfigMapName,
+				Namespace: OLSNamespaceDefault,
+			},
+			Data: map[string]string{
+				testCertKey: testCertContent,
+			},
+		}
+	})
+
+	AfterEach(func() {
+		if testConfigMap != nil {
+			_ = k8sClient.Delete(ctx, testConfigMap)
+		}
+	})
+
+	Context("when proxy CA is configured", func() {
+		It("should return the SHA256 hash of the certificate content", func() {
+			Expect(k8sClient.Create(ctx, testConfigMap)).To(Succeed())
+
+			hash, err := GetProxyCACertHash(testReconciler, ctx, testOLSConfig)
+
+			Expect(err).NotTo(HaveOccurred())
+
+			expectedHash := sha256.Sum256([]byte(testCertContent))
+			expectedHashString := hex.EncodeToString(expectedHash[:])
+
+			Expect(hash).To(Equal(expectedHashString))
+		})
+
+		It("should return consistent hash for same certificate content", func() {
+			Expect(k8sClient.Create(ctx, testConfigMap)).To(Succeed())
+
+			hash1, err1 := GetProxyCACertHash(testReconciler, ctx, testOLSConfig)
+			hash2, err2 := GetProxyCACertHash(testReconciler, ctx, testOLSConfig)
+
+			Expect(err1).NotTo(HaveOccurred())
+			Expect(err2).NotTo(HaveOccurred())
+			Expect(hash1).To(Equal(hash2))
+			Expect(hash1).NotTo(BeEmpty())
+		})
+
+		It("should return different hash when certificate content changes", func() {
+			Expect(k8sClient.Create(ctx, testConfigMap)).To(Succeed())
+
+			hash1, err := GetProxyCACertHash(testReconciler, ctx, testOLSConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			testConfigMap.Data[testCertKey] = "-----BEGIN CERTIFICATE-----\nDIFFERENT_CERT\n-----END CERTIFICATE-----"
+			Expect(k8sClient.Update(ctx, testConfigMap)).To(Succeed())
+
+			hash2, err := GetProxyCACertHash(testReconciler, ctx, testOLSConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(hash1).NotTo(Equal(hash2))
+			Expect(hash1).NotTo(BeEmpty())
+			Expect(hash2).NotTo(BeEmpty())
+		})
+
+		It("should return error when ConfigMap does not exist", func() {
+			hash, err := GetProxyCACertHash(testReconciler, ctx, testOLSConfig)
+
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			Expect(hash).To(BeEmpty())
+		})
+
+		It("should return error when certificate key is missing from ConfigMap", func() {
+			testConfigMap.Data = map[string]string{
+				"wrong-key": testCertContent,
+			}
+			Expect(k8sClient.Create(ctx, testConfigMap)).To(Succeed())
+
+			hash, err := GetProxyCACertHash(testReconciler, ctx, testOLSConfig)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not found in ConfigMap"))
+			Expect(hash).To(BeEmpty())
+		})
+
+		It("should use custom key when specified in ProxyCACertificateRef", func() {
+			customKey := "custom-ca.crt"
+			testOLSConfig.Spec.OLSConfig.ProxyConfig.ProxyCACertificateRef.Key = customKey
+			testConfigMap.Data = map[string]string{
+				customKey: testCertContent,
+			}
+			Expect(k8sClient.Create(ctx, testConfigMap)).To(Succeed())
+
+			hash, err := GetProxyCACertHash(testReconciler, ctx, testOLSConfig)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hash).NotTo(BeEmpty())
+
+			expectedHash := sha256.Sum256([]byte(testCertContent))
+			expectedHashString := hex.EncodeToString(expectedHash[:])
+			Expect(hash).To(Equal(expectedHashString))
+		})
+	})
+
+	Context("when proxy is not configured", func() {
+		It("should return empty string when ProxyConfig is nil", func() {
+			testOLSConfig.Spec.OLSConfig.ProxyConfig = nil
+
+			hash, err := GetProxyCACertHash(testReconciler, ctx, testOLSConfig)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hash).To(BeEmpty())
+		})
+
+		It("should return empty string when ProxyCACertificateRef is nil", func() {
+			testOLSConfig.Spec.OLSConfig.ProxyConfig.ProxyCACertificateRef = nil
+
+			hash, err := GetProxyCACertHash(testReconciler, ctx, testOLSConfig)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hash).To(BeEmpty())
+		})
+
+		It("should return empty string when ConfigMap name is empty", func() {
+			testOLSConfig.Spec.OLSConfig.ProxyConfig.ProxyCACertificateRef.Name = ""
+
+			hash, err := GetProxyCACertHash(testReconciler, ctx, testOLSConfig)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hash).To(BeEmpty())
+		})
+	})
+
+	Context("hash validation for reconciliation behavior", func() {
+		It("should detect actual certificate changes (not just ResourceVersion changes)", func() {
+			// This validates the main purpose: deployments only restart when certificate
+			// content changes, not when ConfigMap ResourceVersion changes (e.g., service-ca updates)
+
+			Expect(k8sClient.Create(ctx, testConfigMap)).To(Succeed())
+
+			hash1, err := GetProxyCACertHash(testReconciler, ctx, testOLSConfig)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hash1).NotTo(BeEmpty())
+
+			cm := &corev1.ConfigMap{}
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: testConfigMapName, Namespace: OLSNamespaceDefault}, cm)).To(Succeed())
+
+			if cm.Annotations == nil {
+				cm.Annotations = make(map[string]string)
+			}
+			cm.Annotations["test-annotation"] = "test-value"
+			Expect(k8sClient.Update(ctx, cm)).To(Succeed())
+
+			hash2, err := GetProxyCACertHash(testReconciler, ctx, testOLSConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Hash should be identical because certificate content didn't change
+			Expect(hash2).To(Equal(hash1))
+
+			cm.Data[testCertKey] = "-----BEGIN CERTIFICATE-----\nNEW_CERT\n-----END CERTIFICATE-----"
+			Expect(k8sClient.Update(ctx, cm)).To(Succeed())
+
+			hash3, err := GetProxyCACertHash(testReconciler, ctx, testOLSConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Hash should be different because certificate content changed
+			Expect(hash3).NotTo(Equal(hash1))
+			Expect(hash3).NotTo(Equal(hash2))
+		})
+	})
+})

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -34,7 +34,7 @@ const (
 // - Creates test infrastructure (squid proxy) and cleans up with DeleteAndWait
 // - All tests share a single cluster-scoped OLSConfig CR
 // - FlakeAttempts(5) handles transient network and port-forwarding issues
-var _ = XDescribe("Proxy test", Ordered, Label("Proxy"), FlakeAttempts(5), func() {
+var _ = Describe("Proxy test", Ordered, Label("Proxy"), FlakeAttempts(5), func() {
 
 	var cr *olsv1alpha1.OLSConfig
 	var err error


### PR DESCRIPTION
## Description

Logic for configmap resourceversion was causing an infinite reconciliation loop on checking the resourceversion of openshift-service-ca.crt since the resourceVersion of this configmap is constantly updated.
Instead we check for the content hash and only reconcile if that has changed.
Also reenabling proxy test to verify if issue is solved

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
