### PR TITLE
Fix IntrospectionEnabled Default, removed read only flag

### DIFF
--- a/api/v1alpha1/olsconfig_types.go
+++ b/api/v1alpha1/olsconfig_types.go
@@ -206,10 +206,12 @@ type OLSSpec struct {
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="TLS Security Profile",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
 	TLSSecurityProfile *configv1.TLSSecurityProfile `json:"tlsSecurityProfile,omitempty"`
-	// Enable introspection features
+	// Enable introspection features (e.g. built-in OpenShift MCP server). Omitted means use the
+	// CRD default (true); explicit false disables introspection.
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=true
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Introspection Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
-	IntrospectionEnabled bool `json:"introspectionEnabled,omitempty"`
+	IntrospectionEnabled *bool `json:"introspectionEnabled,omitempty"`
 	// MCP Kubernetes server configuration
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="MCP Kube Server Configuration",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
 	// +kubebuilder:validation:Optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -431,7 +431,7 @@ func (in *OLSSpec) DeepCopyInto(out *OLSSpec) {
 	if in.MCPKubeServerConfig != nil {
 		in, out := &in.MCPKubeServerConfig, &out.MCPKubeServerConfig
 		*out = new(MCPKubeServerConfiguration)
-		**out = **in
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ProxyConfig != nil {
 		in, out := &in.ProxyConfig, &out.ProxyConfig

--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -114,24 +114,6 @@ spec:
           - description: Fake Provider MCP Tool Call
             displayName: Fake Provider MCP Tool Call
             path: llm.providers[0].fakeProviderMCPToolCall
-          - description: Google Vertex Anthropic Config
-            displayName: Google Vertex Anthropic Config
-            path: llm.providers[0].googleVertexAnthropicConfig
-          - description: Server region location
-            displayName: Server Region Location
-            path: llm.providers[0].googleVertexAnthropicConfig.location
-          - description: Google Cloud project ID
-            displayName: Google Cloud Project ID
-            path: llm.providers[0].googleVertexAnthropicConfig.projectID
-          - description: Google Vertex Config
-            displayName: Google Vertex Config
-            path: llm.providers[0].googleVertexConfig
-          - description: Server region location
-            displayName: Server Region Location
-            path: llm.providers[0].googleVertexConfig.location
-          - description: Google Cloud project ID
-            displayName: Google Cloud Project ID
-            path: llm.providers[0].googleVertexConfig.projectID
           - description: List of models from the provider
             displayName: Models
             path: llm.providers[0].models

--- a/config/crd/bases/ols.openshift.io_olsconfigs.yaml
+++ b/config/crd/bases/ols.openshift.io_olsconfigs.yaml
@@ -140,10 +140,10 @@ spec:
                                       is 2048 tokens.
                                     type: integer
                                   toolBudgetRatio:
-                                    default: 0.25
+                                    default: 0.5
                                     description: Ratio of context window size allocated
                                       for tool token budget. Must be between 0.1 and
-                                      0.5. The default is 0.25.
+                                      0.5. The default is 0.5.
                                     maximum: 0.5
                                     minimum: 0.1
                                     type: number
@@ -4412,7 +4412,10 @@ spec:
                       x-kubernetes-map-type: atomic
                     type: array
                   introspectionEnabled:
-                    description: Enable introspection features
+                    default: true
+                    description: |-
+                      Enable introspection features (e.g. built-in OpenShift MCP server). Omitted means use the
+                      CRD default (true); explicit false disables introspection.
                     type: boolean
                   logLevel:
                     default: INFO

--- a/config/manifests/bases/lightspeed-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/lightspeed-operator.clusterserviceversion.yaml
@@ -97,7 +97,7 @@ spec:
         displayName: Max Tokens For Response
         path: llm.providers[0].models[0].parameters.maxTokensForResponse
       - description: Ratio of context window size allocated for tool token budget.
-          Must be between 0.1 and 0.5. The default is 0.25.
+          Must be between 0.1 and 0.5. The default is 0.5.
         displayName: Tool Budget Ratio
         path: llm.providers[0].models[0].parameters.toolBudgetRatio
       - description: Model API URL
@@ -233,7 +233,9 @@ spec:
           authentication
         displayName: Image Pull Secrets
         path: ols.imagePullSecrets
-      - description: Enable introspection features
+      - description: |-
+          Enable introspection features (e.g. built-in OpenShift MCP server). Omitted means use the
+          CRD default (true); explicit false disables introspection.
         displayName: Introspection Enabled
         path: ols.introspectionEnabled
         x-descriptors:

--- a/internal/controller/appserver/assets.go
+++ b/internal/controller/appserver/assets.go
@@ -220,7 +220,7 @@ func buildToolFilteringConfig(cr *olsv1alpha1.OLSConfig, mcpServers []utils.MCPS
 	if len(mcpServers) == 0 {
 		r.GetLogger().Info(
 			"ToolFilteringConfig specified but no MCP servers configured. Tool filtering will be disabled.",
-			"IntrospectionEnabled", cr.Spec.OLSConfig.IntrospectionEnabled,
+			"IntrospectionEnabled", utils.BoolDeref(cr.Spec.OLSConfig.IntrospectionEnabled, true),
 			"MCPServersCount", len(cr.Spec.MCPServers),
 		)
 		return nil
@@ -349,7 +349,7 @@ func generateMCPServerConfigs(r reconciler.Reconciler, cr *olsv1alpha1.OLSConfig
 	servers := []utils.MCPServerConfig{}
 
 	// Add OpenShift MCP server if introspection is enabled
-	if cr.Spec.OLSConfig.IntrospectionEnabled {
+	if utils.BoolDeref(cr.Spec.OLSConfig.IntrospectionEnabled, true) {
 		// Get timeout from MCPKubeServerConfig if specified, otherwise use default
 		timeout := utils.OpenShiftMCPServerTimeout
 		if cr.Spec.OLSConfig.MCPKubeServerConfig != nil && cr.Spec.OLSConfig.MCPKubeServerConfig.Timeout != 0 {

--- a/internal/controller/appserver/assets_test.go
+++ b/internal/controller/appserver/assets_test.go
@@ -14,6 +14,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/yaml"
@@ -465,7 +466,7 @@ var _ = Describe("App server assets", func() {
 		})
 
 		It("should generate configmap with introspectionEnabled", func() {
-			cr.Spec.OLSConfig.IntrospectionEnabled = true
+			cr.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(true)
 			cm, err := GenerateOLSConfigMap(testReconcilerInstance, context.TODO(), cr)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -588,7 +589,7 @@ var _ = Describe("App server assets", func() {
 		})
 
 		It("should generate configmap with additional MCP server along side the default MCP server", func() {
-			cr.Spec.OLSConfig.IntrospectionEnabled = true
+			cr.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(true)
 			cr.Spec.FeatureGates = []olsv1alpha1.FeatureGate{utils.FeatureGateMCPServer}
 			cr.Spec.MCPServers = []olsv1alpha1.MCPServerConfig{
 				{
@@ -646,6 +647,181 @@ var _ = Describe("App server assets", func() {
 			// Verify APIVersion is set at the ProviderConfig level
 			Expect(provider.APIVersion).To(Equal("2021-09-01"))
 
+		})
+
+		It("should generate the OLS deployment", func() {
+			By("generate full deployment when telemetry pull secret exists")
+			utils.CreateTelemetryPullSecret(ctx, k8sClient, true)
+
+			dep, err := GenerateOLSDeployment(testReconcilerInstance, cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dep.Name).To(Equal(utils.OLSAppServerDeploymentName))
+			Expect(dep.Namespace).To(Equal(utils.OLSNamespaceDefault))
+			// application container
+			Expect(dep.Spec.Template.Spec.Containers[0].Image).To(Equal(utils.OLSAppServerImageDefault))
+			Expect(dep.Spec.Template.Spec.Containers[0].Name).To(Equal(utils.OLSAppServerContainerName))
+			Expect(dep.Spec.Template.Spec.Containers[0].Resources).ToNot(BeNil())
+			Expect(dep.Spec.Template.Spec.Containers[0].Ports).To(Equal([]corev1.ContainerPort{
+				{
+					ContainerPort: utils.OLSAppServerContainerPort,
+					Name:          "https",
+					Protocol:      corev1.ProtocolTCP,
+				},
+			}))
+			Expect(dep.Spec.Template.Spec.Containers[0].Env).To(Equal([]corev1.EnvVar{
+				{
+					Name:  "OLS_CONFIG_FILE",
+					Value: path.Join("/etc/ols", utils.OLSConfigFilename),
+				},
+			}))
+			Expect(dep.Spec.Template.Spec.Containers[0].VolumeMounts).To(ConsistOf(get10RequiredVolumeMounts()))
+			Expect(dep.Spec.Template.Spec.Containers[0].Resources).To(Equal(corev1.ResourceRequirements{
+				Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("4Gi")},
+				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m"), corev1.ResourceMemory: resource.MustParse("1Gi")},
+				Claims:   []corev1.ResourceClaim{},
+			}))
+			// dataverse exporter container
+			Expect(dep.Spec.Template.Spec.Containers[1].Image).To(Equal(utils.DataverseExporterImageDefault))
+			Expect(dep.Spec.Template.Spec.Containers[1].Name).To(Equal(utils.DataverseExporterContainerName))
+			Expect(dep.Spec.Template.Spec.Containers[1].Resources).ToNot(BeNil())
+			Expect(dep.Spec.Template.Spec.Containers[1].Args).To(Equal([]string{
+				"--mode",
+				"openshift",
+				"--config",
+				path.Join(utils.ExporterConfigMountPath, utils.ExporterConfigFilename),
+				"--log-level",
+				string(olsv1alpha1.LogLevelInfo),
+				"--data-dir",
+				utils.OLSUserDataMountPath,
+			}))
+			Expect(dep.Spec.Template.Spec.Containers[1].VolumeMounts).To(ConsistOf(get10RequiredVolumeMounts()))
+			Expect(dep.Spec.Template.Spec.Containers[1].Resources).To(Equal(corev1.ResourceRequirements{
+				Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("200Mi")},
+				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("50m"), corev1.ResourceMemory: resource.MustParse("64Mi")},
+				Claims:   []corev1.ResourceClaim{},
+			}))
+			Expect(len(dep.Spec.Template.Spec.Volumes)).To(Equal(10))
+			Expect(dep.Spec.Selector.MatchLabels).To(Equal(utils.GenerateAppServerSelectorLabels()))
+
+			By("generate deployment without data collector when telemetry pull secret does not exist")
+			utils.DeleteTelemetryPullSecret(ctx, k8sClient)
+			dep, err = GenerateOLSDeployment(testReconcilerInstance, cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dep.Name).To(Equal(utils.OLSAppServerDeploymentName))
+			Expect(dep.Namespace).To(Equal(utils.OLSNamespaceDefault))
+			Expect(dep.Spec.Template.Spec.Containers).To(HaveLen(1))
+			// application container
+			Expect(dep.Spec.Template.Spec.Containers[0].Image).To(Equal(utils.OLSAppServerImageDefault))
+			Expect(dep.Spec.Template.Spec.Containers[0].Name).To(Equal(utils.OLSAppServerContainerName))
+			Expect(dep.Spec.Template.Spec.Containers[0].Resources).ToNot(BeNil())
+			Expect(dep.Spec.Template.Spec.Containers[0].Ports).To(Equal([]corev1.ContainerPort{
+				{
+					ContainerPort: utils.OLSAppServerContainerPort,
+					Name:          "https",
+					Protocol:      corev1.ProtocolTCP,
+				},
+			}))
+			Expect(dep.Spec.Template.Spec.Containers[0].Env).To(Equal([]corev1.EnvVar{
+				{
+					Name:  "OLS_CONFIG_FILE",
+					Value: path.Join("/etc/ols", utils.OLSConfigFilename),
+				},
+			}))
+			Expect(dep.Spec.Template.Spec.Containers[0].VolumeMounts).To(ConsistOf(get8RequiredVolumeMounts()))
+			Expect(len(dep.Spec.Template.Spec.Volumes)).To(Equal(8))
+
+			By("generate deployment without data collector when telemetry pull secret does not contain telemetry token")
+			utils.CreateTelemetryPullSecret(ctx, k8sClient, false)
+			dep, err = GenerateOLSDeployment(testReconcilerInstance, cr)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dep.Name).To(Equal(utils.OLSAppServerDeploymentName))
+			Expect(dep.Namespace).To(Equal(utils.OLSNamespaceDefault))
+			Expect(dep.Spec.Template.Spec.Containers).To(HaveLen(1))
+			// application container
+			Expect(dep.Spec.Template.Spec.Containers[0].Image).To(Equal(utils.OLSAppServerImageDefault))
+			Expect(dep.Spec.Template.Spec.Containers[0].Name).To(Equal(utils.OLSAppServerContainerName))
+			Expect(dep.Spec.Template.Spec.Containers[0].Resources).ToNot(BeNil())
+			Expect(dep.Spec.Template.Spec.Containers[0].Ports).To(Equal([]corev1.ContainerPort{
+				{
+					ContainerPort: utils.OLSAppServerContainerPort,
+					Name:          "https",
+					Protocol:      corev1.ProtocolTCP,
+				},
+			}))
+			Expect(dep.Spec.Template.Spec.Containers[0].Env).To(Equal([]corev1.EnvVar{
+				{
+					Name:  "OLS_CONFIG_FILE",
+					Value: path.Join("/etc/ols", utils.OLSConfigFilename),
+				},
+			}))
+			Expect(dep.Spec.Template.Spec.Containers[0].VolumeMounts).To(ConsistOf(get8RequiredVolumeMounts()))
+			Expect(len(dep.Spec.Template.Spec.Volumes)).To(Equal(8))
+			utils.DeleteTelemetryPullSecret(ctx, k8sClient)
+		})
+
+		It("should use configured log level for data collector container", func() {
+			utils.CreateTelemetryPullSecret(ctx, k8sClient, true)
+
+			By("using default INFO log level when not specified")
+			cr.Spec.OLSDataCollectorConfig = olsv1alpha1.OLSDataCollectorSpec{}
+			dep, err := GenerateOLSDeployment(testReconcilerInstance, cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dep.Spec.Template.Spec.Containers).To(HaveLen(2))
+			// data collector container should be the second container
+			Expect(dep.Spec.Template.Spec.Containers[1].Name).To(Equal(utils.DataverseExporterContainerName))
+			Expect(dep.Spec.Template.Spec.Containers[1].Args).To(ContainElement(string(olsv1alpha1.LogLevelInfo)))
+
+			By("using DEBUG log level when configured")
+			cr.Spec.OLSDataCollectorConfig = olsv1alpha1.OLSDataCollectorSpec{
+				LogLevel: olsv1alpha1.LogLevelDebug,
+			}
+			dep, err = GenerateOLSDeployment(testReconcilerInstance, cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dep.Spec.Template.Spec.Containers).To(HaveLen(2))
+			Expect(dep.Spec.Template.Spec.Containers[1].Name).To(Equal(utils.DataverseExporterContainerName))
+			Expect(dep.Spec.Template.Spec.Containers[1].Args).To(Equal([]string{
+				"--mode",
+				"openshift",
+				"--config",
+				path.Join(utils.ExporterConfigMountPath, utils.ExporterConfigFilename),
+				"--log-level",
+				string(olsv1alpha1.LogLevelDebug),
+				"--data-dir",
+				utils.OLSUserDataMountPath,
+			}))
+
+			By("using WARNING log level when configured")
+			cr.Spec.OLSDataCollectorConfig = olsv1alpha1.OLSDataCollectorSpec{
+				LogLevel: olsv1alpha1.LogLevelWarning,
+			}
+			dep, err = GenerateOLSDeployment(testReconcilerInstance, cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dep.Spec.Template.Spec.Containers).To(HaveLen(2))
+			Expect(dep.Spec.Template.Spec.Containers[1].Name).To(Equal(utils.DataverseExporterContainerName))
+			Expect(dep.Spec.Template.Spec.Containers[1].Args).To(ContainElement(string(olsv1alpha1.LogLevelWarning)))
+
+			By("using ERROR log level when configured")
+			cr.Spec.OLSDataCollectorConfig = olsv1alpha1.OLSDataCollectorSpec{
+				LogLevel: olsv1alpha1.LogLevelError,
+			}
+			dep, err = GenerateOLSDeployment(testReconcilerInstance, cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dep.Spec.Template.Spec.Containers).To(HaveLen(2))
+			Expect(dep.Spec.Template.Spec.Containers[1].Name).To(Equal(utils.DataverseExporterContainerName))
+			Expect(dep.Spec.Template.Spec.Containers[1].Args).To(ContainElement(string(olsv1alpha1.LogLevelError)))
+
+			By("using CRITICAL log level when configured")
+			cr.Spec.OLSDataCollectorConfig = olsv1alpha1.OLSDataCollectorSpec{
+				LogLevel: olsv1alpha1.LogLevelCritical,
+			}
+			dep, err = GenerateOLSDeployment(testReconcilerInstance, cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dep.Spec.Template.Spec.Containers).To(HaveLen(2))
+			Expect(dep.Spec.Template.Spec.Containers[1].Name).To(Equal(utils.DataverseExporterContainerName))
+			Expect(dep.Spec.Template.Spec.Containers[1].Args).To(ContainElement(string(olsv1alpha1.LogLevelCritical)))
+
+			utils.DeleteTelemetryPullSecret(ctx, k8sClient)
 		})
 
 		It("should generate the OLS service", func() {
@@ -748,6 +924,165 @@ var _ = Describe("App server assets", func() {
 
 		})
 
+		It("should switch data collection on and off as CR defines in .spec.ols_config.user_data_collection", func() {
+			utils.CreateTelemetryPullSecret(ctx, k8sClient, true)
+			defer utils.DeleteTelemetryPullSecret(ctx, k8sClient)
+			By("Switching data collection off")
+			cr.Spec.OLSConfig.UserDataCollection = olsv1alpha1.UserDataCollectionSpec{
+				FeedbackDisabled:    true,
+				TranscriptsDisabled: true,
+			}
+			cm, err := GenerateOLSConfigMap(testReconcilerInstance, context.TODO(), cr)
+			Expect(err).NotTo(HaveOccurred())
+			olsconfigGenerated := utils.AppSrvConfigFile{}
+			err = yaml.Unmarshal([]byte(cm.Data[utils.OLSConfigFilename]), &olsconfigGenerated)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(olsconfigGenerated.OLSConfig.UserDataCollection.FeedbackDisabled).To(BeTrue())
+			Expect(olsconfigGenerated.OLSConfig.UserDataCollection.TranscriptsDisabled).To(BeTrue())
+
+			deployment, err := GenerateOLSDeployment(testReconcilerInstance, cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
+			Expect(deployment.Spec.Template.Spec.Volumes).To(Not(ContainElement(
+				corev1.Volume{
+					Name: "ols-user-data",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+			)))
+
+			By("Switching data collection on")
+			cr.Spec.OLSConfig.UserDataCollection = olsv1alpha1.UserDataCollectionSpec{
+				FeedbackDisabled:    false,
+				TranscriptsDisabled: false,
+			}
+			cm, err = GenerateOLSConfigMap(testReconcilerInstance, context.TODO(), cr)
+			Expect(err).NotTo(HaveOccurred())
+			err = yaml.Unmarshal([]byte(cm.Data[utils.OLSConfigFilename]), &olsconfigGenerated)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(olsconfigGenerated.OLSConfig.UserDataCollection.FeedbackDisabled).To(BeFalse())
+			Expect(olsconfigGenerated.OLSConfig.UserDataCollection.TranscriptsDisabled).To(BeFalse())
+
+			deployment, err = GenerateOLSDeployment(testReconcilerInstance, cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(2))
+			Expect(deployment.Spec.Template.Spec.Containers[1].Image).To(Equal(utils.DataverseExporterImageDefault))
+			Expect(deployment.Spec.Template.Spec.Containers[1].Name).To(Equal(utils.DataverseExporterContainerName))
+			Expect(deployment.Spec.Template.Spec.Containers[1].Resources).ToNot(BeNil())
+			Expect(deployment.Spec.Template.Spec.Containers[1].Args).To(Equal([]string{
+				"--mode",
+				"openshift",
+				"--config",
+				path.Join(utils.ExporterConfigMountPath, utils.ExporterConfigFilename),
+				"--log-level",
+				string(olsv1alpha1.LogLevelInfo),
+				"--data-dir",
+				utils.OLSUserDataMountPath,
+			}))
+			Expect(deployment.Spec.Template.Spec.Containers[1].VolumeMounts).To(ConsistOf(get10RequiredVolumeMounts()))
+			Expect(deployment.Spec.Template.Spec.Volumes).To(ContainElement(
+				corev1.Volume{
+					Name: "ols-user-data",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+			))
+		})
+
+		It("should use user provided TLS settings if user provided one", func() {
+			const tlsSecretName = "test-tls-secret"
+			cr.Spec.OLSConfig.TLSConfig = &olsv1alpha1.TLSConfig{
+				KeyCertSecretRef: corev1.LocalObjectReference{
+					Name: tlsSecretName,
+				},
+			}
+			cm, err := GenerateOLSConfigMap(testReconcilerInstance, context.TODO(), cr)
+			Expect(err).NotTo(HaveOccurred())
+			olsconfigGenerated := utils.AppSrvConfigFile{}
+			err = yaml.Unmarshal([]byte(cm.Data[utils.OLSConfigFilename]), &olsconfigGenerated)
+			Expect(err).NotTo(HaveOccurred())
+			// Config always uses /etc/certs/lightspeed-tls/ path regardless of secret name
+			Expect(olsconfigGenerated.OLSConfig.TLSConfig.TLSCertificatePath).To(Equal(path.Join(utils.OLSAppCertsMountRoot, "lightspeed-tls", "tls.crt")))
+			Expect(olsconfigGenerated.OLSConfig.TLSConfig.TLSKeyPath).To(Equal(path.Join(utils.OLSAppCertsMountRoot, "lightspeed-tls", "tls.key")))
+
+			deployment, err := GenerateOLSDeployment(testReconcilerInstance, cr)
+			Expect(err).NotTo(HaveOccurred())
+			// Volume mount uses canonical name regardless of secret name
+			Expect(deployment.Spec.Template.Spec.Containers[0].VolumeMounts).To(ContainElement(
+				corev1.VolumeMount{
+					Name:      "secret-lightspeed-tls",
+					MountPath: path.Join(utils.OLSAppCertsMountRoot, "lightspeed-tls"),
+					ReadOnly:  true,
+				},
+			))
+			// Volume has canonical name but references the user's secret
+			Expect(deployment.Spec.Template.Spec.Volumes).To(ContainElement(
+				corev1.Volume{
+					Name: "secret-lightspeed-tls",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName:  tlsSecretName, // References user's secret
+							DefaultMode: &defaultVolumeMode,
+						},
+					},
+				},
+			))
+		})
+
+		It("should generate RAG volume and initContainers", func() {
+			cr.Spec.OLSConfig.RAG = []olsv1alpha1.RAGSpec{
+				{
+					IndexPath: "/rag/vector_db/ocp_product_docs/4.19",
+					IndexID:   "ocp-product-docs-4_19",
+					Image:     "rag-ocp-product-docs:4.19",
+				},
+				{
+					IndexPath: "/rag/vector_db/ansible_docs/2.18",
+					IndexID:   "ansible-docs-2_18",
+					Image:     "rag-ansible-docs:2.18",
+				},
+			}
+			deployment, err := GenerateOLSDeployment(testReconcilerInstance, cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deployment.Spec.Template.Spec.Volumes).To(ContainElement(
+				corev1.Volume{
+					Name: utils.RAGVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				}))
+
+			Expect(deployment.Spec.Template.Spec.InitContainers).To(ConsistOf(
+				utils.GeneratePostgresWaitInitContainer(testReconcilerInstance.GetPostgresImage()),
+				corev1.Container{
+					Name:    "rag-0",
+					Image:   "rag-ocp-product-docs:4.19",
+					Command: []string{"sh", "-c", fmt.Sprintf("mkdir -p %s/rag-0 && cp -a /rag/vector_db/ocp_product_docs/4.19/. %s/rag-0", utils.RAGVolumeMountPath, utils.RAGVolumeMountPath)},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      utils.RAGVolumeName,
+							MountPath: utils.RAGVolumeMountPath,
+						},
+					},
+					ImagePullPolicy: corev1.PullAlways,
+				},
+				corev1.Container{
+					Name:    "rag-1",
+					Image:   "rag-ansible-docs:2.18",
+					Command: []string{"sh", "-c", fmt.Sprintf("mkdir -p %s/rag-1 && cp -a /rag/vector_db/ansible_docs/2.18/. %s/rag-1", utils.RAGVolumeMountPath, utils.RAGVolumeMountPath)},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      utils.RAGVolumeName,
+							MountPath: utils.RAGVolumeMountPath,
+						},
+					},
+					ImagePullPolicy: corev1.PullAlways,
+				},
+			))
+		})
+
 		It("should fill app config with multiple RAG indexes and remove them when no additional RAG is defined", func() {
 			By("additional RAG indexes are added")
 			cr.Spec.OLSConfig.RAG = []olsv1alpha1.RAGSpec{
@@ -831,6 +1166,143 @@ var _ = Describe("App server assets", func() {
 			}))
 		})
 
+		It("should generate deployment with MCP server sidecar when introspectionEnabled is true", func() {
+			utils.CreateTelemetryPullSecret(ctx, k8sClient, true)
+			defer utils.DeleteTelemetryPullSecret(ctx, k8sClient)
+
+			By("Enabling introspection")
+			cr.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(true)
+
+			dep, err := GenerateOLSDeployment(testReconcilerInstance, cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dep.Name).To(Equal(utils.OLSAppServerDeploymentName))
+			Expect(dep.Namespace).To(Equal(utils.OLSNamespaceDefault))
+
+			// Should have 3 containers: main app, telemetry, and MCP server
+			Expect(dep.Spec.Template.Spec.Containers).To(HaveLen(3))
+
+			// Verify OpenShift MCP server container (should be the third container)
+			openshiftMCPServerContainer := dep.Spec.Template.Spec.Containers[2]
+			Expect(openshiftMCPServerContainer.Name).To(Equal(utils.OpenShiftMCPServerContainerName))
+			Expect(openshiftMCPServerContainer.Image).To(Equal(utils.OpenShiftMCPServerImageDefault))
+			Expect(openshiftMCPServerContainer.ImagePullPolicy).To(Equal(corev1.PullIfNotPresent))
+			Expect(openshiftMCPServerContainer.Command).To(Equal([]string{
+				"/openshift-mcp-server",
+				"--config", utils.GetOpenShiftMCPServerConfigPath(),
+				"--port", fmt.Sprintf("%d", utils.OpenShiftMCPServerPort),
+			}))
+			Expect(openshiftMCPServerContainer.SecurityContext).To(Equal(utils.RestrictedContainerSecurityContext()))
+			Expect(openshiftMCPServerContainer.Resources).To(Equal(corev1.ResourceRequirements{
+				Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("200Mi")},
+				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("50m"), corev1.ResourceMemory: resource.MustParse("64Mi")},
+				Claims:   []corev1.ResourceClaim{},
+			}))
+
+			// Verify MCP server has its own config volume mount
+			_, expectedConfigMount := utils.GetOpenShiftMCPServerConfigVolumeAndMount()
+			Expect(openshiftMCPServerContainer.VolumeMounts).To(ContainElement(expectedConfigMount))
+
+			// Verify MCP server config volume is in deployment
+			expectedConfigVolume, _ := utils.GetOpenShiftMCPServerConfigVolumeAndMount()
+			Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(expectedConfigVolume))
+
+			By("Disabling introspection")
+			cr.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(false)
+
+			dep, err = GenerateOLSDeployment(testReconcilerInstance, cr)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Should have only 2 containers: main app and dataverse exporter (no MCP server)
+			Expect(dep.Spec.Template.Spec.Containers).To(HaveLen(2))
+			Expect(dep.Spec.Template.Spec.Containers[0].Name).To(Equal(utils.OLSAppServerContainerName))
+			Expect(dep.Spec.Template.Spec.Containers[1].Name).To(Equal(utils.DataverseExporterContainerName))
+		})
+
+		It("should deploy MCP container independently of data collection settings", func() {
+			By("Test case 1: introspection enabled, data collection enabled - should have both MCP and dataverse exporter containers")
+			utils.CreateTelemetryPullSecret(ctx, k8sClient, true)
+			cr.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(true)
+			cr.Spec.OLSConfig.UserDataCollection = olsv1alpha1.UserDataCollectionSpec{
+				FeedbackDisabled:    false,
+				TranscriptsDisabled: false,
+			}
+
+			dep, err := GenerateOLSDeployment(testReconcilerInstance, cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dep.Spec.Template.Spec.Containers).To(HaveLen(3))
+			Expect(dep.Spec.Template.Spec.Containers[0].Name).To(Equal(utils.OLSAppServerContainerName))
+			Expect(dep.Spec.Template.Spec.Containers[1].Name).To(Equal(utils.DataverseExporterContainerName))
+			Expect(dep.Spec.Template.Spec.Containers[2].Name).To(Equal(utils.OpenShiftMCPServerContainerName))
+
+			By("Test case 2: introspection enabled, data collection disabled - should have only MCP container (no dataverse exporter)")
+			cr.Spec.OLSConfig.UserDataCollection = olsv1alpha1.UserDataCollectionSpec{
+				FeedbackDisabled:    true,
+				TranscriptsDisabled: true,
+			}
+
+			dep, err = GenerateOLSDeployment(testReconcilerInstance, cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dep.Spec.Template.Spec.Containers).To(HaveLen(2))
+			Expect(dep.Spec.Template.Spec.Containers[0].Name).To(Equal(utils.OLSAppServerContainerName))
+			Expect(dep.Spec.Template.Spec.Containers[1].Name).To(Equal(utils.OpenShiftMCPServerContainerName))
+
+			By("Test case 3: introspection disabled, data collection enabled - should have only dataverse exporter container (no MCP)")
+			cr.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(false)
+			cr.Spec.OLSConfig.UserDataCollection = olsv1alpha1.UserDataCollectionSpec{
+				FeedbackDisabled:    false,
+				TranscriptsDisabled: false,
+			}
+
+			dep, err = GenerateOLSDeployment(testReconcilerInstance, cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dep.Spec.Template.Spec.Containers).To(HaveLen(2))
+			Expect(dep.Spec.Template.Spec.Containers[0].Name).To(Equal(utils.OLSAppServerContainerName))
+			Expect(dep.Spec.Template.Spec.Containers[1].Name).To(Equal(utils.DataverseExporterContainerName))
+
+			By("Test case 4: introspection disabled, data collection disabled - should have only main container")
+			cr.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(false)
+			cr.Spec.OLSConfig.UserDataCollection = olsv1alpha1.UserDataCollectionSpec{
+				FeedbackDisabled:    true,
+				TranscriptsDisabled: true,
+			}
+
+			dep, err = GenerateOLSDeployment(testReconcilerInstance, cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dep.Spec.Template.Spec.Containers).To(HaveLen(1))
+			Expect(dep.Spec.Template.Spec.Containers[0].Name).To(Equal(utils.OLSAppServerContainerName))
+
+			utils.DeleteTelemetryPullSecret(ctx, k8sClient)
+		})
+
+		It("should deploy MCP container when introspection is enabled regardless of telemetry settings", func() {
+			By("Test case: introspection enabled with no telemetry pull secret - MCP should still be deployed")
+			cr.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(true)
+			cr.Spec.OLSConfig.UserDataCollection = olsv1alpha1.UserDataCollectionSpec{
+				FeedbackDisabled:    true,
+				TranscriptsDisabled: true,
+			}
+
+			dep, err := GenerateOLSDeployment(testReconcilerInstance, cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dep.Spec.Template.Spec.Containers).To(HaveLen(2))
+			Expect(dep.Spec.Template.Spec.Containers[0].Name).To(Equal(utils.OLSAppServerContainerName))
+			Expect(dep.Spec.Template.Spec.Containers[1].Name).To(Equal(utils.OpenShiftMCPServerContainerName))
+
+			// Verify MCP container configuration
+			mcpContainer := dep.Spec.Template.Spec.Containers[1]
+			Expect(mcpContainer.Image).To(Equal(utils.OpenShiftMCPServerImageDefault))
+			Expect(mcpContainer.Command).To(Equal([]string{
+				"/openshift-mcp-server",
+				"--config", utils.GetOpenShiftMCPServerConfigPath(),
+				"--port", fmt.Sprintf("%d", utils.OpenShiftMCPServerPort),
+			}))
+			Expect(mcpContainer.Resources).To(Equal(corev1.ResourceRequirements{
+				Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("200Mi")},
+				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("50m"), corev1.ResourceMemory: resource.MustParse("64Mi")},
+				Claims:   []corev1.ResourceClaim{},
+			}))
+		})
+
 		It("should generate exporter configmap with service_id 'ols' by default", func() {
 			cm, err := generateExporterConfigMap(testReconcilerInstance, cr)
 			Expect(err).NotTo(HaveOccurred())
@@ -858,6 +1330,9 @@ var _ = Describe("App server assets", func() {
 	Context("empty custom resource", func() {
 		BeforeEach(func() {
 			cr = utils.GetEmptyOLSConfigCR()
+			// Without an API round-trip, nil would match CRD default (true) via BoolDeref in generators;
+			// these tests expect introspection off for an "empty" in-memory CR.
+			cr.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(false)
 			By("create the OpenShift certificates config map")
 			configmap, _ = utils.GenerateRandomConfigMap()
 			configmap.SetOwnerReferences([]metav1.OwnerReference{
@@ -1049,6 +1524,70 @@ user_data_collector_config: {}
 			}))
 		})
 
+		It("should generate the OLS deployment", func() {
+			utils.CreateTelemetryPullSecret(ctx, k8sClient, true)
+			defer utils.DeleteTelemetryPullSecret(ctx, k8sClient)
+			dep, err := GenerateOLSDeployment(testReconcilerInstance, cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dep.Name).To(Equal(utils.OLSAppServerDeploymentName))
+			Expect(dep.Namespace).To(Equal(utils.OLSNamespaceDefault))
+			Expect(dep.Spec.Template.Spec.Containers[0].Image).To(Equal(utils.OLSAppServerImageDefault))
+			Expect(dep.Spec.Template.Spec.Containers[0].Name).To(Equal(utils.OLSAppServerContainerName))
+			Expect(dep.Spec.Template.Spec.Containers[0].Ports).To(Equal([]corev1.ContainerPort{
+				{
+					ContainerPort: utils.OLSAppServerContainerPort,
+					Name:          "https",
+					Protocol:      corev1.ProtocolTCP,
+				},
+			}))
+			Expect(dep.Spec.Template.Spec.Containers[0].Env).To(Equal([]corev1.EnvVar{
+				{
+					Name:  "OLS_CONFIG_FILE",
+					Value: path.Join("/etc/ols", utils.OLSConfigFilename),
+				},
+			}))
+			Expect(dep.Spec.Template.Spec.Containers[0].VolumeMounts).To(ConsistOf(
+				append(get7RequiredVolumeMounts(),
+					corev1.VolumeMount{
+						Name:      "ols-user-data",
+						ReadOnly:  false,
+						MountPath: "/app-root/ols-user-data",
+					},
+					corev1.VolumeMount{
+						Name:      utils.ExporterConfigVolumeName,
+						ReadOnly:  true,
+						MountPath: utils.ExporterConfigMountPath,
+					}),
+			))
+			Expect(dep.Spec.Template.Spec.Volumes).To(ConsistOf(
+				append(get7RequiredVolumes(),
+					corev1.Volume{
+						Name: "ols-user-data",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+					},
+					corev1.Volume{
+						Name: utils.ExporterConfigVolumeName,
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{Name: utils.ExporterConfigCmName},
+								DefaultMode:          &defaultVolumeMode,
+							},
+						},
+					}),
+			))
+			Expect(dep.Spec.Selector.MatchLabels).To(Equal(utils.GenerateAppServerSelectorLabels()))
+			Expect(dep.Spec.Template.Spec.Containers[0].LivenessProbe).ToNot(BeNil())
+			Expect(dep.Spec.Template.Spec.Containers[0].LivenessProbe.HTTPGet.Port).To(Equal(intstr.FromString("https")))
+			Expect(dep.Spec.Template.Spec.Containers[0].LivenessProbe.HTTPGet.Path).To(Equal("/liveness"))
+			Expect(dep.Spec.Template.Spec.Containers[0].ReadinessProbe).ToNot(BeNil())
+			Expect(dep.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Port).To(Equal(intstr.FromString("https")))
+			Expect(dep.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Path).To(Equal("/readiness"))
+			Expect(dep.Spec.Template.Spec.Tolerations).To(BeNil())
+			Expect(dep.Spec.Template.Spec.NodeSelector).To(BeNil())
+		})
+
 		It("should generate the OLS service monitor", func() {
 			serviceMonitor, err := GenerateServiceMonitor(testReconcilerInstance, cr)
 			Expect(err).NotTo(HaveOccurred())
@@ -1142,12 +1681,25 @@ user_data_collector_config: {}
 	})
 
 	Context("Additional CA", func() {
+
 		const caConfigMapName = "test-ca-configmap"
 		const certFilename = "additional-ca.crt"
 		var additionalCACm *corev1.ConfigMap
 
 		BeforeEach(func() {
 			cr = utils.GetDefaultOLSConfigCR()
+			By("create the provider secret")
+			secret, _ = utils.GenerateRandomSecret()
+			secret.SetOwnerReferences([]metav1.OwnerReference{
+				{
+					Kind:       "Secret",
+					APIVersion: "v1",
+					UID:        "ownerUID",
+					Name:       "test-secret",
+				},
+			})
+			err := testReconcilerInstance.Create(ctx, secret)
+			Expect(err).NotTo(HaveOccurred())
 			By("create the additional CA configmap")
 			additionalCACm = &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1158,14 +1710,117 @@ user_data_collector_config: {}
 					certFilename: utils.TestCACert,
 				},
 			}
-			err := testReconcilerInstance.Create(ctx, additionalCACm)
+			err = testReconcilerInstance.Create(ctx, additionalCACm)
 			Expect(err).NotTo(HaveOccurred())
+
+			By("create the OpenShift certificates config map")
+			configmap, _ = utils.GenerateRandomConfigMap()
+			configmap.SetOwnerReferences([]metav1.OwnerReference{
+				{
+					Kind:       "Configmap",
+					APIVersion: "v1",
+					UID:        "ownerUID",
+					Name:       utils.DefaultOpenShiftCerts,
+				},
+			})
+			configMapCreationErr := testReconcilerInstance.Create(ctx, configmap)
+			Expect(configMapCreationErr).NotTo(HaveOccurred())
 		})
 
 		AfterEach(func() {
-			By("Delete the additional CA configmap")
-			err := testReconcilerInstance.Delete(ctx, additionalCACm)
+			By("Delete the provider secret")
+			err := testReconcilerInstance.Delete(ctx, secret)
 			Expect(err).NotTo(HaveOccurred())
+			By("Delete the additional CA configmap")
+			err = testReconcilerInstance.Delete(ctx, additionalCACm)
+			Expect(err).NotTo(HaveOccurred())
+			configMapDeletionErr := testReconcilerInstance.Delete(ctx, configmap)
+			Expect(configMapDeletionErr).NotTo(HaveOccurred())
+		})
+
+		It("should update OLS config and mount volumes for additional CA", func() {
+			dep, err := GenerateOLSDeployment(testReconcilerInstance, cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dep.Spec.Template.Spec.Volumes).NotTo(ContainElement(
+				corev1.Volume{
+					Name: utils.AdditionalCAVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: caConfigMapName,
+							},
+							DefaultMode: &defaultVolumeMode,
+						},
+					},
+				}))
+
+			cr.Spec.OLSConfig.AdditionalCAConfigMapRef = &corev1.LocalObjectReference{
+				Name: caConfigMapName,
+			}
+
+			olsCm, err := GenerateOLSConfigMap(testReconcilerInstance, ctx, cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(olsCm.Data[utils.OLSConfigFilename]).To(ContainSubstring("extra_ca:\n  - /etc/certs/ols-additional-ca/service-ca.crt\n  - /etc/certs/ols-user-ca/additional-ca.crt"))
+			Expect(olsCm.Data[utils.OLSConfigFilename]).To(ContainSubstring("certificate_directory: /etc/certs/cert-bundle"))
+
+			dep, err = GenerateOLSDeployment(testReconcilerInstance, cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dep.Spec.Template.Spec.Volumes).To(ContainElements(
+				corev1.Volume{
+					Name: utils.AdditionalCAVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: caConfigMapName,
+							},
+							DefaultMode: &defaultVolumeMode,
+						},
+					},
+				},
+				corev1.Volume{
+					Name: utils.CertBundleVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+			))
+
+		})
+
+		It("should generate ImagePullSecrets in the app server deployment pod template", func() {
+			// there should be no ImagePullSecrets in the app server deployment
+			// pod template if none are specified in OLSCconfig
+			Expect(cr.Spec.OLSConfig.ImagePullSecrets).To(BeNil())
+			dep, err := GenerateOLSDeployment(testReconcilerInstance, cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dep.Spec.Template.Spec.ImagePullSecrets).To(BeNil())
+
+			imagePullSecrets := []corev1.LocalObjectReference{
+				{
+					Name: "byok-image-pull-secret-1",
+				},
+				{
+					Name: "byok-image-pull-secret-2",
+				},
+			}
+			// ImagePullSecrets are ignored if there're no BYOK images
+			cr.Spec.OLSConfig.ImagePullSecrets = imagePullSecrets
+			dep, err = GenerateOLSDeployment(testReconcilerInstance, cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dep.Spec.Template.Spec.ImagePullSecrets).To(BeNil())
+
+			// ImagePullSecrets should be set in the app server deployment
+			// pod template if there are BYOK images
+			cr.Spec.OLSConfig.RAG = []olsv1alpha1.RAGSpec{
+				{
+					Image:     "rag-image-1",
+					IndexPath: "/path/to/index-1",
+					IndexID:   "index-id-1",
+				},
+			}
+			dep, err = GenerateOLSDeployment(testReconcilerInstance, cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dep.Spec.Template.Spec.ImagePullSecrets).To(Equal(imagePullSecrets))
 		})
 
 		It("should return error if the CA text is malformed", func() {
@@ -1180,6 +1835,7 @@ user_data_collector_config: {}
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to validate additional CA certificate"))
 		})
+
 	})
 
 	Context("Proxy settings", func() {
@@ -1189,7 +1845,19 @@ user_data_collector_config: {}
 
 		BeforeEach(func() {
 			cr = utils.GetDefaultOLSConfigCR()
-			By("create the proxy CA configmap")
+			By("create the provider secret")
+			secret, _ = utils.GenerateRandomSecret()
+			secret.SetOwnerReferences([]metav1.OwnerReference{
+				{
+					Kind:       "Secret",
+					APIVersion: "v1",
+					UID:        "ownerUID",
+					Name:       "test-secret",
+				},
+			})
+			err := testReconcilerInstance.Create(ctx, secret)
+			Expect(err).NotTo(HaveOccurred())
+			By("create the additional CA configmap")
 			proxyCACm = &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      caConfigMapName,
@@ -1199,14 +1867,91 @@ user_data_collector_config: {}
 					utils.ProxyCACertFileName: utils.TestCACert,
 				},
 			}
-			err := testReconcilerInstance.Create(ctx, proxyCACm)
+			err = testReconcilerInstance.Create(ctx, proxyCACm)
 			Expect(err).NotTo(HaveOccurred())
+
+			By("create the OpenShift certificates config map")
+			configmap, _ = utils.GenerateRandomConfigMap()
+			configmap.SetOwnerReferences([]metav1.OwnerReference{
+				{
+					Kind:       "Configmap",
+					APIVersion: "v1",
+					UID:        "ownerUID",
+					Name:       utils.DefaultOpenShiftCerts,
+				},
+			})
+			configMapCreationErr := testReconcilerInstance.Create(ctx, configmap)
+			Expect(configMapCreationErr).NotTo(HaveOccurred())
 		})
 
 		AfterEach(func() {
-			By("Delete the proxy CA configmap")
-			err := testReconcilerInstance.Delete(ctx, proxyCACm)
+			By("Delete the provider secret")
+			err := testReconcilerInstance.Delete(ctx, secret)
 			Expect(err).NotTo(HaveOccurred())
+			By("Delete the additional CA configmap")
+			err = testReconcilerInstance.Delete(ctx, proxyCACm)
+			Expect(err).NotTo(HaveOccurred())
+			configMapDeletionErr := testReconcilerInstance.Delete(ctx, configmap)
+			Expect(configMapDeletionErr).NotTo(HaveOccurred())
+		})
+
+		It("should update OLS config and mount volumes for proxy settings", func() {
+			olsCm, err := GenerateOLSConfigMap(testReconcilerInstance, ctx, cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(olsCm.Data[utils.OLSConfigFilename]).NotTo(ContainSubstring("proxy_config:"))
+
+			dep, err := GenerateOLSDeployment(testReconcilerInstance, cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dep.Spec.Template.Spec.Volumes).NotTo(ContainElement(
+				MatchFields(IgnoreExtras, Fields{
+					"Name": Equal(utils.ProxyCACertVolumeName),
+				}),
+			))
+			Expect(dep.Spec.Template.Spec.Containers[0].VolumeMounts).NotTo(ContainElement(
+				MatchFields(IgnoreExtras, Fields{
+					"Name": Equal(utils.ProxyCACertVolumeName),
+				}),
+			))
+
+			cr.Spec.OLSConfig.ProxyConfig = &olsv1alpha1.ProxyConfig{
+				ProxyURL: proxyURL,
+				ProxyCACertificateRef: &olsv1alpha1.ProxyCACertConfigMapRef{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: caConfigMapName,
+					},
+					// No Key specified - tests backward compatibility
+				},
+			}
+
+			olsCm, err = GenerateOLSConfigMap(testReconcilerInstance, ctx, cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(olsCm.Data[utils.OLSConfigFilename]).To(ContainSubstring("proxy_ca_cert_path: /etc/certs/proxy-ca/" + utils.ProxyCACertFileName))
+			Expect(olsCm.Data[utils.OLSConfigFilename]).To(ContainSubstring("proxy_url: " + proxyURL))
+
+			dep, err = GenerateOLSDeployment(testReconcilerInstance, cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(
+				corev1.Volume{
+					Name: utils.ProxyCACertVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: caConfigMapName,
+							},
+							DefaultMode: &defaultVolumeMode,
+							Items: []corev1.KeyToPath{
+								{Key: utils.ProxyCACertFileName, Path: utils.ProxyCACertFileName},
+							},
+						},
+					},
+				}))
+			Expect(dep.Spec.Template.Spec.Containers[0].VolumeMounts).To(ContainElement(
+				corev1.VolumeMount{
+					Name:      utils.ProxyCACertVolumeName,
+					MountPath: path.Join(utils.OLSAppCertsMountRoot, utils.ProxyCACertVolumeName),
+					ReadOnly:  true,
+				},
+			))
 		})
 
 		It("should return error if the CA text is malformed", func() {
@@ -1220,6 +1965,7 @@ user_data_collector_config: {}
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: caConfigMapName,
 					},
+					// No Key specified - tests backward compatibility
 				},
 			}
 			_, err = GenerateOLSConfigMap(testReconcilerInstance, ctx, cr)
@@ -1247,7 +1993,6 @@ user_data_collector_config: {}
 			Expect(olsCm.Data[utils.OLSConfigFilename]).To(ContainSubstring("proxy_url: " + proxyURL))
 		})
 	})
-
 })
 
 func get7RequiredVolumeMounts() []corev1.VolumeMount {
@@ -1314,6 +2059,69 @@ func get10RequiredVolumeMounts() []corev1.VolumeMount {
 			ReadOnly:  true,
 			MountPath: utils.ExporterConfigMountPath,
 		})
+}
+
+func get7RequiredVolumes() []corev1.Volume {
+
+	return []corev1.Volume{
+		{
+			Name: "secret-lightspeed-tls",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  utils.OLSCertsSecretName,
+					DefaultMode: &defaultVolumeMode,
+				},
+			},
+		},
+		{
+			Name: "cm-olsconfig",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: utils.OLSConfigCmName},
+					DefaultMode:          &defaultVolumeMode,
+				},
+			},
+		},
+		{
+			Name: "secret-lightspeed-postgres-secret",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  utils.PostgresSecretName,
+					DefaultMode: &defaultVolumeMode,
+				},
+			},
+		},
+		{
+			Name: utils.PostgresCAVolume,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: utils.OLSCAConfigMap},
+					DefaultMode:          &defaultVolumeMode,
+				},
+			},
+		},
+		{
+			Name: utils.TmpVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name: "openshift-ca",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "kube-root-ca.crt"},
+					DefaultMode:          &defaultVolumeMode,
+				},
+			},
+		},
+		{
+			Name: "cert-bundle",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+	}
 }
 
 var _ = Describe("Helper function unit tests", func() {
@@ -1393,7 +2201,7 @@ var _ = Describe("Helper function unit tests", func() {
 
 	Context("generateMCPServerConfigs", func() {
 		It("should return empty list when introspection is disabled and no user servers", func() {
-			cr.Spec.OLSConfig.IntrospectionEnabled = false
+			cr.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(false)
 			cr.Spec.MCPServers = nil
 			servers, err := generateMCPServerConfigs(testReconcilerInstance, cr)
 			Expect(err).NotTo(HaveOccurred())
@@ -1401,7 +2209,7 @@ var _ = Describe("Helper function unit tests", func() {
 		})
 
 		It("should add OpenShift MCP server when introspection is enabled", func() {
-			cr.Spec.OLSConfig.IntrospectionEnabled = true
+			cr.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(true)
 			servers, err := generateMCPServerConfigs(testReconcilerInstance, cr)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(servers).To(HaveLen(1))
@@ -1411,7 +2219,7 @@ var _ = Describe("Helper function unit tests", func() {
 		})
 
 		It("should use default timeout for OpenShift MCP server when MCPKubeServerConfig is not set", func() {
-			cr.Spec.OLSConfig.IntrospectionEnabled = true
+			cr.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(true)
 			cr.Spec.OLSConfig.MCPKubeServerConfig = nil
 			servers, err := generateMCPServerConfigs(testReconcilerInstance, cr)
 			Expect(err).NotTo(HaveOccurred())
@@ -1421,7 +2229,7 @@ var _ = Describe("Helper function unit tests", func() {
 		})
 
 		It("should use custom timeout for OpenShift MCP server when MCPKubeServerConfig is set", func() {
-			cr.Spec.OLSConfig.IntrospectionEnabled = true
+			cr.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(true)
 			cr.Spec.OLSConfig.MCPKubeServerConfig = &olsv1alpha1.MCPKubeServerConfiguration{
 				Timeout: 120,
 			}
@@ -1579,7 +2387,7 @@ var _ = Describe("Helper function unit tests", func() {
 		})
 
 		It("should include both OpenShift and user-defined servers", func() {
-			cr.Spec.OLSConfig.IntrospectionEnabled = true
+			cr.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(true)
 			cr.Spec.FeatureGates = []olsv1alpha1.FeatureGate{utils.FeatureGateMCPServer}
 			cr.Spec.MCPServers = []olsv1alpha1.MCPServerConfig{
 				{

--- a/internal/controller/appserver/deployment.go
+++ b/internal/controller/appserver/deployment.go
@@ -505,8 +505,9 @@ func GenerateOLSDeployment(r reconciler.Reconciler, cr *olsv1alpha1.OLSConfig) (
 	// Add OpenShift MCP server sidecar container if introspection is enabled.
 	// The sidecar is configured with a TOML config that denies access to Secret resources,
 	// preventing secret data from reaching the LLM.
-	if cr.Spec.OLSConfig.IntrospectionEnabled {
+	if utils.BoolDeref(cr.Spec.OLSConfig.IntrospectionEnabled, true) {
 		configVolume, configMount := utils.GetOpenShiftMCPServerConfigVolumeAndMount()
+
 		openshiftMCPServerSidecarContainer := corev1.Container{
 			Name:            "openshift-mcp-server",
 			Image:           r.GetOpenShiftMCPServerImage(),
@@ -515,7 +516,6 @@ func GenerateOLSDeployment(r reconciler.Reconciler, cr *olsv1alpha1.OLSConfig) (
 			VolumeMounts:    []corev1.VolumeMount{configMount},
 			Command: []string{
 				"/openshift-mcp-server",
-				"--read-only",
 				"--config", utils.GetOpenShiftMCPServerConfigPath(),
 				"--port", fmt.Sprintf("%d", utils.OpenShiftMCPServerPort),
 			},

--- a/internal/controller/appserver/deployment_test.go
+++ b/internal/controller/appserver/deployment_test.go
@@ -133,7 +133,7 @@ var _ = Describe("App server deployment generation", func() {
 			defer utils.DeleteTelemetryPullSecret(ctx, k8sClient)
 
 			By("Enabling introspection")
-			cr.Spec.OLSConfig.IntrospectionEnabled = true
+			cr.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(true)
 
 			dep, err := GenerateOLSDeployment(testReconcilerInstance, cr)
 			Expect(err).NotTo(HaveOccurred())
@@ -148,13 +148,12 @@ var _ = Describe("App server deployment generation", func() {
 			Expect(openshiftMCPServerContainer.Image).To(Equal(utils.OpenShiftMCPServerImageDefault))
 			Expect(openshiftMCPServerContainer.Command).To(Equal([]string{
 				"/openshift-mcp-server",
-				"--read-only",
 				"--config", utils.GetOpenShiftMCPServerConfigPath(),
 				"--port", fmt.Sprintf("%d", utils.OpenShiftMCPServerPort),
 			}))
 
 			By("Disabling introspection")
-			cr.Spec.OLSConfig.IntrospectionEnabled = false
+			cr.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(false)
 
 			dep, err = GenerateOLSDeployment(testReconcilerInstance, cr)
 			Expect(err).NotTo(HaveOccurred())
@@ -163,12 +162,24 @@ var _ = Describe("App server deployment generation", func() {
 			Expect(dep.Spec.Template.Spec.Containers).To(HaveLen(2))
 			Expect(dep.Spec.Template.Spec.Containers[0].Name).To(Equal(utils.OLSAppServerContainerName))
 			Expect(dep.Spec.Template.Spec.Containers[1].Name).To(Equal(utils.DataverseExporterContainerName))
+
+			By("Leaving introspection unset should use default enabled behavior")
+			cr.Spec.OLSConfig.IntrospectionEnabled = nil
+
+			dep, err = GenerateOLSDeployment(testReconcilerInstance, cr)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Default is enabled, so MCP sidecar should be present again.
+			Expect(dep.Spec.Template.Spec.Containers).To(HaveLen(3))
+			Expect(dep.Spec.Template.Spec.Containers[0].Name).To(Equal(utils.OLSAppServerContainerName))
+			Expect(dep.Spec.Template.Spec.Containers[1].Name).To(Equal(utils.DataverseExporterContainerName))
+			Expect(dep.Spec.Template.Spec.Containers[2].Name).To(Equal(utils.OpenShiftMCPServerContainerName))
 		})
 
 		It("should deploy MCP container independently of data collection settings", func() {
 			By("introspection enabled, data collection enabled")
 			utils.CreateTelemetryPullSecret(ctx, k8sClient, true)
-			cr.Spec.OLSConfig.IntrospectionEnabled = true
+			cr.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(true)
 			cr.Spec.OLSConfig.UserDataCollection = olsv1alpha1.UserDataCollectionSpec{
 				FeedbackDisabled:    false,
 				TranscriptsDisabled: false,
@@ -195,7 +206,7 @@ var _ = Describe("App server deployment generation", func() {
 
 		It("should deploy MCP container when introspection is enabled regardless of telemetry settings", func() {
 			By("introspection enabled with no telemetry pull secret")
-			cr.Spec.OLSConfig.IntrospectionEnabled = true
+			cr.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(true)
 			cr.Spec.OLSConfig.UserDataCollection = olsv1alpha1.UserDataCollectionSpec{
 				FeedbackDisabled:    true,
 				TranscriptsDisabled: true,
@@ -212,7 +223,6 @@ var _ = Describe("App server deployment generation", func() {
 			Expect(mcpContainer.Image).To(Equal(utils.OpenShiftMCPServerImageDefault))
 			Expect(mcpContainer.Command).To(Equal([]string{
 				"/openshift-mcp-server",
-				"--read-only",
 				"--config", utils.GetOpenShiftMCPServerConfigPath(),
 				"--port", fmt.Sprintf("%d", utils.OpenShiftMCPServerPort),
 			}))

--- a/internal/controller/appserver/reconciler_test.go
+++ b/internal/controller/appserver/reconciler_test.go
@@ -224,7 +224,7 @@ var _ = Describe("App server reconciliator", Ordered, func() {
 			olsConfig := &olsv1alpha1.OLSConfig{}
 			err := k8sClient.Get(ctx, crNamespacedName, olsConfig)
 			Expect(err).NotTo(HaveOccurred())
-			olsConfig.Spec.OLSConfig.IntrospectionEnabled = false
+			olsConfig.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(false)
 
 			By("Reconcile with introspection disabled")
 			err = ReconcileAppServer(testReconcilerInstance, ctx, olsConfig)
@@ -245,7 +245,7 @@ var _ = Describe("App server reconciliator", Ordered, func() {
 			By("Enable introspection")
 			err = k8sClient.Get(ctx, crNamespacedName, olsConfig)
 			Expect(err).NotTo(HaveOccurred())
-			olsConfig.Spec.OLSConfig.IntrospectionEnabled = true
+			olsConfig.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(true)
 
 			By("Reconcile with introspection enabled")
 			err = ReconcileAppServer(testReconcilerInstance, ctx, olsConfig)
@@ -266,7 +266,7 @@ var _ = Describe("App server reconciliator", Ordered, func() {
 			By("Disable introspection again")
 			err = k8sClient.Get(ctx, crNamespacedName, olsConfig)
 			Expect(err).NotTo(HaveOccurred())
-			olsConfig.Spec.OLSConfig.IntrospectionEnabled = false
+			olsConfig.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(false)
 
 			By("Reconcile with introspection disabled again")
 			err = ReconcileAppServer(testReconcilerInstance, ctx, olsConfig)
@@ -292,7 +292,7 @@ var _ = Describe("App server reconciliator", Ordered, func() {
 			olsConfig := &olsv1alpha1.OLSConfig{}
 			err := k8sClient.Get(ctx, crNamespacedName, olsConfig)
 			Expect(err).NotTo(HaveOccurred())
-			olsConfig.Spec.OLSConfig.IntrospectionEnabled = true
+			olsConfig.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(true)
 
 			By("Reconcile to create MCP ConfigMap")
 			err = ReconcileAppServer(testReconcilerInstance, ctx, olsConfig)

--- a/internal/controller/lcore/config.go
+++ b/internal/controller/lcore/config.go
@@ -753,7 +753,7 @@ func buildLCoreMCPServersConfig(r reconciler.Reconciler, cr *olsv1alpha1.OLSConf
 	mcpServers := []map[string]interface{}{}
 
 	// Add OpenShift MCP server if introspection is enabled
-	if cr.Spec.OLSConfig.IntrospectionEnabled {
+	if utils.BoolDeref(cr.Spec.OLSConfig.IntrospectionEnabled, true) {
 		mcpServers = append(mcpServers, map[string]interface{}{
 			"name": "openshift",
 			"url":  fmt.Sprintf(utils.OpenShiftMCPServerURL, utils.OpenShiftMCPServerPort),

--- a/internal/controller/lcore/config_test.go
+++ b/internal/controller/lcore/config_test.go
@@ -54,7 +54,7 @@ func TestBuildLCoreMCPServersConfig_NoServers(t *testing.T) {
 		},
 		Spec: olsv1alpha1.OLSConfigSpec{
 			OLSConfig: olsv1alpha1.OLSSpec{
-				IntrospectionEnabled: false,
+				IntrospectionEnabled: utils.BoolPtr(false),
 			},
 		},
 	}
@@ -75,7 +75,7 @@ func TestBuildLCoreMCPServersConfig_IntrospectionOnly(t *testing.T) {
 		},
 		Spec: olsv1alpha1.OLSConfigSpec{
 			OLSConfig: olsv1alpha1.OLSSpec{
-				IntrospectionEnabled: true,
+				IntrospectionEnabled: utils.BoolPtr(true),
 			},
 		},
 	}
@@ -119,7 +119,7 @@ func TestBuildLCoreMCPServersConfig_UserDefinedServers_KubernetesPlaceholder(t *
 		Spec: olsv1alpha1.OLSConfigSpec{
 			FeatureGates: []olsv1alpha1.FeatureGate{utils.FeatureGateMCPServer},
 			OLSConfig: olsv1alpha1.OLSSpec{
-				IntrospectionEnabled: false,
+				IntrospectionEnabled: utils.BoolPtr(false),
 			},
 			MCPServers: []olsv1alpha1.MCPServerConfig{
 				{
@@ -181,7 +181,7 @@ func TestBuildLCoreMCPServersConfig_UserDefinedServers_WithSecretRef(t *testing.
 		Spec: olsv1alpha1.OLSConfigSpec{
 			FeatureGates: []olsv1alpha1.FeatureGate{utils.FeatureGateMCPServer},
 			OLSConfig: olsv1alpha1.OLSSpec{
-				IntrospectionEnabled: false,
+				IntrospectionEnabled: utils.BoolPtr(false),
 			},
 			MCPServers: []olsv1alpha1.MCPServerConfig{
 				{
@@ -243,7 +243,7 @@ func TestBuildLCoreMCPServersConfig_Combined(t *testing.T) {
 		Spec: olsv1alpha1.OLSConfigSpec{
 			FeatureGates: []olsv1alpha1.FeatureGate{utils.FeatureGateMCPServer},
 			OLSConfig: olsv1alpha1.OLSSpec{
-				IntrospectionEnabled: true,
+				IntrospectionEnabled: utils.BoolPtr(true),
 			},
 			MCPServers: []olsv1alpha1.MCPServerConfig{
 				{
@@ -293,7 +293,7 @@ func TestBuildLCoreMCPServersConfig_FiltersNonHTTP(t *testing.T) {
 		Spec: olsv1alpha1.OLSConfigSpec{
 			FeatureGates: []olsv1alpha1.FeatureGate{utils.FeatureGateMCPServer},
 			OLSConfig: olsv1alpha1.OLSSpec{
-				IntrospectionEnabled: false,
+				IntrospectionEnabled: utils.BoolPtr(false),
 			},
 			MCPServers: []olsv1alpha1.MCPServerConfig{
 				{
@@ -335,7 +335,7 @@ func TestBuildLCoreMCPServersConfig_EmptyHeadersNotAdded(t *testing.T) {
 		Spec: olsv1alpha1.OLSConfigSpec{
 			FeatureGates: []olsv1alpha1.FeatureGate{utils.FeatureGateMCPServer},
 			OLSConfig: olsv1alpha1.OLSSpec{
-				IntrospectionEnabled: false,
+				IntrospectionEnabled: utils.BoolPtr(false),
 			},
 			MCPServers: []olsv1alpha1.MCPServerConfig{
 				{
@@ -368,6 +368,9 @@ func TestBuildLCoreMCPServersConfig_SkipsEmptySecretRefs(t *testing.T) {
 		},
 		Spec: olsv1alpha1.OLSConfigSpec{
 			FeatureGates: []olsv1alpha1.FeatureGate{utils.FeatureGateMCPServer},
+			OLSConfig: olsv1alpha1.OLSSpec{
+				IntrospectionEnabled: utils.BoolPtr(false),
+			},
 			MCPServers: []olsv1alpha1.MCPServerConfig{
 				{
 					Name: "server-with-mixed-headers",
@@ -425,7 +428,7 @@ func TestBuildLCoreConfigYAML_WithMCPServers(t *testing.T) {
 		},
 		Spec: olsv1alpha1.OLSConfigSpec{
 			OLSConfig: olsv1alpha1.OLSSpec{
-				IntrospectionEnabled: true,
+				IntrospectionEnabled: utils.BoolPtr(true),
 			},
 		},
 	}
@@ -455,7 +458,7 @@ func TestBuildLCoreConfigYAML_WithoutMCPServers(t *testing.T) {
 		},
 		Spec: olsv1alpha1.OLSConfigSpec{
 			OLSConfig: olsv1alpha1.OLSSpec{
-				IntrospectionEnabled: false,
+				IntrospectionEnabled: utils.BoolPtr(false),
 			},
 		},
 	}

--- a/internal/controller/lcore/deployment.go
+++ b/internal/controller/lcore/deployment.go
@@ -98,7 +98,7 @@ func getOLSDataCollectorResources(cr *olsv1alpha1.OLSConfig) *corev1.ResourceReq
 // The sidecar is configured with a TOML config that denies access to Secret resources,
 // preventing secret data from reaching the LLM.
 func addOpenShiftMCPServerSidecar(r reconciler.Reconciler, cr *olsv1alpha1.OLSConfig, deployment *appsv1.Deployment) {
-	if !cr.Spec.OLSConfig.IntrospectionEnabled {
+	if !utils.BoolDeref(cr.Spec.OLSConfig.IntrospectionEnabled, true) {
 		return
 	}
 
@@ -112,7 +112,6 @@ func addOpenShiftMCPServerSidecar(r reconciler.Reconciler, cr *olsv1alpha1.OLSCo
 		VolumeMounts:    []corev1.VolumeMount{configMount},
 		Command: []string{
 			"/openshift-mcp-server",
-			"--read-only",
 			"--config", utils.GetOpenShiftMCPServerConfigPath(),
 			"--port", fmt.Sprintf("%d", utils.OpenShiftMCPServerPort),
 		},

--- a/internal/controller/lcore/deployment_test.go
+++ b/internal/controller/lcore/deployment_test.go
@@ -96,6 +96,9 @@ func TestGenerateLCoreDeployment(t *testing.T) {
 					},
 				},
 			},
+			OLSConfig: olsv1alpha1.OLSSpec{
+				IntrospectionEnabled: utils.BoolPtr(false),
+			},
 		},
 	}
 
@@ -312,6 +315,7 @@ func TestGenerateLCoreDeploymentWithAdditionalCA(t *testing.T) {
 				},
 			},
 			OLSConfig: olsv1alpha1.OLSSpec{
+				IntrospectionEnabled: utils.BoolPtr(false),
 				AdditionalCAConfigMapRef: &corev1.LocalObjectReference{
 					Name: "custom-ca-bundle",
 				},
@@ -436,7 +440,7 @@ func TestGenerateLCoreDeploymentWithIntrospection(t *testing.T) {
 				},
 			},
 			OLSConfig: olsv1alpha1.OLSSpec{
-				IntrospectionEnabled: true,
+				IntrospectionEnabled: utils.BoolPtr(true),
 			},
 		},
 	}
@@ -485,7 +489,7 @@ func TestGenerateLCoreDeploymentWithIntrospection(t *testing.T) {
 		t.Errorf("Expected ImagePullPolicy PullIfNotPresent, got %v", openshiftMCPContainer.ImagePullPolicy)
 	}
 
-	// Verify command includes port, read-only, and config flags
+	// Verify command includes port and config flags
 	if len(openshiftMCPContainer.Command) == 0 {
 		t.Error("OpenShift MCP server container has no command")
 	} else {
@@ -493,9 +497,6 @@ func TestGenerateLCoreDeploymentWithIntrospection(t *testing.T) {
 		expectedPort := fmt.Sprintf("%d", utils.OpenShiftMCPServerPort)
 		if !strings.Contains(commandStr, "--port") || !strings.Contains(commandStr, expectedPort) {
 			t.Errorf("Expected command to include '--port %s', got: %s", expectedPort, commandStr)
-		}
-		if !strings.Contains(commandStr, "--read-only") {
-			t.Error("Expected command to include '--read-only' flag")
 		}
 		if !strings.Contains(commandStr, "--config") || !strings.Contains(commandStr, utils.GetOpenShiftMCPServerConfigPath()) {
 			t.Errorf("Expected command to include '--config %s', got: %s", utils.GetOpenShiftMCPServerConfigPath(), commandStr)
@@ -677,7 +678,7 @@ func TestGenerateLCoreDeploymentWithoutIntrospection(t *testing.T) {
 				},
 			},
 			OLSConfig: olsv1alpha1.OLSSpec{
-				IntrospectionEnabled: false,
+				IntrospectionEnabled: utils.BoolPtr(false),
 			},
 		},
 	}
@@ -789,6 +790,9 @@ func TestGenerateLCoreDeploymentLibraryMode(t *testing.T) {
 						},
 					},
 				},
+			},
+			OLSConfig: olsv1alpha1.OLSSpec{
+				IntrospectionEnabled: utils.BoolPtr(false),
 			},
 		},
 	}
@@ -1006,6 +1010,7 @@ func TestDataCollectorSidecar_Enabled(t *testing.T) {
 				},
 			},
 			OLSConfig: olsv1alpha1.OLSSpec{
+				IntrospectionEnabled: utils.BoolPtr(false),
 				UserDataCollection: olsv1alpha1.UserDataCollectionSpec{
 					FeedbackDisabled:    false,
 					TranscriptsDisabled: false,
@@ -1106,6 +1111,7 @@ func TestDataCollectorSidecar_Disabled(t *testing.T) {
 				},
 			},
 			OLSConfig: olsv1alpha1.OLSSpec{
+				IntrospectionEnabled: utils.BoolPtr(false),
 				UserDataCollection: olsv1alpha1.UserDataCollectionSpec{
 					FeedbackDisabled:    true,
 					TranscriptsDisabled: true,
@@ -1162,6 +1168,7 @@ func TestDataCollectorSidecar_LibraryMode(t *testing.T) {
 				},
 			},
 			OLSConfig: olsv1alpha1.OLSSpec{
+				IntrospectionEnabled: utils.BoolPtr(false),
 				UserDataCollection: olsv1alpha1.UserDataCollectionSpec{
 					FeedbackDisabled:    false,
 					TranscriptsDisabled: false,

--- a/internal/controller/lcore/reconciler_test.go
+++ b/internal/controller/lcore/reconciler_test.go
@@ -421,7 +421,7 @@ var _ = Describe("LCore reconciliator", Ordered, func() {
 			By("Disable introspection initially")
 			err := k8sClient.Get(ctx, crNamespacedName, cr)
 			Expect(err).NotTo(HaveOccurred())
-			cr.Spec.OLSConfig.IntrospectionEnabled = false
+			cr.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(false)
 			err = k8sClient.Update(ctx, cr)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -444,7 +444,7 @@ var _ = Describe("LCore reconciliator", Ordered, func() {
 			By("Enable introspection")
 			err = k8sClient.Get(ctx, crNamespacedName, cr)
 			Expect(err).NotTo(HaveOccurred())
-			cr.Spec.OLSConfig.IntrospectionEnabled = true
+			cr.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(true)
 			err = k8sClient.Update(ctx, cr)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -467,7 +467,7 @@ var _ = Describe("LCore reconciliator", Ordered, func() {
 			By("Disable introspection again")
 			err = k8sClient.Get(ctx, crNamespacedName, cr)
 			Expect(err).NotTo(HaveOccurred())
-			cr.Spec.OLSConfig.IntrospectionEnabled = false
+			cr.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(false)
 			err = k8sClient.Update(ctx, cr)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -494,7 +494,7 @@ var _ = Describe("LCore reconciliator", Ordered, func() {
 			By("Enable introspection")
 			err := k8sClient.Get(ctx, crNamespacedName, cr)
 			Expect(err).NotTo(HaveOccurred())
-			cr.Spec.OLSConfig.IntrospectionEnabled = true
+			cr.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(true)
 			err = k8sClient.Update(ctx, cr)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/internal/controller/utils/mcp_server_config.go
+++ b/internal/controller/utils/mcp_server_config.go
@@ -71,7 +71,7 @@ func ReconcileOpenShiftMCPServerConfigMap(r reconciler.Reconciler, ctx context.C
 	foundCm := &corev1.ConfigMap{}
 	getErr := r.Get(ctx, client.ObjectKey{Name: OpenShiftMCPServerConfigCmName, Namespace: r.GetNamespace()}, foundCm)
 
-	if !cr.Spec.OLSConfig.IntrospectionEnabled {
+	if !BoolDeref(cr.Spec.OLSConfig.IntrospectionEnabled, true) {
 		if getErr == nil {
 			r.GetLogger().Info("deleting MCP server config configmap", "configmap", OpenShiftMCPServerConfigCmName)
 			if err := r.Delete(ctx, foundCm); err != nil {

--- a/internal/controller/utils/test_fixtures.go
+++ b/internal/controller/utils/test_fixtures.go
@@ -88,10 +88,11 @@ func GetDefaultOLSConfigCR() *olsv1alpha1.OLSConfig {
 						MaxConnections: PostgresMaxConnections,
 					},
 				},
-				DefaultModel:    "testModel",
-				DefaultProvider: "testProvider",
-				MaxIterations:   5,
-				LogLevel:        olsv1alpha1.LogLevelInfo,
+				DefaultModel:         "testModel",
+				DefaultProvider:      "testProvider",
+				MaxIterations:        5,
+				LogLevel:             olsv1alpha1.LogLevelInfo,
+				IntrospectionEnabled: BoolPtr(false),
 			},
 		},
 	}
@@ -125,6 +126,7 @@ func GetOLSConfigWithCacheCR() *olsv1alpha1.OLSConfig {
 						MaxConnections: PostgresMaxConnections,
 					},
 				},
+				IntrospectionEnabled: BoolPtr(false),
 			},
 		},
 	}

--- a/internal/controller/utils/utils.go
+++ b/internal/controller/utils/utils.go
@@ -1060,3 +1060,16 @@ func ReconcileProxyCAConfigMap(r reconciler.Reconciler, ctx context.Context, cr 
 	r.GetLogger().Info("proxy CA configmap reconciled", "configmap", cm.Name)
 	return nil
 }
+
+// BoolDeref returns *p when non-nil; otherwise def.
+func BoolDeref(p *bool, def bool) bool {
+	if p != nil {
+		return *p
+	}
+	return def
+}
+
+// BoolPtr returns a pointer to b (for optional API fields).
+func BoolPtr(b bool) *bool {
+	return &b
+}

--- a/test/e2e/all_features_test.go
+++ b/test/e2e/all_features_test.go
@@ -543,7 +543,7 @@ var _ = Describe("All Features Enabled", Ordered, Label("AllFeatures"), func() {
 		Expect(cr.Spec.MCPServers[0].Name).To(Equal("test-mcp-server"))
 
 		By("Verifying introspection enabled")
-		Expect(cr.Spec.OLSConfig.IntrospectionEnabled).To(BeTrue())
+		Expect(utils.BoolDeref(cr.Spec.OLSConfig.IntrospectionEnabled, true)).To(BeTrue())
 
 		By("Verifying BYOK RAG only mode")
 		Expect(cr.Spec.OLSConfig.ByokRAGOnly).To(BeTrue())

--- a/test/e2e/assets.go
+++ b/test/e2e/assets.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	olsv1alpha1 "github.com/openshift/lightspeed-operator/api/v1alpha1"
+	"github.com/openshift/lightspeed-operator/internal/controller/utils"
 )
 
 func generateLLMTokenSecret(name string) (*corev1.Secret, error) { // nolint:unused
@@ -234,7 +235,7 @@ func generateAllFeaturesOLSConfig() (*olsv1alpha1.OLSConfig, error) { // nolint:
 
 	return generateBaseOLSConfig(opts, func(config *olsv1alpha1.OLSConfig) {
 		// Add all additional features not in base config
-		config.Spec.OLSConfig.IntrospectionEnabled = true
+		config.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(true)
 		config.Spec.OLSConfig.ByokRAGOnly = true
 		config.Spec.OLSConfig.QuerySystemPrompt = "You are a comprehensive test assistant for OpenShift."
 		config.Spec.OLSConfig.MaxIterations = 10

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Upgrade operator tests", Ordered, Label("Upgrade"), func() {
 				Size:  resource.MustParse("768Mi"),
 				Class: storageClassName,
 			}
-			cr.Spec.OLSConfig.IntrospectionEnabled = true
+			cr.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(true)
 			cr.Spec.OLSConfig.UserDataCollection = olsv1alpha1.UserDataCollectionSpec{
 				FeedbackDisabled:    false,
 				TranscriptsDisabled: false,


### PR DESCRIPTION
## Description

**Overview**
This PR fixes the default behavior of the IntrospectionEnabled field, and removes the --read-only flag from the MCP server command.
 
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
https://redhat.atlassian.net/browse/OLS-2895
- Closes #
https://redhat.atlassian.net/browse/OLS-2895

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
