### PR TITLE
OLS-2772: dedicated console image for OCP 4.19 - 4.21

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ endif
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.33.0
+OPERATOR_SDK_VERSION ?= v1.36.1
 
 # Image URL to use all building/pushing image targets
 IMG ?= $(IMAGE_TAG_BASE):$(VERSION)

--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     console.openshift.io/operator-monitoring-default: "true"
-    createdAt: "2026-04-10T08:19:49Z"
+    createdAt: "2026-04-15T21:37:03Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -876,6 +876,7 @@ spec:
                       - --service-image=registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9@sha256:7314d1c8cf1469f558376439f6c17713238e5676d7808e07d8183516b1e1a057
                       - --console-image=registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:405f82a75608e34551de89af9a7639a1b54021f1a88c51327a45269d34e70ff9
                       - --console-image-pf5=registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-pf5-rhel9@sha256:d886c434e03774448c44abe97bd79f660b6114c2585944441aab30e26599c270
+                      - --console-image-4-19=registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-419-rhel9@sha256:cd6199b76eadbf921dc303850d401841a0653a6b77bff7dbf4c83b1db84f49fb
                       - --postgres-image=registry.redhat.io/rhel9/postgresql-16@sha256:42f385ac3c9b8913426da7c57e70bc6617cd237aaf697c667f6385a8c0b0118b
                       - --openshift-mcp-server-image=registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9@sha256:55dd00232a33bdfa68d7b0087e7e6efa527baee5d0675829479e49fb52edcec8
                       - --dataverse-exporter-image=registry.redhat.io/lightspeed-core/dataverse-exporter-rhel9@sha256:dc071421c925dbe55fd03765f7a2ede7140e9a4d49aa95c0b4d2435cbee95f0f
@@ -1003,6 +1004,8 @@ spec:
       image: registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:405f82a75608e34551de89af9a7639a1b54021f1a88c51327a45269d34e70ff9
     - name: lightspeed-console-plugin-pf5
       image: registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-pf5-rhel9@sha256:d886c434e03774448c44abe97bd79f660b6114c2585944441aab30e26599c270
+    - name: lightspeed-console-plugin-4-19
+      image: registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-419-rhel9@sha256:cd6199b76eadbf921dc303850d401841a0653a6b77bff7dbf4c83b1db84f49fb
     - name: lightspeed-operator
       image: registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:f972945e6cae4273d0e5547f65a4473939cca39bacfdb889e8ade2bba974db7b
     - name: openshift-mcp-server

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -98,6 +98,7 @@ var (
 		"postgres-image":             utils.PostgresServerImageDefault,
 		"console-plugin":             utils.ConsoleUIImageDefault,
 		"console-plugin-pf5":         utils.ConsoleUIImagePF5Default,
+		"console-plugin-4-19":        utils.ConsoleUIImage419Default,
 		"openshift-mcp-server-image": utils.OpenShiftMCPServerImageDefault,
 		"lightspeed-core":            utils.LlamaStackImageDefault,
 		"dataverse-exporter-image":   utils.DataverseExporterImageDefault,
@@ -119,7 +120,7 @@ func init() {
 
 // overrideImages overrides the default images with the images provided by the user.
 // If an image is not provided, the default is used.
-func overrideImages(serviceImage string, consoleImage string, consoleImage_pf5 string, postgresImage string, openshiftMCPServerImage string, lcoreImage string, dataverseExporterImage string, ocpRagImage string) map[string]string {
+func overrideImages(serviceImage string, consoleImage string, consoleImage_pf5 string, consoleImage_419 string, postgresImage string, openshiftMCPServerImage string, lcoreImage string, dataverseExporterImage string, ocpRagImage string) map[string]string {
 	res := defaultImages
 	if serviceImage != "" {
 		res["lightspeed-service"] = serviceImage
@@ -129,6 +130,9 @@ func overrideImages(serviceImage string, consoleImage string, consoleImage_pf5 s
 	}
 	if consoleImage_pf5 != "" {
 		res["console-plugin-pf5"] = consoleImage_pf5
+	}
+	if consoleImage_419 != "" {
+		res["console-plugin-4-19"] = consoleImage_419
 	}
 	if postgresImage != "" {
 		res["postgres-image"] = postgresImage
@@ -173,6 +177,7 @@ func main() {
 	var serviceImage string
 	var consoleImage string
 	var consoleImage_pf5 string
+	var consoleImage_419 string
 	var namespace string
 	var postgresImage string
 	var openshiftMCPServerImage string
@@ -194,6 +199,7 @@ func main() {
 	flag.StringVar(&serviceImage, "service-image", utils.OLSAppServerImageDefault, "The image of the lightspeed-service container.")
 	flag.StringVar(&consoleImage, "console-image", utils.ConsoleUIImageDefault, "The image of the console-plugin container using PatternFly 6.")
 	flag.StringVar(&consoleImage_pf5, "console-image-pf5", utils.ConsoleUIImagePF5Default, "The image of the console-plugin container using PatternFly 5.")
+	flag.StringVar(&consoleImage_419, "console-image-4-19", utils.ConsoleUIImage419Default, "The image of the console-plugin container for OCP 4.19 - 4.21.")
 	flag.StringVar(&namespace, "namespace", "", "The namespace where the operator is deployed.")
 	flag.StringVar(&postgresImage, "postgres-image", utils.PostgresServerImageDefault, "The image of the PostgreSQL server.")
 	flag.StringVar(&openshiftMCPServerImage, "openshift-mcp-server-image", utils.OpenShiftMCPServerImageDefault, "The image of the OpenShift MCP server container.")
@@ -214,7 +220,7 @@ func main() {
 		namespace = getWatchNamespace()
 	}
 
-	imagesMap := overrideImages(serviceImage, consoleImage, consoleImage_pf5, postgresImage, openshiftMCPServerImage, lcoreImage, dataverseExporterImage, ocpRagImage)
+	imagesMap := overrideImages(serviceImage, consoleImage, consoleImage_pf5, consoleImage_419, postgresImage, openshiftMCPServerImage, lcoreImage, dataverseExporterImage, ocpRagImage)
 	setupLog.Info("Images setting loaded", "images", listImages())
 
 	// Log which backend is being used
@@ -347,8 +353,11 @@ func main() {
 	if mVersion < 19 {
 		// Use PF5
 		consoleImage = imagesMap["console-plugin-pf5"]
+	} else if mVersion < 22 {
+		// Use 4.19 - 4.21 PF6 image
+		consoleImage = imagesMap["console-plugin-4-19"]
 	} else {
-		// Use PF6
+		// Use 4.22+ image
 		consoleImage = imagesMap["console-plugin"]
 	}
 

--- a/config/default/deployment-patch.yaml
+++ b/config/default/deployment-patch.yaml
@@ -11,6 +11,9 @@
   value: --console-image-pf5=__REPLACE_LIGHTSPEED_CONSOLE_PLUGIN_PF5__
 - op: add
   path: /spec/template/spec/containers/0/args/-
+  value: --console-image-4-19=__REPLACE_LIGHTSPEED_CONSOLE_PLUGIN_4_19__
+- op: add
+  path: /spec/template/spec/containers/0/args/-
   value: --postgres-image=__REPLACE_LIGHTSPEED_POSTGRESQL__
 - op: add
   path: /spec/template/spec/containers/0/args/-

--- a/hack/image_placeholders.json
+++ b/hack/image_placeholders.json
@@ -35,6 +35,11 @@
     "target": "args"
   },
   {
+    "name": "lightspeed-console-plugin-4-19",
+    "placeholder": "__REPLACE_LIGHTSPEED_CONSOLE_PLUGIN_4_19__",
+    "target": "args"
+  },
+  {
     "name": "lightspeed-postgresql",
     "placeholder": "__REPLACE_LIGHTSPEED_POSTGRESQL__",
     "target": "args"

--- a/hack/snapshot_to_image_list.sh
+++ b/hack/snapshot_to_image_list.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 
 usage() {
-    echo "Usage: $0 -s <snapshot-ref> -b <bundle-snapshot-ref> -o <output-file> -p"
-    echo "  -s snapshot-ref: required, the snapshot's references, example: ols-cq8sl"
-    echo "  -b bundle-snapshot-ref: optional, the ols-bundle snapshot's references, example: ols-bundle-wf8st"
-    echo "  -o output-file: optional, the catalog index file to update, default is empty (output to stdout)"
-    echo "  -r: optional, use which registry: stable, preview, ci"
-    echo "  -h: Show this help message"
-    echo "Example: $0 -s ols-cq8sl -b ols-bundle-wf8st -o related_images.json"
+	echo "Usage: $0 -s <snapshot-ref> -b <bundle-snapshot-ref> -o <output-file> -p"
+	echo "  -s snapshot-ref: required, the snapshot's references, example: ols-cq8sl"
+	echo "  -b bundle-snapshot-ref: optional, the ols-bundle snapshot's references, example: ols-bundle-wf8st"
+	echo "  -o output-file: optional, the catalog index file to update, default is empty (output to stdout)"
+	echo "  -r: optional, use which registry: stable, preview, ci"
+	echo "  -h: Show this help message"
+	echo "Example: $0 -s ols-cq8sl -b ols-bundle-wf8st -o related_images.json"
 }
 
 if [ $# == 0 ]; then
-    usage
-    exit 1
+	usage
+	exit 1
 fi
 
 SNAPSHOT_REF=""
@@ -21,55 +21,55 @@ USE_REGISTRY="ci"
 KONFLUX_NAMESPACE="crt-nshift-lightspeed-tenant"
 
 while getopts ":s:b:o:r:h" argname; do
-    case "$argname" in
-    "s")
-        SNAPSHOT_REF=${OPTARG}
-        ;;
-    "b")
-        BUNDLE_SNAPSHOT_REF=${OPTARG}
-        ;;
-    "o")
-        OUTPUT_FILE=${OPTARG}
-        ;;
-    "r")
-        USE_REGISTRY=${OPTARG}
-        if [[ "${USE_REGISTRY}" != "stable" && "${USE_REGISTRY}" != "preview" && "${USE_REGISTRY}" != "ci" ]]; then
-            echo "Invalid registry option: ${USE_REGISTRY}. Use 'stable', 'preview', or 'ci'."
-            usage
-            exit 1
-        fi
-        ;;
-    "h")
-        usage
-        exit 0
-        ;;
-    "?")
-        echo "Unknown option $OPTARG"
-        usage
-        exit 1
-        ;;
-    *)
-        echo "Unknown error while processing options"
-        exit 1
-        ;;
-    esac
+	case "$argname" in
+	"s")
+		SNAPSHOT_REF=${OPTARG}
+		;;
+	"b")
+		BUNDLE_SNAPSHOT_REF=${OPTARG}
+		;;
+	"o")
+		OUTPUT_FILE=${OPTARG}
+		;;
+	"r")
+		USE_REGISTRY=${OPTARG}
+		if [[ "${USE_REGISTRY}" != "stable" && "${USE_REGISTRY}" != "preview" && "${USE_REGISTRY}" != "ci" ]]; then
+			echo "Invalid registry option: ${USE_REGISTRY}. Use 'stable', 'preview', or 'ci'."
+			usage
+			exit 1
+		fi
+		;;
+	"h")
+		usage
+		exit 0
+		;;
+	"?")
+		echo "Unknown option $OPTARG"
+		usage
+		exit 1
+		;;
+	*)
+		echo "Unknown error while processing options"
+		exit 1
+		;;
+	esac
 done
 
 if [ -z "${SNAPSHOT_REF}" ]; then
-    echo "snapshot-ref is required"
-    usage
-    exit 1
+	echo "snapshot-ref is required"
+	usage
+	exit 1
 fi
 
 if [ -z "${BUNDLE_SNAPSHOT_REF}" ]; then
-    echo "bundle-snapshot-ref is not specified, will not update bundle image"
+	echo "bundle-snapshot-ref is not specified, will not update bundle image"
 fi
 
 : ${JQ:=$(command -v jq)}
 # check if jq exists
 if [ -z "${JQ}" ]; then
-    echo "jq is required"
-    exit 1
+	echo "jq is required"
+	exit 1
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -79,13 +79,13 @@ TMP_SNAPSHOT_JSON=$(mktemp)
 TMP_BUNDLE_SNAPSHOT_JSON=$(mktemp)
 
 cleanup() {
-    # remove temporary snapshot file
-    if [ -n "${TMP_SNAPSHOT_JSON}" ]; then
-        rm -f "${TMP_SNAPSHOT_JSON}"
-    fi
-    if [ -n "${TMP_BUNDLE_SNAPSHOT_JSON}" ]; then
-        rm -f "${TMP_BUNDLE_SNAPSHOT_JSON}"
-    fi
+	# remove temporary snapshot file
+	if [ -n "${TMP_SNAPSHOT_JSON}" ]; then
+		rm -f "${TMP_SNAPSHOT_JSON}"
+	fi
+	if [ -n "${TMP_BUNDLE_SNAPSHOT_JSON}" ]; then
+		rm -f "${TMP_BUNDLE_SNAPSHOT_JSON}"
+	fi
 }
 
 trap cleanup EXIT
@@ -94,27 +94,27 @@ trap cleanup EXIT
 oc get -n ${KONFLUX_NAMESPACE} snapshot ${SNAPSHOT_REF} -o json >"${TMP_SNAPSHOT_JSON}"
 
 if [ $? -ne 0 ]; then
-    echo "Failed to get snapshot ${SNAPSHOT_REF}"
-    echo "Please make sure the snapshot exists and the snapshot name is correct"
-    echo "Need to login Konflux through oc login, proxy command to be found here: https://registration-service-toolchain-host-operator.apps.stone-prd-host1.wdlc.p1.openshiftapps.com/"
-    exit 1
+	echo "Failed to get snapshot ${SNAPSHOT_REF}"
+	echo "Please make sure the snapshot exists and the snapshot name is correct"
+	echo "Need to login Konflux through oc login, proxy command to be found here: https://registration-service-toolchain-host-operator.apps.stone-prd-host1.wdlc.p1.openshiftapps.com/"
+	exit 1
 fi
 
 if [ -n "${BUNDLE_SNAPSHOT_REF}" ]; then
-    oc get -n ${KONFLUX_NAMESPACE} snapshot ${BUNDLE_SNAPSHOT_REF} -o json >"${TMP_BUNDLE_SNAPSHOT_JSON}"
-    if [ $? -ne 0 ]; then
-        echo "Failed to get snapshot ${BUNDLE_SNAPSHOT_REF}"
-        echo "Please make sure the bundle snapshot exists and the snapshot name is correct"
-        exit 1
-    fi
+	oc get -n ${KONFLUX_NAMESPACE} snapshot ${BUNDLE_SNAPSHOT_REF} -o json >"${TMP_BUNDLE_SNAPSHOT_JSON}"
+	if [ $? -ne 0 ]; then
+		echo "Failed to get snapshot ${BUNDLE_SNAPSHOT_REF}"
+		echo "Please make sure the bundle snapshot exists and the snapshot name is correct"
+		exit 1
+	fi
 fi
 
 cp ${TMP_SNAPSHOT_JSON} snapshot.json
 cp ${TMP_BUNDLE_SNAPSHOT_JSON} bundle_snapshot.json
 
 if [ -n "${BUNDLE_SNAPSHOT_REF}" ]; then
-    BUNDLE_IMAGE=$(${JQ} -r '.spec.components[]| select(.name=="ols-bundle") | .containerImage' "${TMP_BUNDLE_SNAPSHOT_JSON}")
-    BUNDLE_REVISION=$(${JQ} -r '.spec.components[]| select(.name=="ols-bundle") | .source.git.revision' "${TMP_BUNDLE_SNAPSHOT_JSON}")
+	BUNDLE_IMAGE=$(${JQ} -r '.spec.components[]| select(.name=="ols-bundle") | .containerImage' "${TMP_BUNDLE_SNAPSHOT_JSON}")
+	BUNDLE_REVISION=$(${JQ} -r '.spec.components[]| select(.name=="ols-bundle") | .source.git.revision' "${TMP_BUNDLE_SNAPSHOT_JSON}")
 fi
 OPERATOR_IMAGE=$(${JQ} -r '.spec.components[]| select(.name=="lightspeed-operator") | .containerImage' "${TMP_SNAPSHOT_JSON}")
 OPERATOR_REVISION=$(${JQ} -r '.spec.components[]| select(.name=="lightspeed-operator") | .source.git.revision' "${TMP_SNAPSHOT_JSON}")
@@ -122,128 +122,150 @@ CONSOLE_IMAGE=$(${JQ} -r '.spec.components[]| select(.name=="lightspeed-console"
 CONSOLE_REVISION=$(${JQ} -r '.spec.components[]| select(.name=="lightspeed-console") | .source.git.revision' "${TMP_SNAPSHOT_JSON}")
 CONSOLE_IMAGE_PF5=$(${JQ} -r '.spec.components[]| select(.name=="lightspeed-console-pf5") | .containerImage' "${TMP_SNAPSHOT_JSON}")
 CONSOLE_REVISION_PF5=$(${JQ} -r '.spec.components[]| select(.name=="lightspeed-console-pf5") | .source.git.revision' "${TMP_SNAPSHOT_JSON}")
+CONSOLE_IMAGE_419=$(${JQ} -r '.spec.components[]| select(.name=="lightspeed-console-4-19") | .containerImage' "${TMP_SNAPSHOT_JSON}")
+CONSOLE_REVISION_419=$(${JQ} -r '.spec.components[]| select(.name=="lightspeed-console-4-19") | .source.git.revision' "${TMP_SNAPSHOT_JSON}")
 SERVICE_IMAGE=$(${JQ} -r '.spec.components[]| select(.name=="lightspeed-service") | .containerImage' "${TMP_SNAPSHOT_JSON}")
 SERVICE_REVISION=$(${JQ} -r '.spec.components[]| select(.name=="lightspeed-service") | .source.git.revision' "${TMP_SNAPSHOT_JSON}")
 OPENSHIFT_MCP_SERVER_IMAGE=$(${JQ} -r '.spec.components[]| select(.name=="openshift-mcp-server") | .containerImage' "${TMP_SNAPSHOT_JSON}")
 OPENSHIFT_MCP_SERVER_REVISION=$(${JQ} -r '.spec.components[]| select(.name=="openshift-mcp-server") | .source.git.revision' "${TMP_SNAPSHOT_JSON}")
-DATAVERSE_EXPORTER_IMAGE=$(${JQ} -r '.spec.components[]| select(.name=="lightspeed-to-dataverse-exporter") | .containerImage' "${TMP_SNAPSHOT_JSON}")
-DATAVERSE_EXPORTER_REVISION=$(${JQ} -r '.spec.components[]| select(.name=="lightspeed-to-dataverse-exporter") | .source.git.revision' "${TMP_SNAPSHOT_JSON}")
 OCP_RAG_IMAGE=$(${JQ} -r '.spec.components[]| select(.name=="lightspeed-ocp-rag") | .containerImage' "${TMP_SNAPSHOT_JSON}")
 OCP_RAG_REVISION=$(${JQ} -r '.spec.components[]| select(.name=="lightspeed-ocp-rag") | .source.git.revision' "${TMP_SNAPSHOT_JSON}")
 if [ "${USE_REGISTRY}" = "preview" ]; then
-    OPERATOR_IMAGE_BASE="registry.redhat.io/openshift-lightspeed-tech-preview/lightspeed-rhel9-operator"
-    CONSOLE_IMAGE_BASE="registry.redhat.io/openshift-lightspeed-tech-preview/lightspeed-console-plugin-rhel9"
-    CONSOLE_IMAGE_BASE_PF5="registry.redhat.io/openshift-lightspeed-tech-preview/lightspeed-console-plugin-pf5-rhel9"
-    SERVICE_IMAGE_BASE="registry.redhat.io/openshift-lightspeed-tech-preview/lightspeed-service-api-rhel9"
-    OPENSHIFT_MCP_SERVER_IMAGE_BASE="registry.redhat.io/openshift-lightspeed-tech-preview/openshift-mcp-server-rhel9"
-    DATAVERSE_EXPORTER_IMAGE_BASE="registry.redhat.io/openshift-lightspeed-tech-preview/lightspeed-to-dataverse-exporter-rhel9"
-    OCP_RAG_IMAGE_BASE="registry.redhat.io/openshift-lightspeed-tech-preview/lightspeed-ocp-rag-rhel9"
+	OPERATOR_IMAGE_BASE="registry.redhat.io/openshift-lightspeed-tech-preview/lightspeed-rhel9-operator"
+	CONSOLE_IMAGE_BASE="registry.redhat.io/openshift-lightspeed-tech-preview/lightspeed-console-plugin-rhel9"
+	CONSOLE_IMAGE_BASE_PF5="registry.redhat.io/openshift-lightspeed-tech-preview/lightspeed-console-plugin-pf5-rhel9"
+	CONSOLE_IMAGE_BASE_419="registry.redhat.io/openshift-lightspeed-tech-preview/lightspeed-console-plugin-419-rhel9"
+	SERVICE_IMAGE_BASE="registry.redhat.io/openshift-lightspeed-tech-preview/lightspeed-service-api-rhel9"
+	OPENSHIFT_MCP_SERVER_IMAGE_BASE="registry.redhat.io/openshift-lightspeed-tech-preview/openshift-mcp-server-rhel9"
+	OCP_RAG_IMAGE_BASE="registry.redhat.io/openshift-lightspeed-tech-preview/lightspeed-ocp-rag-rhel9"
 
-    OPERATOR_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator|'"${OPERATOR_IMAGE_BASE}"'|g' <<<${OPERATOR_IMAGE})
-    CONSOLE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console|'"${CONSOLE_IMAGE_BASE}"'|g' <<<${CONSOLE_IMAGE})
-    CONSOLE_IMAGE_PF5=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-console-pf5|'"${CONSOLE_IMAGE_BASE_PF5}"'|g' <<<${CONSOLE_IMAGE_PF5})
-    SERVICE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service|'"${SERVICE_IMAGE_BASE}"'|g' <<<${SERVICE_IMAGE})
-    OPENSHIFT_MCP_SERVER_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/openshift-mcp-server|'"${OPENSHIFT_MCP_SERVER_IMAGE_BASE}"'|g' <<<${OPENSHIFT_MCP_SERVER_IMAGE})
-    DATAVERSE_EXPORTER_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-to-dataverse-exporter|'"${DATAVERSE_EXPORTER_IMAGE_BASE}"'|g' <<<${DATAVERSE_EXPORTER_IMAGE})
-    OCP_RAG_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-ocp-rag|'"${OCP_RAG_IMAGE_BASE}"'|g' <<<${OCP_RAG_EXPORTER_IMAGE})    
-    POSTGRES_IMAGE=$(sed "s|quay\.io.*/lightspeed-postgresql|registry.redhat.io/rhel9/postgresql-16|g" <<<"${POSTGRES_IMAGE}")
+	OPERATOR_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator|'"${OPERATOR_IMAGE_BASE}"'|g' <<<${OPERATOR_IMAGE})
+	CONSOLE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console|'"${CONSOLE_IMAGE_BASE}"'|g' <<<${CONSOLE_IMAGE})
+	CONSOLE_IMAGE_PF5=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-console-pf5|'"${CONSOLE_IMAGE_BASE_PF5}"'|g' <<<${CONSOLE_IMAGE_PF5})
+	CONSOLE_IMAGE_419=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-console-4-19|'"${CONSOLE_IMAGE_BASE_419}"'|g' <<<${CONSOLE_IMAGE_419})
+	SERVICE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service|'"${SERVICE_IMAGE_BASE}"'|g' <<<${SERVICE_IMAGE})
+	OPENSHIFT_MCP_SERVER_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/openshift-mcp-server|'"${OPENSHIFT_MCP_SERVER_IMAGE_BASE}"'|g' <<<${OPENSHIFT_MCP_SERVER_IMAGE})
+	OCP_RAG_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-ocp-rag|'"${OCP_RAG_IMAGE_BASE}"'|g' <<<${OCP_RAG_IMAGE})
+	POSTGRES_IMAGE=$(sed "s|quay\.io.*/lightspeed-postgresql|registry.redhat.io/rhel9/postgresql-16|g" <<<"${POSTGRES_IMAGE}")
 
-    if [ -n "${BUNDLE_SNAPSHOT_REF}" ]; then
-        BUNDLE_IMAGE_BASE="registry.redhat.io/openshift-lightspeed-tech-preview/lightspeed-operator-bundle"
-        BUNDLE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols-bundle|'"${BUNDLE_IMAGE_BASE}"'|g' <<<${BUNDLE_IMAGE})
-    fi
+	if [ -n "${BUNDLE_SNAPSHOT_REF}" ]; then
+		BUNDLE_IMAGE_BASE="registry.redhat.io/openshift-lightspeed-tech-preview/lightspeed-operator-bundle"
+		BUNDLE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols-bundle|'"${BUNDLE_IMAGE_BASE}"'|g' <<<${BUNDLE_IMAGE})
+	fi
 fi
 
 if [ "${USE_REGISTRY}" = "stable" ]; then
-    OPERATOR_IMAGE_BASE="registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator"
-    CONSOLE_IMAGE_BASE="registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9"
-    SERVICE_IMAGE_BASE="registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9"
-    CONSOLE_IMAGE_BASE_PF5="registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-pf5-rhel9"
-    OPENSHIFT_MCP_SERVER_IMAGE_BASE="registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9"
-    DATAVERSE_EXPORTER_IMAGE_BASE="registry.redhat.io/openshift-lightspeed/lightspeed-to-dataverse-exporter-rhel9"
-    OCP_RAG_IMAGE_BASE="registry.redhat.io/openshift-lightspeed/lightspeed-ocp-rag-rhel9"
+	OPERATOR_IMAGE_BASE="registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator"
+	CONSOLE_IMAGE_BASE="registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9"
+	SERVICE_IMAGE_BASE="registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9"
+	CONSOLE_IMAGE_BASE_PF5="registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-pf5-rhel9"
+	CONSOLE_IMAGE_BASE_419="registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-419-rhel9"
+	OPENSHIFT_MCP_SERVER_IMAGE_BASE="registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9"
+	OCP_RAG_IMAGE_BASE="registry.redhat.io/openshift-lightspeed/lightspeed-ocp-rag-rhel9"
 
-    OPERATOR_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator|'"${OPERATOR_IMAGE_BASE}"'|g' <<<${OPERATOR_IMAGE})
-    CONSOLE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console|'"${CONSOLE_IMAGE_BASE}"'|g' <<<${CONSOLE_IMAGE})
-    SERVICE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service|'"${SERVICE_IMAGE_BASE}"'|g' <<<${SERVICE_IMAGE})
-    CONSOLE_IMAGE_PF5=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-console-pf5|'"${CONSOLE_IMAGE_BASE_PF5}"'|g' <<<${CONSOLE_IMAGE_PF5})
-    OPENSHIFT_MCP_SERVER_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/openshift-mcp-server|'"${OPENSHIFT_MCP_SERVER_IMAGE_BASE}"'|g' <<<${OPENSHIFT_MCP_SERVER_IMAGE})
-    DATAVERSE_EXPORTER_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-to-dataverse-exporter|'"${DATAVERSE_EXPORTER_IMAGE_BASE}"'|g' <<<${DATAVERSE_EXPORTER_IMAGE})
-    OCP_RAG_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-ocp-rag|'"${OCP_RAG_IMAGE_BASE}"'|g' <<<${OCP_RAG_IMAGE})    
-    POSTGRES_IMAGE=$(sed "s|quay\.io.*/lightspeed-postgresql|registry.redhat.io/rhel9/postgresql-16|g" <<<"${POSTGRES_IMAGE}")
+	OPERATOR_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator|'"${OPERATOR_IMAGE_BASE}"'|g' <<<${OPERATOR_IMAGE})
+	CONSOLE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console|'"${CONSOLE_IMAGE_BASE}"'|g' <<<${CONSOLE_IMAGE})
+	SERVICE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service|'"${SERVICE_IMAGE_BASE}"'|g' <<<${SERVICE_IMAGE})
+	CONSOLE_IMAGE_PF5=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-console-pf5|'"${CONSOLE_IMAGE_BASE_PF5}"'|g' <<<${CONSOLE_IMAGE_PF5})
+	CONSOLE_IMAGE_419=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-console-4-19|'"${CONSOLE_IMAGE_BASE_419}"'|g' <<<${CONSOLE_IMAGE_419})
+	OPENSHIFT_MCP_SERVER_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/openshift-mcp-server|'"${OPENSHIFT_MCP_SERVER_IMAGE_BASE}"'|g' <<<${OPENSHIFT_MCP_SERVER_IMAGE})
+	OCP_RAG_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-ocp-rag|'"${OCP_RAG_IMAGE_BASE}"'|g' <<<${OCP_RAG_IMAGE})
+	POSTGRES_IMAGE=$(sed "s|quay\.io.*/lightspeed-postgresql|registry.redhat.io/rhel9/postgresql-16|g" <<<"${POSTGRES_IMAGE}")
 
-    if [ -n "${BUNDLE_SNAPSHOT_REF}" ]; then
-        BUNDLE_IMAGE_BASE="registry.redhat.io/openshift-lightspeed/lightspeed-operator-bundle"
-        BUNDLE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols-bundle|'"${BUNDLE_IMAGE_BASE}"'|g' <<<${BUNDLE_IMAGE})
-    fi
+	if [ -n "${BUNDLE_SNAPSHOT_REF}" ]; then
+		BUNDLE_IMAGE_BASE="registry.redhat.io/openshift-lightspeed/lightspeed-operator-bundle"
+		BUNDLE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols-bundle|'"${BUNDLE_IMAGE_BASE}"'|g' <<<${BUNDLE_IMAGE})
+	fi
 fi
 
 if [ -z "${POSTGRES_IMAGE}" ] || [ "${POSTGRES_IMAGE}" == "null" ]; then
-    if [ -f "${OUTPUT_FILE}" ]; then
-        POSTGRES_IMAGE=$(jq -r '.[] | select(.name == "lightspeed-postgresql") | .image' "${OUTPUT_FILE}")
-    fi
+	if [ -f "${OUTPUT_FILE}" ]; then
+		POSTGRES_IMAGE=$(jq -r '.[] | select(.name == "lightspeed-postgresql") | .image' "${OUTPUT_FILE}")
+	fi
 fi
 
 if [ -z "${POSTGRES_IMAGE}" ] || [ "${POSTGRES_IMAGE}" == "null" ]; then
-    DEFAULT_POSTGRES_IMAGE=$(grep -o 'PostgresServerImageDefault = "registry[^"]*"' "${SCRIPT_DIR}/../internal/controller/utils/constants.go" | sed 's/PostgresServerImageDefault = "\(.*\)"/\1/')
-    POSTGRES_IMAGE="${DEFAULT_POSTGRES_IMAGE}"
+	DEFAULT_POSTGRES_IMAGE=$(grep -o 'PostgresServerImageDefault = "registry[^"]*"' "${SCRIPT_DIR}/../internal/controller/utils/constants.go" | sed 's/PostgresServerImageDefault = "\(.*\)"/\1/')
+	POSTGRES_IMAGE="${DEFAULT_POSTGRES_IMAGE}"
+fi
+
+# lightspeed-to-dataverse-exporter does not comes from OLS snapshot.
+# Preserve versions from the existing related images file.
+DATAVERSE_EXPORTER_IMAGE=""
+if [ -n "${OUTPUT_FILE}" ] && [ -f "${OUTPUT_FILE}" ]; then
+	DATAVERSE_EXPORTER_IMAGE=$(${JQ} -r '.[] | select(.name == "lightspeed-to-dataverse-exporter") | .image' "${OUTPUT_FILE}")
+fi
+if [ -z "${DATAVERSE_EXPORTER_IMAGE}" ] || [ "${DATAVERSE_EXPORTER_IMAGE}" == "null" ]; then
+	DEFAULT_RELATED_IMAGES="${SCRIPT_DIR}/../related_images.json"
+	if [ -f "${DEFAULT_RELATED_IMAGES}" ]; then
+		DATAVERSE_EXPORTER_IMAGE=$(${JQ} -r '.[] | select(.name == "lightspeed-to-dataverse-exporter") | .image' "${DEFAULT_RELATED_IMAGES}")
+	fi
+fi
+if [ -z "${DATAVERSE_EXPORTER_IMAGE}" ] || [ "${DATAVERSE_EXPORTER_IMAGE}" == "null" ]; then
+	echo "lightspeed-to-dataverse-exporter image not found: use -o with an existing related_images.json, or ensure ${SCRIPT_DIR}/../related_images.json lists it." >&2
+	exit 1
 fi
 
 RELATED_IMAGES=$(
-    cat <<-EOF
-[
-  {
-    "name": "lightspeed-service-api",
-    "image": "${SERVICE_IMAGE}",
-    "revision": "${SERVICE_REVISION}"
-  },
-  {
-    "name": "lightspeed-console-plugin",
-    "image": "${CONSOLE_IMAGE}",
-    "revision": "${CONSOLE_REVISION}"
-  },
-  {
-    "name": "lightspeed-console-plugin-pf5",
-    "image": "${CONSOLE_IMAGE_PF5}",
-    "revision": "${CONSOLE_REVISION_PF5}"
-  },
-  {
-    "name": "lightspeed-operator",
-    "image": "${OPERATOR_IMAGE}",
-    "revision": "${OPERATOR_REVISION}"
-  },
-  {
-    "name": "openshift-mcp-server",
-    "image": "${OPENSHIFT_MCP_SERVER_IMAGE}",
-    "revision": "${OPENSHIFT_MCP_SERVER_REVISION}"
-  },
-  {
-    "name": "lightspeed-to-dataverse-exporter",
-    "image": "${DATAVERSE_EXPORTER_IMAGE}",
-    "revision": "${DATAVERSE_EXPORTER_REVISION}"
-  },
-  {
-    "name": "lightspeed-ocp-rag",
-    "image": "${OCP_RAG_IMAGE}",
-    "revision": "${OCP_RAG_REVISION}"
-  },
-  {
-    "name": "lightspeed-postgresql",
-    "image": "${POSTGRES_IMAGE}"
-  }
-]
-EOF
+	cat <<-EOF
+		[
+		  {
+		    "name": "lightspeed-service-api",
+		    "image": "${SERVICE_IMAGE}",
+		    "revision": "${SERVICE_REVISION}"
+		  },
+		  {
+		    "name": "lightspeed-console-plugin",
+		    "image": "${CONSOLE_IMAGE}",
+		    "revision": "${CONSOLE_REVISION}"
+		  },
+		  {
+		    "name": "lightspeed-console-plugin-pf5",
+		    "image": "${CONSOLE_IMAGE_PF5}",
+		    "revision": "${CONSOLE_REVISION_PF5}"
+		  },
+		  {
+		    "name": "lightspeed-console-plugin-4-19",
+		    "image": "${CONSOLE_IMAGE_419}",
+		    "revision": "${CONSOLE_REVISION_419}"
+		  },
+		  {
+		    "name": "lightspeed-operator",
+		    "image": "${OPERATOR_IMAGE}",
+		    "revision": "${OPERATOR_REVISION}"
+		  },
+		  {
+		    "name": "openshift-mcp-server",
+		    "image": "${OPENSHIFT_MCP_SERVER_IMAGE}",
+		    "revision": "${OPENSHIFT_MCP_SERVER_REVISION}"
+		  },
+		  {
+		    "name": "lightspeed-to-dataverse-exporter",
+		    "image": "${DATAVERSE_EXPORTER_IMAGE}",
+		    "revision": "${DATAVERSE_EXPORTER_REVISION}"
+		  },
+		  {
+		    "name": "lightspeed-ocp-rag",
+		    "image": "${OCP_RAG_IMAGE}",
+		    "revision": "${OCP_RAG_REVISION}"
+		  },
+		  {
+		    "name": "lightspeed-postgresql",
+		    "image": "${POSTGRES_IMAGE}"
+		  }
+		]
+	EOF
 )
 
 if [ -n "${BUNDLE_IMAGE}" ]; then
-    RELATED_IMAGES=$(echo "${RELATED_IMAGES}" | ${JQ} \
-        --arg img "${BUNDLE_IMAGE}" \
-        --arg rev "${BUNDLE_REVISION}" \
-        '. += [{"name":"lightspeed-operator-bundle","image":$img,"revision":$rev}]')
+	RELATED_IMAGES=$(echo "${RELATED_IMAGES}" | ${JQ} \
+		--arg img "${BUNDLE_IMAGE}" \
+		--arg rev "${BUNDLE_REVISION}" \
+		'. += [{"name":"lightspeed-operator-bundle","image":$img,"revision":$rev}]')
 fi
 
 if [ -n "${OUTPUT_FILE}" ]; then
-    ${JQ} <<<$RELATED_IMAGES >${OUTPUT_FILE}
+	${JQ} <<<$RELATED_IMAGES >${OUTPUT_FILE}
 else
-    ${JQ} <<<$RELATED_IMAGES
+	${JQ} <<<$RELATED_IMAGES
 fi

--- a/internal/controller/utils/constants.go
+++ b/internal/controller/utils/constants.go
@@ -429,6 +429,7 @@ var (
 	OLSAppServerImageDefault       = relatedimages.GetDefaultImage("lightspeed-service-api")
 	ConsoleUIImageDefault          = relatedimages.GetDefaultImage("lightspeed-console-plugin")
 	ConsoleUIImagePF5Default       = relatedimages.GetDefaultImage("lightspeed-console-plugin-pf5")
+	ConsoleUIImage419Default       = relatedimages.GetDefaultImage("lightspeed-console-plugin-4-19")
 	PostgresServerImageDefault     = relatedimages.GetDefaultImage("lightspeed-postgresql")
 	OpenShiftMCPServerImageDefault = relatedimages.GetDefaultImage("openshift-mcp-server")
 	DataverseExporterImageDefault  = relatedimages.GetDefaultImage("lightspeed-to-dataverse-exporter")

--- a/related_images.json
+++ b/related_images.json
@@ -15,6 +15,11 @@
     "revision": "c6d9c2fe8ce107ae86a69a43007e99870fdf84e7"
   },
   {
+    "name": "lightspeed-console-plugin-4-19",
+    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-419-rhel9@sha256:cd6199b76eadbf921dc303850d401841a0653a6b77bff7dbf4c83b1db84f49fb",
+    "revision": "dcf95a42dce63122a735b00f3d61616ff7fa5e9c"
+  },
+  {
     "name": "lightspeed-operator",
     "image": "registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:f972945e6cae4273d0e5547f65a4473939cca39bacfdb889e8ade2bba974db7b",
     "revision": "c9efdb48e785f58b9cab85e085284df9a76c0f18"


### PR DESCRIPTION
## Description

On Openshift 4.19 -  4.21, the console image comes from OLS component "lightspeed-console-4-19":
- operator adds an argument for this new console image
- snapshot_to_image_list.sh script add generations code for this new console image, fixed some technical debt at the same time.
- bundle update scripts adapted with the new console image

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
