### PR TITLE
regenerate the bundle to align it with APIs

### DIFF
--- a/api/v1alpha1/olsconfig_types.go
+++ b/api/v1alpha1/olsconfig_types.go
@@ -209,7 +209,6 @@ type OLSSpec struct {
 	// Enable introspection features (e.g. built-in OpenShift MCP server). Omitted means use the
 	// CRD default (true); explicit false disables introspection.
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=true
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Introspection Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	IntrospectionEnabled *bool `json:"introspectionEnabled,omitempty"`
 	// MCP Kubernetes server configuration

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -33,10 +33,10 @@ LABEL io.k8s.display-name="Openshift Lightspeed"
 LABEL io.openshift.tags="openshift,lightspeed,ai,assistant"
 LABEL name="openshift-lightspeed/lightspeed-operator-bundle"
 LABEL cpe="cpe:/a:redhat:openshift_lightspeed:1::el9"
-LABEL release=1.0.12
+LABEL release=1.0.11
 LABEL url="https://github.com/openshift/lightspeed-operator"
 LABEL vendor="Red Hat, Inc."
-LABEL version=1.0.12
+LABEL version=1.0.11
 LABEL summary="Red Hat OpenShift Lightspeed"
 
 # OCP compatibility labels

--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     console.openshift.io/operator-monitoring-default: "true"
-    createdAt: "2026-05-06T14:29:56Z"
+    createdAt: "2026-05-07T12:08:38Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -114,6 +114,24 @@ spec:
           - description: Fake Provider MCP Tool Call
             displayName: Fake Provider MCP Tool Call
             path: llm.providers[0].fakeProviderMCPToolCall
+          - description: Google Vertex Anthropic Config
+            displayName: Google Vertex Anthropic Config
+            path: llm.providers[0].googleVertexAnthropicConfig
+          - description: Server region location
+            displayName: Server Region Location
+            path: llm.providers[0].googleVertexAnthropicConfig.location
+          - description: Google Cloud project ID
+            displayName: Google Cloud Project ID
+            path: llm.providers[0].googleVertexAnthropicConfig.projectID
+          - description: Google Vertex Config
+            displayName: Google Vertex Config
+            path: llm.providers[0].googleVertexConfig
+          - description: Server region location
+            displayName: Server Region Location
+            path: llm.providers[0].googleVertexConfig.location
+          - description: Google Cloud project ID
+            displayName: Google Cloud Project ID
+            path: llm.providers[0].googleVertexConfig.projectID
           - description: List of models from the provider
             displayName: Models
             path: llm.providers[0].models
@@ -262,7 +280,9 @@ spec:
           - description: Pull secrets for BYOK RAG images from image registries requiring authentication
             displayName: Image Pull Secrets
             path: ols.imagePullSecrets
-          - description: Enable introspection features
+          - description: |-
+              Enable introspection features (e.g. built-in OpenShift MCP server). Omitted means use the
+              CRD default (true); explicit false disables introspection.
             displayName: Introspection Enabled
             path: ols.introspectionEnabled
             x-descriptors:
@@ -382,7 +402,6 @@ spec:
                 - tls.crt: Server certificate (PEM format) - REQUIRED
                 - tls.key: Private key (PEM format) - REQUIRED
                 - ca.crt: CA certificate for console proxy trust (PEM format) - OPTIONAL
-
 
               If ca.crt is not provided, the OpenShift Console proxy will use the default system trust store.
             displayName: TLS Certificate Secret Reference
@@ -1018,4 +1037,4 @@ spec:
     - name: lightspeed-postgresql
       image: registry.redhat.io/rhel9/postgresql-16@sha256:42f385ac3c9b8913426da7c57e70bc6617cd237aaf697c667f6385a8c0b0118b
     - name: lightspeed-operator-bundle
-      image: registry.redhat.io/openshift-lightspeed/lightspeed-operator-bundle@sha256:893099609cd961e0c9c2d50f929565ac7214d39e3263203ee52449ce61c82db0
+      image: registry.redhat.io/openshift-lightspeed/lightspeed-operator-bundle@sha256:3705e3ec24aa4e0cb6d8d9d178ad02949d1bc787741c02f4ed312a7e18440cd5

--- a/bundle/manifests/ols.openshift.io_olsconfigs.yaml
+++ b/bundle/manifests/ols.openshift.io_olsconfigs.yaml
@@ -4412,7 +4412,9 @@ spec:
                       x-kubernetes-map-type: atomic
                     type: array
                   introspectionEnabled:
-                    description: Enable introspection features
+                    description: |-
+                      Enable introspection features (e.g. built-in OpenShift MCP server). Omitted means use the
+                      CRD default (true); explicit false disables introspection.
                     type: boolean
                   logLevel:
                     default: INFO

--- a/config/crd/bases/ols.openshift.io_olsconfigs.yaml
+++ b/config/crd/bases/ols.openshift.io_olsconfigs.yaml
@@ -4412,7 +4412,6 @@ spec:
                       x-kubernetes-map-type: atomic
                     type: array
                   introspectionEnabled:
-                    default: true
                     description: |-
                       Enable introspection features (e.g. built-in OpenShift MCP server). Omitted means use the
                       CRD default (true); explicit false disables introspection.

--- a/config/manifests/bases/lightspeed-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/lightspeed-operator.clusterserviceversion.yaml
@@ -80,6 +80,24 @@ spec:
       - description: Fake Provider MCP Tool Call
         displayName: Fake Provider MCP Tool Call
         path: llm.providers[0].fakeProviderMCPToolCall
+      - description: Google Vertex Anthropic Config
+        displayName: Google Vertex Anthropic Config
+        path: llm.providers[0].googleVertexAnthropicConfig
+      - description: Server region location
+        displayName: Server Region Location
+        path: llm.providers[0].googleVertexAnthropicConfig.location
+      - description: Google Cloud project ID
+        displayName: Google Cloud Project ID
+        path: llm.providers[0].googleVertexAnthropicConfig.projectID
+      - description: Google Vertex Config
+        displayName: Google Vertex Config
+        path: llm.providers[0].googleVertexConfig
+      - description: Server region location
+        displayName: Server Region Location
+        path: llm.providers[0].googleVertexConfig.location
+      - description: Google Cloud project ID
+        displayName: Google Cloud Project ID
+        path: llm.providers[0].googleVertexConfig.projectID
       - description: List of models from the provider
         displayName: Models
         path: llm.providers[0].models


### PR DESCRIPTION
## Description

Updates the operator so introspectionEnabled correctly represents optional cluster intent (unset ⇒ enabled by default), adjusts the OpenShift MCP server sidecar startup to match current server expectations, and surfaces TLSSecurityProfile into the appserver ols_config payload. Tests and fixtures are updated for the API shape change.



## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
