### PR TITLE
OLS-3018 add bundle composition spec for co-deployed agentic controller

### DIFF
--- a/.ai/spec/README.md
+++ b/.ai/spec/README.md
@@ -39,6 +39,7 @@ AI agents (Claude). Content is optimized for precision and machine consumption o
 | Understand security constraints | `what/security.md` |
 | Debug external resource watching | `what/resource-lifecycle.md` + `how/reconciliation.md` |
 | Add metrics or alerts | `what/observability.md` |
+| Understand the OLM bundle (both controllers) | `what/bundle-composition.md` |
 
 ## Conventions
 

--- a/.ai/spec/how/deployment-generation.md
+++ b/.ai/spec/how/deployment-generation.md
@@ -101,6 +101,10 @@ Both must be true. The service ID is `"ols"` unless the CR has `openstack.org/li
 | Proxy env vars | `utils.GetProxyEnvVars()` | HTTP_PROXY, HTTPS_PROXY, NO_PROXY from cluster |
 | RAG images | CR `spec.ols.rag[].image` | Container images for init containers |
 
+## Agentic Controller Deployment (OLM-managed)
+
+Unlike the AppServer, PostgreSQL, and Console UI deployments (which are reconciled by the lightspeed-operator controller at runtime), the agentic controller deployment is statically defined in the CSV and managed by OLM. The lightspeed-operator controller has no code to generate, update, or restart the agentic controller deployment. The agentic controller's operand images (agentic console plugin, etc.) are configured via startup flags on its deployment in the CSV, not via the lightspeed-operator's flags.
+
 ## Implementation Notes
 
 - `RevisionHistoryLimit` is set to 1 for all deployments to minimize stored ReplicaSets.

--- a/.ai/spec/what/README.md
+++ b/.ai/spec/what/README.md
@@ -11,7 +11,8 @@ Defines what the operator must do. Each spec contains numbered behavioral rules,
 | `reconciliation.md` | Reconciliation behavioral rules: ordering, idempotency, error handling, status updates, finalizer semantics. |
 | `app-server.md` | Application server backend behavioral rules: deployment shape, configuration generation, health checks, resource requirements. |
 | `postgres.md` | PostgreSQL component behavioral rules: deployment, secret management, TLS, connection parameters, PVC lifecycle. |
-| `console-ui.md` | Console UI plugin behavioral rules: ConsolePlugin CR, service proxy, OCP version-based image selection, enable/disable lifecycle. |
+| `console-ui.md` | Console UI plugin (Lightspeed chat) behavioral rules: ConsolePlugin CR, service proxy, OCP version-based image selection, enable/disable lifecycle. |
+| `bundle-composition.md` | OLM bundle structure for co-deploying lightspeed-operator and lightspeed-agentic-operator: CRD ownership, git-based sync, image references, controller independence, console plugin separation. |
 | `tls.md` | TLS behavioral rules: service-ca integration, custom certificate support, TLS profile inheritance, CA bundle management. |
 | `security.md` | Security behavioral rules: RBAC, network policies, secret handling, security contexts, pod security standards. |
 | `resource-lifecycle.md` | Resource lifecycle: owned resources (OwnerReferences, Owns()), external resources (annotation-based watching, change detection, restart mapping). |

--- a/.ai/spec/what/bundle-composition.md
+++ b/.ai/spec/what/bundle-composition.md
@@ -1,0 +1,49 @@
+# Bundle Composition
+
+The lightspeed-operator OLM bundle installs both the lightspeed-operator controller and the lightspeed-agentic-operator controller. This spec defines the bundle structure, CRD ownership, image references, and the boundaries between the two controllers.
+
+## Behavioral Rules
+
+### Bundle Structure
+
+1. The lightspeed-operator OLM bundle (CSV + manifests in `bundle/`) contains the static resources for both the lightspeed-operator controller and the lightspeed-agentic-operator controller.
+2. The CSV defines two deployments: one for the lightspeed-operator controller and one for the lightspeed-agentic-operator controller.
+3. Both controllers start when the operator is installed. No feature gate or manual step is required to start either controller process.
+
+### CRD Ownership
+
+4. CRD YAML for `agentic.openshift.io` types is generated in the `lightspeed-agentic-operator` repo (via `make manifests`).
+5. The agentic-operator repo remains the single source of truth for `agentic.openshift.io` API types. The lightspeed-operator repo does not define or modify these types.
+6. The lightspeed-operator repo has a `make` target that fetches CRD YAML from the `lightspeed-agentic-operator` repo via a git-based fetch at a pinned ref/tag, and copies the CRD files into `bundle/manifests/`.
+7. When the agentic CRDs change, the pinned ref is updated in the lightspeed-operator repo and the make target is re-run to sync.
+
+### Image References
+
+8. The lightspeed-operator controller image is specified in its CSV deployment spec (as today).
+9. The lightspeed-agentic-operator controller image is specified in its own CSV deployment spec, following the same pattern.
+10. Operand images for each controller (console plugins, service images, etc.) are passed via startup flags or environment variables on their respective deployments.
+
+### Controller Independence
+
+11. The two controllers share no runtime state. They reconcile different CRDs (`ols.openshift.io` vs `agentic.openshift.io`).
+12. Feature gates on `OLSConfig` (`MCPServer`, `ToolFiltering`) have no effect on the agentic controller.
+13. The agentic controller is effectively inert until its CRs are created — it watches for `AgenticOLSConfig`, `Proposal`, and related CRs, but takes no action without them.
+
+### Console Plugins
+
+14. Each controller deploys its own, separate console plugin. The lightspeed-operator deploys the Lightspeed chat console plugin. The lightspeed-agentic-operator deploys the agentic console plugin.
+15. The lightspeed-operator never deploys the agentic console plugin, and vice versa.
+
+## Configuration Surface
+
+| Item | Location | Description |
+|---|---|---|
+| Agentic CRD pinned ref | lightspeed-operator repo (Makefile or config) | Git ref/tag for fetching agentic CRD YAML |
+| Agentic controller image | CSV deployment spec | Container image for the agentic controller |
+| Agentic controller startup flags | CSV deployment spec args | Operand image overrides for the agentic controller |
+
+## Constraints
+
+1. The lightspeed-operator controller code does not import, reference, or reconcile any `agentic.openshift.io` types.
+2. The agentic CRD YAML in `bundle/manifests/` must not be hand-edited — it is synced from the agentic-operator repo via the make target.
+3. Both controllers must be able to run in disconnected (air-gapped) environments. All image references must be overridable.

--- a/.ai/spec/what/console-ui.md
+++ b/.ai/spec/what/console-ui.md
@@ -1,6 +1,6 @@
 # Console UI
 
-The operator deploys the OpenShift Lightspeed console plugin, which integrates the Lightspeed chat interface into the OpenShift web console.
+The operator deploys the OpenShift Lightspeed **chat** console plugin, which integrates the Lightspeed chat interface into the OpenShift web console. This spec covers only the Lightspeed chat console plugin. The agentic console plugin is a separate plugin deployed by the lightspeed-agentic-operator controller (see `bundle-composition.md`).
 
 ## Behavioral Rules
 

--- a/.ai/spec/what/system-overview.md
+++ b/.ai/spec/what/system-overview.md
@@ -7,36 +7,45 @@ The OpenShift Lightspeed Operator is a Kubernetes operator that manages the life
 ### Operator Role
 
 1. OLSConfig is treated as a singleton per cluster: the operator only reconciles the cluster-scoped instance named "cluster". Any other OLSConfig objects are ignored. Reconciled workloads are created in the openshift-lightspeed namespace.
-2. The operator deploys and manages three components: an application server backend, a PostgreSQL database, and a Console UI plugin, plus operator-level monitoring/networking resources.
+2. The operator deploys and manages three components: an application server backend, a PostgreSQL database, and a Console UI plugin (Lightspeed chat), plus operator-level monitoring/networking resources.
 3. The operator is fully event-driven. It does not use periodic/timer-based reconciliation. All changes are detected via Kubernetes watches on owned resources and annotated external resources.
+
+### Co-deployed Agentic Controller
+
+4. The lightspeed-operator OLM bundle deploys **two controllers** side by side: the lightspeed-operator controller and the lightspeed-agentic-operator controller. OLM applies all static manifests (deployments, service accounts, roles, role bindings, CRDs) for both controllers at installation time.
+5. The lightspeed-operator controller has no runtime interaction with the lightspeed-agentic-operator controller. The two reconcile different API groups (`ols.openshift.io` vs `agentic.openshift.io`) and share no runtime state.
+6. Feature gates on `OLSConfig` (`MCPServer`, `ToolFiltering`) do not control the activation of the agentic controller.
+7. The agentic controller is inert until its CRs (`AgenticOLSConfig`, `Agent`, `LLMProvider`, `ApprovalPolicy`, etc.) are created.
+8. The agentic controller image is specified in the CSV deployment spec, following the same pattern as the lightspeed-operator's own controller image. Operand images for the agentic controller (agentic console plugin, etc.) are configured via startup flags on the agentic controller deployment.
+9. See `bundle-composition.md` for details on the bundle structure, CRD ownership, and image references.
 
 ### Component Inventory
 
-4. Application server backend: Python/FastAPI application (lightspeed-service) that handles LLM queries, RAG retrieval, conversation management, and tool execution. Talks to LLM providers directly.
-5. PostgreSQL: single-replica database providing conversation cache and quota state. Always deployed.
-6. Console UI Plugin: OpenShift console extension that provides the Lightspeed chat interface. Integrates via ConsolePlugin CR and proxies requests to the backend.
-7. Operator-level resources: ServiceMonitor for operator metrics, NetworkPolicy restricting operator pod access.
+10. Application server backend: Python/FastAPI application (lightspeed-service) that handles LLM queries, RAG retrieval, conversation management, and tool execution. Talks to LLM providers directly.
+11. PostgreSQL: single-replica database providing conversation cache and quota state. Always deployed.
+12. Console UI Plugin: OpenShift console extension that provides the Lightspeed chat interface. Integrates via ConsolePlugin CR and proxies requests to the backend.
+13. Operator-level resources: ServiceMonitor for operator metrics, NetworkPolicy restricting operator pod access.
 
 ### Lifecycle
 
-8. On CR creation: the operator adds a finalizer, then reconciles all component resources in two phases.
-9. On CR update: the operator re-reconciles, detecting changes via resource version tracking and content hashing.
-10. On CR deletion: the operator runs finalizer cleanup -- removes console UI from the Console CR, explicitly deletes all owned resources, waits for deletion to complete, then removes the finalizer.
-11. The operator reports status via conditions (ApiReady, CacheReady, ConsolePluginReady, ResourceReconciliation) and an aggregate OverallStatus (Ready/NotReady).
-12. When deployments are unhealthy, the operator collects pod-level diagnostics and populates status.diagnosticInfo with container failure details.
+14. On CR creation: the operator adds a finalizer, then reconciles all component resources in two phases.
+15. On CR update: the operator re-reconciles, detecting changes via resource version tracking and content hashing.
+16. On CR deletion: the operator runs finalizer cleanup -- removes console UI from the Console CR, explicitly deletes all owned resources, waits for deletion to complete, then removes the finalizer.
+17. The operator reports status via conditions (ApiReady, CacheReady, ConsolePluginReady, ResourceReconciliation) and an aggregate OverallStatus (Ready/NotReady).
+18. When deployments are unhealthy, the operator collects pod-level diagnostics and populates status.diagnosticInfo with container failure details.
 
 ### Deployment Model
 
-13. The operator runs as a single-instance deployment in the openshift-lightspeed namespace (configurable).
-14. It supports leader election for HA deployments.
-15. Images for all operands are configurable via command-line flags, with defaults embedded in the binary.
+19. The operator runs as a single-instance deployment in the openshift-lightspeed namespace (configurable).
+20. It supports leader election for HA deployments.
+21. Images for all operands are configurable via command-line flags, with defaults embedded in the binary.
 
 ### Integration Points
 
-16. The operator reads OpenShift cluster version to select the correct console plugin image: PatternFly 5 for OCP < 4.19, a 4.19-specific PatternFly 6 image for OCP 4.19–4.21, and the current PatternFly 6 image for OCP >= 4.22.
-17. The operator detects Prometheus Operator availability and conditionally creates ServiceMonitor and PrometheusRule resources.
-18. The operator uses the OpenShift service-ca operator for automatic TLS certificate generation (unless custom certificates are provided).
-19. The operator watches the telemetry pull secret in openshift-config namespace to determine whether data collection is enabled.
+22. The operator reads OpenShift cluster version to select the correct console plugin image: PatternFly 5 for OCP < 4.19, a 4.19-specific PatternFly 6 image for OCP 4.19–4.21, and the current PatternFly 6 image for OCP >= 4.22.
+23. The operator detects Prometheus Operator availability and conditionally creates ServiceMonitor and PrometheusRule resources.
+24. The operator uses the OpenShift service-ca operator for automatic TLS certificate generation (unless custom certificates are provided).
+25. The operator watches the telemetry pull secret in openshift-config namespace to determine whether data collection is enabled.
 
 ## Configuration Surface
 


### PR DESCRIPTION
## Summary
- Adds new `bundle-composition.md` spec documenting how the OLM bundle installs both the lightspeed-operator and lightspeed-agentic-operator controllers side by side
- Covers CRD ownership (git-based sync from agentic-operator repo at pinned ref), image references, controller independence, and console plugin separation
- Updates `system-overview.md` with Co-deployed Agentic Controller section
- Clarifies `console-ui.md` scope to Lightspeed chat plugin only
- Adds OLM-managed agentic controller note to `deployment-generation.md`

## Test plan
- [ ] Review spec files for accuracy and completeness
- [ ] Verify no contradictions with existing specs
- [ ] Cross-reference with companion PR in lightspeed-agentic-operator

🤖 Generated with [Claude Code](https://claude.com/claude-code)