### PR TITLE
OLS-2902 fix: resolve CVE-2026-32280 — bump Go to 1.25.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/lightspeed-operator
 
-go 1.25.7
+go 1.25.9
 
 require (
 	github.com/Jeffail/gabs/v2 v2.7.0
@@ -162,7 +162,7 @@ require (
 	golang.org/x/tools v0.44.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	k8s.io/apiextensions-apiserver v0.35.4 // indirect
+	k8s.io/apiextensions-apiserver v0.35.4
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260427204847-8949caaa1199 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect


### PR DESCRIPTION
## Summary
- Bumps Go toolchain directive in `go.mod` from 1.25.7 to 1.25.9
- Fixes CVE-2026-32280: `crypto/x509` chain-building DoS (CVSS 7.5)
- Go 1.25.9 patches excessive work in `Certificate.Verify` when many intermediate certificates are passed

## Test plan
- [x] `make test` — all unit test suites pass
- [ ] CI pipeline green