### PR TITLE
fix: console e2e test missing cypress binary

### DIFF
--- a/.tekton/integration-tests/scripts/run-console-cypress-tests.sh
+++ b/.tekton/integration-tests/scripts/run-console-cypress-tests.sh
@@ -62,6 +62,7 @@ echo "---------------------------------------------"
 echo "npm version: $(npm -v)"
 echo "---------------------------------------------"
 NODE_OPTIONS=--max-old-space-size=4096 npm ci --omit=optional --no-fund
+npx cypress install
 echo "---------------------------------------------"
 export CYPRESS_LOGIN_PASSWORD="$(cat "${PASSWORD_PATH}")"
 # Ephemeral clusters + console OAuth + plugin proxy are slow; before() often runs bundle then UI.


### PR DESCRIPTION
## Description

fix the error in console e2e test of missing cypress binary

```
npm warn exec The following package was not found and will be installed: cypress@15.15.0
The cypress npm package is installed, but the Cypress binary is missing.

We expected the binary to be installed here: /root/.cache/Cypress/15.15.0/Cypress/Cypress

Reasons it may be missing:

- You're caching 'node_modules' but are not caching this path: /root/.cache/Cypress
- You ran 'npm install' at an earlier build step but did not persist: /root/.cache/Cypress

Properly caching the binary will fix this error and avoid downloading and unzipping Cypress.

Alternatively, you can run 'cypress install' to download the binary again.

https://on.cypress.io/not-installed-ci-error
```

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced integration test setup to ensure all required testing framework dependencies are properly installed before test execution, improving test reliability across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->