### PR TITLE
Removing bundle image references.

### DIFF
--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -1017,5 +1017,3 @@ spec:
       image: registry.redhat.io/openshift-lightspeed/lightspeed-ocp-rag-rhel9@sha256:a5109af1488b1c23babbe585abfe66d9631e933dd28aebd2a0d5620a8c415879
     - name: lightspeed-postgresql
       image: registry.redhat.io/rhel9/postgresql-16@sha256:42f385ac3c9b8913426da7c57e70bc6617cd237aaf697c667f6385a8c0b0118b
-    - name: lightspeed-operator-bundle
-      image: registry.redhat.io/openshift-lightspeed/lightspeed-operator-bundle@sha256:09bded33875233c421eadde090044dff7e65089d6f899425ffc676de35b0dc5b

--- a/hack/snapshot_to_catalog.sh
+++ b/hack/snapshot_to_catalog.sh
@@ -155,8 +155,9 @@ for snapshot in "${!SNAPSHOT_REFS[@]}"; do
   BUNDLE_VERSIONS+=("${BUNDLE_VERSION}")
   # restore bundle image to the catalog file
   ${YQ} eval -i '.image='"\"${BUNDLE_IMAGE}\"" "${TEMP_BUNDLE_FILE}"
-  # restore bundle related images and the bundle itself to the catalog file
-  ${YQ} eval -i '.relatedImages='"${RELATED_IMAGES}" "${TEMP_BUNDLE_FILE}"
+  # restore bundle related images to the catalog file (exclude bundle image, already referenced by .image field)
+  RELATED_IMAGES_CATALOG=$(jq 'map(select(.name != "lightspeed-operator-bundle"))' <<<"${RELATED_IMAGES}")
+  ${YQ} eval -i '.relatedImages='"${RELATED_IMAGES_CATALOG}" "${TEMP_BUNDLE_FILE}"
 
   # Create version-specific bundle file
   BUNDLE_FILE="$(dirname "${CATALOG_FILE}")/bundle-v${BUNDLE_VERSION}.yaml"

--- a/hack/update_bundle.sh
+++ b/hack/update_bundle.sh
@@ -157,7 +157,8 @@ ${JQ} -c '.[]' <<<"${PLACEHOLDERS}" | while IFS= read -r entry; do
 done
 
 # Set spec.relatedImages from related_images.json (strip revision for CSV if present).
-RELATED_IMAGES_CSV=$(${JQ} 'map(del(.revision))' <<<"${RELATED_IMAGES}")
+# The bundle image is only referenced in catalog files, not in the CSV.
+RELATED_IMAGES_CSV=$(${JQ} 'map(del(.revision)) | map(select(.name != "lightspeed-operator-bundle"))' <<<"${RELATED_IMAGES}")
 # set related images to the CSV file
 ${YQ} eval -i '.spec.relatedImages='"${RELATED_IMAGES_CSV}" ${CSV_FILE}
 # add compatibility labels to the annotations file


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed duplicate bundle image reference from the operator manifest's related images list, as it is already declared elsewhere.
  * Updated build automation scripts to exclude duplicate bundle image entries during manifest generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->