### PR TITLE
OLS-3205: Add OCP_VERSION env var to console UI deployment

### DIFF
--- a/internal/controller/console/assets_test.go
+++ b/internal/controller/console/assets_test.go
@@ -67,6 +67,10 @@ var _ = Describe("Console UI assets", func() {
 				Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("100Mi")},
 				Claims:   []corev1.ResourceClaim{},
 			}))
+			Expect(dep.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{
+				Name:  "OCP_VERSION",
+				Value: "123.456",
+			}))
 			Expect(dep.Spec.Template.Spec.Tolerations).To(BeNil())
 			Expect(dep.Spec.Template.Spec.NodeSelector).To(BeNil())
 			Expect(dep.Spec.Template.Spec.ServiceAccountName).To(Equal(utils.ConsoleUIServiceAccountName))

--- a/internal/controller/console/deployment.go
+++ b/internal/controller/console/deployment.go
@@ -60,8 +60,11 @@ func GenerateConsoleUIDeployment(r reconciler.Reconciler, cr *olsv1alpha1.OLSCon
 							},
 							SecurityContext: utils.RestrictedContainerSecurityContext(),
 							ImagePullPolicy: corev1.PullAlways,
-							Env:             utils.GetProxyEnvVars(),
-							Resources:       *resources,
+							Env: append(utils.GetProxyEnvVars(), corev1.EnvVar{
+								Name:  "OCP_VERSION",
+								Value: r.GetOpenShiftMajor() + "." + r.GetOpenshiftMinor(),
+							}),
+							Resources: *resources,
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      certVolumeName,


### PR DESCRIPTION
## Description

**Summary**
Adds OCP_VERSION to the console plugin deployment so the container entrypoint can select the correct UI build for the cluster’s OpenShift version (e.g. 4.17).

The value is {major}.{minor}, built from GetOpenShiftMajor() and GetOpenshiftMinor() — the same version strings the operator already reads from ClusterVersion at startup (also used for app-server RAG product docs paths).

**Changes**
internal/controller/console/deployment.go — append OCP_VERSION to the console container env (alongside existing proxy env vars from GetProxyEnvVars()).
internal/controller/console/assets_test.go — assert OCP_VERSION=123.456 using TestReconciler defaults.


## Type of change

- [ x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
https://redhat.atlassian.net/browse/OLS-3211
- Closes #
https://redhat.atlassian.net/browse/OLS-3211

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Console UI deployment now includes OpenShift cluster version as a container environment variable.

* **Tests**
  * Updated deployment tests to verify OpenShift version environment variable configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->