### PR TITLE
Bundle Update from Snapshot crt-nshift-lightspeed-tenant/ols-20260603-093442-000

### DIFF
--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     console.openshift.io/operator-monitoring-default: "true"
-    createdAt: "2026-05-20T12:27:36Z"
+    createdAt: "2026-06-11T12:32:49Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -874,14 +874,14 @@ spec:
                       - --metrics-bind-address=:8443
                       - --secure-metrics-server
                       - --cert-dir=/etc/tls/private
-                      - --service-image=registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9@sha256:6de7fa294e6c482c48c9ed81b9c4d27241a821665c2485c9b14371cd2a77766b
-                      - --console-image=registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:3413b67d587bddc6ff21bdb6a2c14aca348db7374740c621664f3a48f5548af4
-                      - --console-image-pf5=registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-pf5-rhel9@sha256:bf1052cf922689eb3e802eeca41374294c61c6d27ed9f93584a800b7292a76ff
-                      - --console-image-4-19=registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-419-rhel9@sha256:4afa6a9f49903fe44735a7480a2631ad8da5fb1f43f7c8225bd366e3487e1cdd
+                      - --service-image=registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9@sha256:26f9e07ff6a54d3930a5693b4638995ff7e2f4e8b526e32b4e949b6bb422f2b4
+                      - --console-image=registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:94011900ed85cca5cd654346ce0e8cbed276464c061ae76320a7bf8e79939b32
+                      - --console-image-pf5=registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-pf5-rhel9@sha256:129d6580971ec5c90b4206cd593fc856dcb766808d7f6e29cb1ec2496a1af39b
+                      - --console-image-4-19=registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-419-rhel9@sha256:08140093c340fc20fca849ac3a118b50aa338fde7fa930373a55fd0b3e1167c5
                       - --postgres-image=registry.redhat.io/rhel9/postgresql-16@sha256:42f385ac3c9b8913426da7c57e70bc6617cd237aaf697c667f6385a8c0b0118b
                       - --openshift-mcp-server-image=registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9@sha256:83f288c04aad9c742cf2cee51f45e1be1982e1fcc388d2112cf5483e381fff62
                       - --dataverse-exporter-image=registry.redhat.io/lightspeed-core/dataverse-exporter-rhel9@sha256:dc071421c925dbe55fd03765f7a2ede7140e9a4d49aa95c0b4d2435cbee95f0f
-                      - --ocp-rag-image=registry.redhat.io/openshift-lightspeed/lightspeed-ocp-rag-rhel9@sha256:a5109af1488b1c23babbe585abfe66d9631e933dd28aebd2a0d5620a8c415879
+                      - --ocp-rag-image=registry.redhat.io/openshift-lightspeed/lightspeed-ocp-rag-rhel9@sha256:6154de4ade379d23b8b983f8223fb219b275ba6339b4cfc150e151433e905e5c
                     command:
                       - /manager
                     env:
@@ -889,7 +889,7 @@ spec:
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.annotations['olm.targetNamespaces']
-                    image: registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:2303a30dda8d4a9816cffd8f6e85307b425cd8774fa7293f3479b91ed1b73852
+                    image: registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:90b3971b1b23a3f517f321e1997e5d2b712e8044bb28b886d9736d03d1b6b1f7
                     imagePullPolicy: Always
                     livenessProbe:
                       httpGet:
@@ -1000,20 +1000,20 @@ spec:
   version: 1.1.1
   relatedImages:
     - name: lightspeed-service-api
-      image: registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9@sha256:6de7fa294e6c482c48c9ed81b9c4d27241a821665c2485c9b14371cd2a77766b
+      image: registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9@sha256:26f9e07ff6a54d3930a5693b4638995ff7e2f4e8b526e32b4e949b6bb422f2b4
     - name: lightspeed-console-plugin
-      image: registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:3413b67d587bddc6ff21bdb6a2c14aca348db7374740c621664f3a48f5548af4
+      image: registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:94011900ed85cca5cd654346ce0e8cbed276464c061ae76320a7bf8e79939b32
     - name: lightspeed-console-plugin-pf5
-      image: registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-pf5-rhel9@sha256:bf1052cf922689eb3e802eeca41374294c61c6d27ed9f93584a800b7292a76ff
+      image: registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-pf5-rhel9@sha256:129d6580971ec5c90b4206cd593fc856dcb766808d7f6e29cb1ec2496a1af39b
     - name: lightspeed-console-plugin-4-19
-      image: registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-419-rhel9@sha256:4afa6a9f49903fe44735a7480a2631ad8da5fb1f43f7c8225bd366e3487e1cdd
+      image: registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-419-rhel9@sha256:08140093c340fc20fca849ac3a118b50aa338fde7fa930373a55fd0b3e1167c5
     - name: lightspeed-operator
-      image: registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:2303a30dda8d4a9816cffd8f6e85307b425cd8774fa7293f3479b91ed1b73852
+      image: registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:90b3971b1b23a3f517f321e1997e5d2b712e8044bb28b886d9736d03d1b6b1f7
     - name: openshift-mcp-server
       image: registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9@sha256:83f288c04aad9c742cf2cee51f45e1be1982e1fcc388d2112cf5483e381fff62
     - name: lightspeed-to-dataverse-exporter
       image: registry.redhat.io/lightspeed-core/dataverse-exporter-rhel9@sha256:dc071421c925dbe55fd03765f7a2ede7140e9a4d49aa95c0b4d2435cbee95f0f
     - name: lightspeed-ocp-rag
-      image: registry.redhat.io/openshift-lightspeed/lightspeed-ocp-rag-rhel9@sha256:a5109af1488b1c23babbe585abfe66d9631e933dd28aebd2a0d5620a8c415879
+      image: registry.redhat.io/openshift-lightspeed/lightspeed-ocp-rag-rhel9@sha256:6154de4ade379d23b8b983f8223fb219b275ba6339b4cfc150e151433e905e5c
     - name: lightspeed-postgresql
       image: registry.redhat.io/rhel9/postgresql-16@sha256:42f385ac3c9b8913426da7c57e70bc6617cd237aaf697c667f6385a8c0b0118b

--- a/related_images.json
+++ b/related_images.json
@@ -1,33 +1,32 @@
 [
   {
     "name": "lightspeed-service-api",
-    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9@sha256:6de7fa294e6c482c48c9ed81b9c4d27241a821665c2485c9b14371cd2a77766b",
-    "revision": "6f38dc2e17e033ff471bec441db29b11e9c2d653"
+    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9@sha256:26f9e07ff6a54d3930a5693b4638995ff7e2f4e8b526e32b4e949b6bb422f2b4",
+    "revision": "a8aa7a8a51925f28fcab08af269abd73f9880abc"
   },
   {
     "name": "lightspeed-console-plugin",
-    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:3413b67d587bddc6ff21bdb6a2c14aca348db7374740c621664f3a48f5548af4",
-    "revision": "20441f1300aba215fd88e47304684d598d55e66f"
+    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:94011900ed85cca5cd654346ce0e8cbed276464c061ae76320a7bf8e79939b32",
+    "revision": "11b9c99e3ec1b9176a185a768b44f2abac2a95cd"
   },
   {
     "name": "lightspeed-console-plugin-pf5",
-    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-pf5-rhel9@sha256:bf1052cf922689eb3e802eeca41374294c61c6d27ed9f93584a800b7292a76ff",
-    "revision": "d8ba40de742d3a0700f3c15755f34f29e9d816ca"
+    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-pf5-rhel9@sha256:129d6580971ec5c90b4206cd593fc856dcb766808d7f6e29cb1ec2496a1af39b",
+    "revision": "7785252464ddd3490ab4d1b170c866cb3a11cada"
   },
   {
     "name": "lightspeed-console-plugin-4-19",
-    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-419-rhel9@sha256:4afa6a9f49903fe44735a7480a2631ad8da5fb1f43f7c8225bd366e3487e1cdd",
-    "revision": "844f5e119cfec77609f98b68fdbaa0d1f018f03b"
+    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-419-rhel9@sha256:08140093c340fc20fca849ac3a118b50aa338fde7fa930373a55fd0b3e1167c5",
+    "revision": "719d5786f5503f67e43b86db0d3b8a29002506b5"
   },
   {
     "name": "lightspeed-operator",
-    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:2303a30dda8d4a9816cffd8f6e85307b425cd8774fa7293f3479b91ed1b73852",
-    "revision": "16a2044a50cd2517ac8caad7dcc2e49a89f6fba0"
+    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:90b3971b1b23a3f517f321e1997e5d2b712e8044bb28b886d9736d03d1b6b1f7",
+    "revision": "755d416cd61b5e912140300d5fae6c4cc67a19a5"
   },
   {
     "name": "openshift-mcp-server",
-    "image": "registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9@sha256:83f288c04aad9c742cf2cee51f45e1be1982e1fcc388d2112cf5483e381fff62",
-    "revision": ""
+    "image": "registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9@sha256:83f288c04aad9c742cf2cee51f45e1be1982e1fcc388d2112cf5483e381fff62"
   },
   {
     "name": "lightspeed-to-dataverse-exporter",
@@ -36,8 +35,8 @@
   },
   {
     "name": "lightspeed-ocp-rag",
-    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-ocp-rag-rhel9@sha256:a5109af1488b1c23babbe585abfe66d9631e933dd28aebd2a0d5620a8c415879",
-    "revision": "f604f4cbaf363485dc7bd2ea690bcf4e89510ff5"
+    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-ocp-rag-rhel9@sha256:6154de4ade379d23b8b983f8223fb219b275ba6339b4cfc150e151433e905e5c",
+    "revision": "ebc4cf82147a274c544454c80c721adc7f650ce8"
   },
   {
     "name": "lightspeed-postgresql",


### PR DESCRIPTION
This PR is triggered by the release crt-nshift-lightspeed-tenant/ols-20260603-093442-000-2fdc3cc-wt5jk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CSV metadata timestamp.
  * Refreshed image digests for several operator and platform components, including the operator, service API, console plugins (pf5 and 4-19), platform integration images, the OpenShift MCP server, and the OCP RAG image.
  * No user-facing functional changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->