### PR TITLE
OLS-2490 - Removing support for ols build of ocp-mcp server and auto updation.

### DIFF
--- a/hack/snapshot_to_image_list.sh
+++ b/hack/snapshot_to_image_list.sh
@@ -126,8 +126,6 @@ CONSOLE_IMAGE_419=$(${JQ} -r '.spec.components[]| select(.name=="lightspeed-cons
 CONSOLE_REVISION_419=$(${JQ} -r '.spec.components[]| select(.name=="lightspeed-console-4-19") | .source.git.revision' "${TMP_SNAPSHOT_JSON}")
 SERVICE_IMAGE=$(${JQ} -r '.spec.components[]| select(.name=="lightspeed-service") | .containerImage' "${TMP_SNAPSHOT_JSON}")
 SERVICE_REVISION=$(${JQ} -r '.spec.components[]| select(.name=="lightspeed-service") | .source.git.revision' "${TMP_SNAPSHOT_JSON}")
-OPENSHIFT_MCP_SERVER_IMAGE=$(${JQ} -r '.spec.components[]| select(.name=="openshift-mcp-server") | .containerImage' "${TMP_SNAPSHOT_JSON}")
-OPENSHIFT_MCP_SERVER_REVISION=$(${JQ} -r '.spec.components[]| select(.name=="openshift-mcp-server") | .source.git.revision' "${TMP_SNAPSHOT_JSON}")
 OCP_RAG_IMAGE=$(${JQ} -r '.spec.components[]| select(.name=="lightspeed-ocp-rag") | .containerImage' "${TMP_SNAPSHOT_JSON}")
 OCP_RAG_REVISION=$(${JQ} -r '.spec.components[]| select(.name=="lightspeed-ocp-rag") | .source.git.revision' "${TMP_SNAPSHOT_JSON}")
 if [ "${USE_REGISTRY}" = "preview" ]; then
@@ -136,7 +134,6 @@ if [ "${USE_REGISTRY}" = "preview" ]; then
 	CONSOLE_IMAGE_BASE_PF5="registry.redhat.io/openshift-lightspeed-tech-preview/lightspeed-console-plugin-pf5-rhel9"
 	CONSOLE_IMAGE_BASE_419="registry.redhat.io/openshift-lightspeed-tech-preview/lightspeed-console-plugin-419-rhel9"
 	SERVICE_IMAGE_BASE="registry.redhat.io/openshift-lightspeed-tech-preview/lightspeed-service-api-rhel9"
-	OPENSHIFT_MCP_SERVER_IMAGE_BASE="registry.redhat.io/openshift-lightspeed-tech-preview/openshift-mcp-server-rhel9"
 	OCP_RAG_IMAGE_BASE="registry.redhat.io/openshift-lightspeed-tech-preview/lightspeed-ocp-rag-rhel9"
 
 	OPERATOR_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator|'"${OPERATOR_IMAGE_BASE}"'|g' <<<${OPERATOR_IMAGE})
@@ -144,7 +141,6 @@ if [ "${USE_REGISTRY}" = "preview" ]; then
 	CONSOLE_IMAGE_PF5=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-console-pf5|'"${CONSOLE_IMAGE_BASE_PF5}"'|g' <<<${CONSOLE_IMAGE_PF5})
 	CONSOLE_IMAGE_419=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-console-4-19|'"${CONSOLE_IMAGE_BASE_419}"'|g' <<<${CONSOLE_IMAGE_419})
 	SERVICE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service|'"${SERVICE_IMAGE_BASE}"'|g' <<<${SERVICE_IMAGE})
-	OPENSHIFT_MCP_SERVER_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/openshift-mcp-server|'"${OPENSHIFT_MCP_SERVER_IMAGE_BASE}"'|g' <<<${OPENSHIFT_MCP_SERVER_IMAGE})
 	OCP_RAG_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-ocp-rag|'"${OCP_RAG_IMAGE_BASE}"'|g' <<<${OCP_RAG_IMAGE})
 	POSTGRES_IMAGE=$(sed "s|quay\.io.*/lightspeed-postgresql|registry.redhat.io/rhel9/postgresql-16|g" <<<"${POSTGRES_IMAGE}")
 
@@ -160,7 +156,6 @@ if [ "${USE_REGISTRY}" = "stable" ]; then
 	SERVICE_IMAGE_BASE="registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9"
 	CONSOLE_IMAGE_BASE_PF5="registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-pf5-rhel9"
 	CONSOLE_IMAGE_BASE_419="registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-419-rhel9"
-	OPENSHIFT_MCP_SERVER_IMAGE_BASE="registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9"
 	OCP_RAG_IMAGE_BASE="registry.redhat.io/openshift-lightspeed/lightspeed-ocp-rag-rhel9"
 
 	OPERATOR_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator|'"${OPERATOR_IMAGE_BASE}"'|g' <<<${OPERATOR_IMAGE})
@@ -168,7 +163,6 @@ if [ "${USE_REGISTRY}" = "stable" ]; then
 	SERVICE_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service|'"${SERVICE_IMAGE_BASE}"'|g' <<<${SERVICE_IMAGE})
 	CONSOLE_IMAGE_PF5=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-console-pf5|'"${CONSOLE_IMAGE_BASE_PF5}"'|g' <<<${CONSOLE_IMAGE_PF5})
 	CONSOLE_IMAGE_419=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-console-4-19|'"${CONSOLE_IMAGE_BASE_419}"'|g' <<<${CONSOLE_IMAGE_419})
-	OPENSHIFT_MCP_SERVER_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/openshift-mcp-server|'"${OPENSHIFT_MCP_SERVER_IMAGE_BASE}"'|g' <<<${OPENSHIFT_MCP_SERVER_IMAGE})
 	OCP_RAG_IMAGE=$(sed 's|quay\.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-ocp-rag|'"${OCP_RAG_IMAGE_BASE}"'|g' <<<${OCP_RAG_IMAGE})
 	POSTGRES_IMAGE=$(sed "s|quay\.io.*/lightspeed-postgresql|registry.redhat.io/rhel9/postgresql-16|g" <<<"${POSTGRES_IMAGE}")
 
@@ -206,6 +200,23 @@ if [ -z "${DATAVERSE_EXPORTER_IMAGE}" ] || [ "${DATAVERSE_EXPORTER_IMAGE}" == "n
 	exit 1
 fi
 
+# openshift-mcp-server is built by the downstream OCP MCP team, not by OLS Konflux.
+# Preserve versions from the existing related images file.
+OPENSHIFT_MCP_SERVER_IMAGE=""
+if [ -n "${OUTPUT_FILE}" ] && [ -f "${OUTPUT_FILE}" ]; then
+	OPENSHIFT_MCP_SERVER_IMAGE=$(${JQ} -r '.[] | select(.name == "openshift-mcp-server") | .image' "${OUTPUT_FILE}")
+fi
+if [ -z "${OPENSHIFT_MCP_SERVER_IMAGE}" ] || [ "${OPENSHIFT_MCP_SERVER_IMAGE}" == "null" ]; then
+	DEFAULT_RELATED_IMAGES="${SCRIPT_DIR}/../related_images.json"
+	if [ -f "${DEFAULT_RELATED_IMAGES}" ]; then
+		OPENSHIFT_MCP_SERVER_IMAGE=$(${JQ} -r '.[] | select(.name == "openshift-mcp-server") | .image' "${DEFAULT_RELATED_IMAGES}")
+	fi
+fi
+if [ -z "${OPENSHIFT_MCP_SERVER_IMAGE}" ] || [ "${OPENSHIFT_MCP_SERVER_IMAGE}" == "null" ]; then
+	echo "openshift-mcp-server image not found: use -o with an existing related_images.json, or ensure ${SCRIPT_DIR}/../related_images.json lists it." >&2
+	exit 1
+fi
+
 RELATED_IMAGES=$(
 	cat <<-EOF
 		[
@@ -236,8 +247,7 @@ RELATED_IMAGES=$(
 		  },
 		  {
 		    "name": "openshift-mcp-server",
-		    "image": "${OPENSHIFT_MCP_SERVER_IMAGE}",
-		    "revision": "${OPENSHIFT_MCP_SERVER_REVISION}"
+		    "image": "${OPENSHIFT_MCP_SERVER_IMAGE}"
 		  },
 		  {
 		    "name": "lightspeed-to-dataverse-exporter",

--- a/related_images.json
+++ b/related_images.json
@@ -27,7 +27,7 @@
   {
     "name": "openshift-mcp-server",
     "image": "registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9@sha256:83f288c04aad9c742cf2cee51f45e1be1982e1fcc388d2112cf5483e381fff62",
-    "revision": "59efa788d1eb4b5ba55ec313e07ec9dc7d933a70"
+    "revision": ""
   },
   {
     "name": "lightspeed-to-dataverse-exporter",

--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,16 @@
     "addLabels": [
         "approved",
         "lgtm"
+    ],
+    "regexManagers": [
+        {
+            "description": "Track openshift-mcp-server image digest in related_images.json. The image is built by the OCP MCP team; Renovate polls for new digests and opens a PR when one is available.",
+            "fileMatch": ["^related_images\\.json$"],
+            "matchStrings": [
+                "\"name\":\\s*\"openshift-mcp-server\",\\s*\"image\":\\s*\"(?<depName>[^@]+)@(?<currentDigest>sha256:[a-f0-9]+)\""
+            ],
+            "currentValueTemplate": "latest",
+            "datasourceTemplate": "docker"
+        }
     ]
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Image resolution now loads the openshift-mcp-server image from an external related-images configuration with a fallback and explicit error if not found.
  * Generated image list entries for openshift-mcp-server no longer include a revision field.
  * Renovate configured to detect and track openshift-mcp-server image digest updates from the related-images file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->