### PR TITLE
Add risk level rubric to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,36 +141,7 @@ When finishing a development branch:
 
 ## Risk Levels
 
-When creating Jira tickets for this repo, assign a risk level in the description.
-
-| Level | Customer Impact | Review Requirements | Automation |
-|-------|----------------|---------------------|------------|
-| Risk 1 | Very little impact if change goes wrong | No human code review required | Fully automated implementation |
-| Risk 2 | Medium impact if change causes problems | 1 human reviewer required | Automated implementation with human review gate |
-| Risk 3 | Major impact — risk of losing customers if a bug is introduced | 2+ human reviewers required | Human-driven implementation |
-
-### Classification Examples
-
-| Change Type | Risk Level |
-|-------------|------------|
-| CSV version bump, metadata-only changes | 1 |
-| Dependency version bump | 1 |
-| Internal controller refactor (no CRD/behavior change) | 2 |
-| Reconciler logic changes | 2 |
-| RBAC/permissions changes | 3 |
-| CRD schema changes (OLSConfig) | 3 |
-| Upgrade/migration path changes | 3 |
-
-### Jira Description Format
-
-Include this section in every ticket description:
-
-```
-## Risk Level
-
-Risk {1|2|3} — {one-line impact summary}
-Rationale: {why this classification, referencing the rubric}
-```
+Risk levels are enforced via a PreToolUse hook before every Jira create/edit call. The rubric and classification examples live in [lightspeed-team-harness/hooks/risk-rubric.md](https://github.com/openshift/lightspeed-team-harness/blob/main/hooks/risk-rubric.md).
 
 ## Maintaining This Document
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,39 @@ When finishing a development branch:
 3. Push to the contributor's fork remote (not `origin`)
 4. Create the PR against `origin/main` using `--head <user>:<branch>`
 
+## Risk Levels
+
+When creating Jira tickets for this repo, assign a risk level in the description.
+
+| Level | Customer Impact | Review Requirements | Automation |
+|-------|----------------|---------------------|------------|
+| Risk 1 | Very little impact if change goes wrong | No human code review required | Fully automated implementation |
+| Risk 2 | Medium impact if change causes problems | 1 human reviewer required | Automated implementation with human review gate |
+| Risk 3 | Major impact — risk of losing customers if a bug is introduced | 2+ human reviewers required | Human-driven implementation |
+
+### Classification Examples
+
+| Change Type | Risk Level |
+|-------------|------------|
+| CSV version bump, metadata-only changes | 1 |
+| Dependency version bump | 1 |
+| Internal controller refactor (no CRD/behavior change) | 2 |
+| Reconciler logic changes | 2 |
+| RBAC/permissions changes | 3 |
+| CRD schema changes (OLSConfig) | 3 |
+| Upgrade/migration path changes | 3 |
+
+### Jira Description Format
+
+Include this section in every ticket description:
+
+```
+## Risk Level
+
+Risk {1|2|3} — {one-line impact summary}
+Rationale: {why this classification, referencing the rubric}
+```
+
 ## Maintaining This Document
 
 Always suggest AGENTS.md edits when architectural, structural, or conventional changes are made to the codebase.


### PR DESCRIPTION
Adds a Risk Levels section to AGENTS.md defining risk 1/2/3 classification with repo-specific examples and Jira description format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Risk Levels" section describing risk classification for Jira create/edit actions, how classifications are applied, and where to find the assessment rubric and classification examples in the reference documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->