### PR TITLE
OLS-3030 Postgres rollout fails with Multi-Attach error due to RollingUpdate strategy on RWO PVC

### DIFF
--- a/internal/controller/postgres/assets_test.go
+++ b/internal/controller/postgres/assets_test.go
@@ -28,6 +28,8 @@ var _ = Describe("App postgres server assets", func() {
 		volumeDefaultMode := utils.VolumeDefaultMode
 		Expect(dep.Name).To(Equal(utils.PostgresDeploymentName))
 		Expect(dep.Namespace).To(Equal(utils.OLSNamespaceDefault))
+		Expect(dep.Spec.Strategy.Type).To(Equal(appsv1.RecreateDeploymentStrategyType))
+		Expect(dep.Spec.Strategy.RollingUpdate).To(BeNil())
 		Expect(dep.Spec.Template.Spec.ServiceAccountName).To(Equal(utils.PostgreServiceAccountName))
 		Expect(dep.Spec.Template.Spec.Containers[0].Image).To(Equal(utils.PostgresServerImageDefault))
 		Expect(dep.Spec.Template.Spec.Containers[0].Name).To(Equal(utils.PostgresContainerName))

--- a/internal/controller/postgres/deployment.go
+++ b/internal/controller/postgres/deployment.go
@@ -247,6 +247,12 @@ func GeneratePostgresDeployment(r reconciler.Reconciler, ctx context.Context, cr
 	// Apply pod-level scheduling constraints (replicas not configurable for postgres)
 	utils.ApplyPodDeploymentConfig(&deployment, cr.Spec.OLSConfig.DeploymentConfig.DatabaseContainer, false)
 
+	// Recreate is required when the data volume is RWO: RollingUpdate with maxSurge would start a
+	// second pod before the old one terminates, causing Multi-Attach / ContainerCreating deadlock.
+	deployment.Spec.Strategy = appsv1.DeploymentStrategy{
+		Type: appsv1.RecreateDeploymentStrategyType,
+	}
+
 	if err := controllerutil.SetControllerReference(cr, &deployment, r.GetScheme()); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
