### PR TITLE
spec: add --sandbox-mode flag to agentic controller specs

### DIFF
--- a/.ai/spec/what/bundle-composition.md
+++ b/.ai/spec/what/bundle-composition.md
@@ -41,6 +41,7 @@ The lightspeed-operator OLM bundle installs both the lightspeed-operator control
 | Agentic CRD pinned ref | lightspeed-operator repo (Makefile or config) | Git ref/tag for fetching agentic CRD YAML |
 | Agentic controller image | CSV deployment spec | Container image for the agentic controller |
 | Agentic controller startup flags | CSV deployment spec args | Operand image overrides for the agentic controller |
+| Agentic controller `--sandbox-mode` | CSV deployment spec args | `bare-pod` (default) or `sandbox-claim` — selects sandbox provisioning strategy |
 
 ## Constraints
 

--- a/.ai/spec/what/system-overview.md
+++ b/.ai/spec/what/system-overview.md
@@ -17,6 +17,7 @@ The OpenShift Lightspeed Operator is a Kubernetes operator that manages the life
 6. Feature gates on `OLSConfig` (`MCPServer`, `ToolFiltering`) do not control the activation of the agentic controller.
 7. The agentic controller is inert until its CRs (`AgenticOLSConfig`, `Agent`, `LLMProvider`, `ApprovalPolicy`, etc.) are created.
 8. The agentic controller image is specified in the CSV deployment spec, following the same pattern as the lightspeed-operator's own controller image. Operand images for the agentic controller (agentic console plugin, etc.) are configured via startup flags on the agentic controller deployment.
+8a. The agentic controller accepts a `--sandbox-mode` flag (`bare-pod` default, `sandbox-claim` optional) that determines whether agent sandboxes run as bare Pods or use the Agent Sandbox API. In `bare-pod` mode, no Agent Sandbox API CRDs need to be installed.
 9. See `bundle-composition.md` for details on the bundle structure, CRD ownership, and image references.
 
 ### Component Inventory


### PR DESCRIPTION
## Summary
- **system-overview.md**: Added rule 8a documenting the `--sandbox-mode` flag on the agentic controller
- **bundle-composition.md**: Added `--sandbox-mode` to the configuration surface table

## Test plan
- [ ] Verify spec formatting renders correctly in the PR diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)