### PR TITLE
Change default toolBudgetRatio from 0.25 to 0.5

### DIFF
--- a/api/v1alpha1/olsconfig_types.go
+++ b/api/v1alpha1/olsconfig_types.go
@@ -440,8 +440,8 @@ type ModelParametersSpec struct {
 	// Max tokens for response. The default is 2048 tokens.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Max Tokens For Response"
 	MaxTokensForResponse int `json:"maxTokensForResponse,omitempty"`
-	// Ratio of context window size allocated for tool token budget. Must be between 0.1 and 0.5. The default is 0.25.
-	// +kubebuilder:default=0.25
+	// Ratio of context window size allocated for tool token budget. Must be between 0.1 and 0.5. The default is 0.5.
+	// +kubebuilder:default=0.5
 	// +kubebuilder:validation:Minimum=0.1
 	// +kubebuilder:validation:Maximum=0.5
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Tool Budget Ratio"

--- a/internal/controller/appserver/assets.go
+++ b/internal/controller/appserver/assets.go
@@ -114,7 +114,7 @@ func buildProviderConfigs(cr *olsv1alpha1.OLSConfig) []utils.ProviderConfig {
 		for _, model := range provider.Models {
 			toolBudgetRatio := model.Parameters.ToolBudgetRatio
 			if toolBudgetRatio == 0 {
-				toolBudgetRatio = 0.25
+				toolBudgetRatio = 0.5
 			}
 			modelConfig := utils.ModelConfig{
 				Name: model.Name,

--- a/internal/controller/appserver/assets_test.go
+++ b/internal/controller/appserver/assets_test.go
@@ -140,7 +140,7 @@ var _ = Describe("App server assets", func() {
 								URL:  testURL,
 								Parameters: utils.ModelParameters{
 									MaxTokensForResponse: 20,
-									ToolBudgetRatio:      0.25,
+									ToolBudgetRatio:      0.5,
 								},
 								ContextWindowSize: 32768,
 							},
@@ -199,7 +199,7 @@ var _ = Describe("App server assets", func() {
 
 			Expect(olsconfigGenerated.LLMProviders).To(HaveLen(1))
 			Expect(olsconfigGenerated.LLMProviders[0].Models).To(HaveLen(1))
-			Expect(olsconfigGenerated.LLMProviders[0].Models[0].Parameters.ToolBudgetRatio).To(Equal(0.25))
+			Expect(olsconfigGenerated.LLMProviders[0].Models[0].Parameters.ToolBudgetRatio).To(Equal(0.5))
 			Expect(olsconfigGenerated.LLMProviders[0].Models[0].Parameters.MaxTokensForResponse).To(Equal(0))
 		})
 

--- a/internal/controller/utils/test_fixtures.go
+++ b/internal/controller/utils/test_fixtures.go
@@ -70,7 +70,7 @@ func GetDefaultOLSConfigCR() *olsv1alpha1.OLSConfig {
 								ContextWindowSize: 32768,
 								Parameters: olsv1alpha1.ModelParametersSpec{
 									MaxTokensForResponse: 20,
-									ToolBudgetRatio:      0.25,
+									ToolBudgetRatio:      0.5,
 								},
 							},
 						},


### PR DESCRIPTION
## Summary
- Increase the default `toolBudgetRatio` from 0.25 to 0.5 to allocate more of the context window for tool token budget
- Updates the kubebuilder default marker, the runtime fallback in appserver assets, and corresponding test fixtures/assertions

## Test plan
- [ ] `make test` passes with updated default values
- [ ] Verify CRD manifests reflect the new default after `make bundle`


Made with [Cursor](https://cursor.com)