### PR TITLE
Enable MCP write tools by setting read_only=false in openshift-mcp-server config

### DIFF
--- a/.ai/spec/what/security.md
+++ b/.ai/spec/what/security.md
@@ -33,7 +33,7 @@ The operator enforces security boundaries through RBAC, network policies, pod se
 15. MCP server header secrets must contain a specific key `header` (constant `MCPSECRETDATAPATH`) and are mounted read-only at `/etc/mcp/headers/<secretName>/`.
 
 ### OpenShift MCP Server Security
-16. The shipped OpenShift MCP server runs with the `--read-only` flag and is configured via a TOML config file that blocks access to Secret and RBAC resources, preventing secret data from reaching the LLM.
+16. The shipped OpenShift MCP server is configured via a TOML config file (`read_only = false`, denied Secret/RBAC resources) so the LLM can use core write tools (e.g. `resources_create_or_update`) while secret data stays blocked at the server level. The sidecar does not pass `--read-only` on the command line; `read_only = false` in TOML overrides the RHEL image build default of `ReadOnly: true`.
 17. The denied resources are configured in the `openshift-mcp-server-config` ConfigMap as a TOML config with entries blocking `core/v1/secrets`, `rbac.authorization.k8s.io/v1/roles`, `rbac.authorization.k8s.io/v1/rolebindings`, `rbac.authorization.k8s.io/v1/clusterroles`, and `rbac.authorization.k8s.io/v1/clusterrolebindings`.
 18. User-defined MCP servers (via `spec.mcpServers`) are the user's responsibility to secure.
 

--- a/internal/controller/ocpmcp/assets.go
+++ b/internal/controller/ocpmcp/assets.go
@@ -21,11 +21,14 @@ import (
 // configTOML is the openshift-mcp-server runtime config.
 // Denied resources keep Secret (and RBAC) data out of the LLM path; toolsets are pinned
 // so upstream default changes do not affect OLS. Metrics uses in-cluster Thanos/Alertmanager.
+// read_only = false is required: openshift-mcp-server-rhel9 sets ReadOnly=true in build-time defaults;
+// omitting this leaves only readOnlyHint tools (no resources_create_or_update, etc.).
 const configTOML = `# Denied resources prevent the MCP server from accessing these Kubernetes resource types.
 # This ensures secret data never reaches the LLM through the shipped MCP server.
 # User-brought MCP servers (spec.mcpServers) are the user's responsibility to secure.
 # Toolsets are pinned explicitly so upstream default changes do not affect OLS.
 
+read_only = false
 toolsets = ["core", "config", "helm", "metrics"]
 
 [[denied_resources]]

--- a/internal/controller/ocpmcp/assets_test.go
+++ b/internal/controller/ocpmcp/assets_test.go
@@ -32,6 +32,7 @@ var _ = Describe("OpenShift MCP Server assets", func() {
 		Expect(cm.Labels).To(Equal(labels))
 
 		toml := cm.Data[utils.OpenShiftMCPServerConfigFilename]
+		Expect(toml).To(ContainSubstring("read_only = false"))
 		Expect(toml).To(ContainSubstring(`toolsets = ["core", "config", "helm", "metrics"]`))
 		Expect(toml).To(ContainSubstring(`kind = "Secret"`))
 		Expect(toml).To(ContainSubstring(`group = ""`))


### PR DESCRIPTION
## Description

**Summary**

The shipped `openshift-mcp-server-rhel9` sidecar defaults to `ReadOnly: true` at **build time** (`config_default_overrides.go`). Removing the `--read-only` CLI flag (OLS-*) is not enough: without an explicit TOML override, MCP only exposes read-only tools (`resources_list`, `resources_get`, …) and the assistant falls back to suggesting `oc` for mutations.
This change sets `read_only = false` in the operator-managed `openshift-mcp-server-config` ConfigMap so core write tools (e.g. `resources_create_or_update`, `resources_delete`, `resources_scale`) are available to Lightspeed while Secret/RBAC denied resources remain unchanged.

**Problem**

- Operator pod spec: no `--read-only` ✓  
- Operator TOML: did not set `read_only` → effective **read-only** from image defaults  
- `tools/list`: 24 tools (read-only)  
- User asks to create a ConfigMap → model suggests `oc create` instead of MCP

**Fix**

Add `read_only = false` to `OpenShiftMCPServerConfigTOML` and document in `.ai/spec/what/security.md`.


## Type of change

- [ ] Refactor
- [ ] New feature
- [x ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Updated the shipped MCP server configuration to allow core resource write operations while continuing to deny Secret and RBAC resources.
  * Clarified that configuration settings override the container’s default read-only behavior.

* **Tests**
  * Added coverage confirming the generated configuration uses the intended write-enabled setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->