### PR TITLE
Bundle Update from Snapshot crt-nshift-lightspeed-tenant/ols-20260612-064458-000

### DIFF
--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     console.openshift.io/operator-monitoring-default: "true"
-    createdAt: "2026-06-11T12:32:49Z"
+    createdAt: "2026-06-15T10:11:35Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -875,13 +875,13 @@ spec:
                       - --secure-metrics-server
                       - --cert-dir=/etc/tls/private
                       - --service-image=registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9@sha256:26f9e07ff6a54d3930a5693b4638995ff7e2f4e8b526e32b4e949b6bb422f2b4
-                      - --console-image=registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:94011900ed85cca5cd654346ce0e8cbed276464c061ae76320a7bf8e79939b32
-                      - --console-image-pf5=registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-pf5-rhel9@sha256:129d6580971ec5c90b4206cd593fc856dcb766808d7f6e29cb1ec2496a1af39b
+                      - --console-image=registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:38d230f9f77d199c617b1f048d022d87808c1519a237ba55b4078583eb6b0485
+                      - --console-image-pf5=registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-pf5-rhel9@sha256:ff7397dda843380ee8966958fd16a4aa33897ad5ff23614897e570079e7b2701
                       - --console-image-4-19=registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-419-rhel9@sha256:08140093c340fc20fca849ac3a118b50aa338fde7fa930373a55fd0b3e1167c5
                       - --postgres-image=registry.redhat.io/rhel9/postgresql-16@sha256:42f385ac3c9b8913426da7c57e70bc6617cd237aaf697c667f6385a8c0b0118b
                       - --openshift-mcp-server-image=registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9@sha256:83f288c04aad9c742cf2cee51f45e1be1982e1fcc388d2112cf5483e381fff62
                       - --dataverse-exporter-image=registry.redhat.io/lightspeed-core/dataverse-exporter-rhel9@sha256:1c7ffaead23adfb1dc6bd3adfe75c80f284d6d31f13ca427d754703c78514cb2
-                      - --ocp-rag-image=registry.redhat.io/openshift-lightspeed/lightspeed-ocp-rag-rhel9@sha256:a5109af1488b1c23babbe585abfe66d9631e933dd28aebd2a0d5620a8c415879
+                      - --ocp-rag-image=registry.redhat.io/openshift-lightspeed/lightspeed-ocp-rag-rhel9@sha256:6154de4ade379d23b8b983f8223fb219b275ba6339b4cfc150e151433e905e5c
                     command:
                       - /manager
                     env:
@@ -889,7 +889,7 @@ spec:
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.annotations['olm.targetNamespaces']
-                    image: registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:90b3971b1b23a3f517f321e1997e5d2b712e8044bb28b886d9736d03d1b6b1f7
+                    image: registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:09912631f48e64174d2a8a254977f0136a5bdbb8d23a6352d7a422345d95596a
                     imagePullPolicy: Always
                     livenessProbe:
                       httpGet:
@@ -1002,13 +1002,13 @@ spec:
     - name: lightspeed-service-api
       image: registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9@sha256:26f9e07ff6a54d3930a5693b4638995ff7e2f4e8b526e32b4e949b6bb422f2b4
     - name: lightspeed-console-plugin
-      image: registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:94011900ed85cca5cd654346ce0e8cbed276464c061ae76320a7bf8e79939b32
+      image: registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:38d230f9f77d199c617b1f048d022d87808c1519a237ba55b4078583eb6b0485
     - name: lightspeed-console-plugin-pf5
-      image: registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-pf5-rhel9@sha256:129d6580971ec5c90b4206cd593fc856dcb766808d7f6e29cb1ec2496a1af39b
+      image: registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-pf5-rhel9@sha256:ff7397dda843380ee8966958fd16a4aa33897ad5ff23614897e570079e7b2701
     - name: lightspeed-console-plugin-4-19
       image: registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-419-rhel9@sha256:08140093c340fc20fca849ac3a118b50aa338fde7fa930373a55fd0b3e1167c5
     - name: lightspeed-operator
-      image: registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:90b3971b1b23a3f517f321e1997e5d2b712e8044bb28b886d9736d03d1b6b1f7
+      image: registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:09912631f48e64174d2a8a254977f0136a5bdbb8d23a6352d7a422345d95596a
     - name: openshift-mcp-server
       image: registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9@sha256:83f288c04aad9c742cf2cee51f45e1be1982e1fcc388d2112cf5483e381fff62
     - name: lightspeed-to-dataverse-exporter

--- a/related_images.json
+++ b/related_images.json
@@ -6,13 +6,13 @@
   },
   {
     "name": "lightspeed-console-plugin",
-    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:94011900ed85cca5cd654346ce0e8cbed276464c061ae76320a7bf8e79939b32",
-    "revision": "11b9c99e3ec1b9176a185a768b44f2abac2a95cd"
+    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:38d230f9f77d199c617b1f048d022d87808c1519a237ba55b4078583eb6b0485",
+    "revision": "44776fe091e022762687745fa43827c9c41fef55"
   },
   {
     "name": "lightspeed-console-plugin-pf5",
-    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-pf5-rhel9@sha256:129d6580971ec5c90b4206cd593fc856dcb766808d7f6e29cb1ec2496a1af39b",
-    "revision": "7785252464ddd3490ab4d1b170c866cb3a11cada"
+    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-pf5-rhel9@sha256:ff7397dda843380ee8966958fd16a4aa33897ad5ff23614897e570079e7b2701",
+    "revision": "40dc504072ce912237b9ea7fb9eeedb59c813aae"
   },
   {
     "name": "lightspeed-console-plugin-4-19",
@@ -21,8 +21,8 @@
   },
   {
     "name": "lightspeed-operator",
-    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:90b3971b1b23a3f517f321e1997e5d2b712e8044bb28b886d9736d03d1b6b1f7",
-    "revision": "755d416cd61b5e912140300d5fae6c4cc67a19a5"
+    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:09912631f48e64174d2a8a254977f0136a5bdbb8d23a6352d7a422345d95596a",
+    "revision": "a0de2f571c376af021fc698ca16de71f5334bf50"
   },
   {
     "name": "openshift-mcp-server",


### PR DESCRIPTION
This PR is triggered by the release crt-nshift-lightspeed-tenant/ols-20260612-064458-000-05a4e57-kbdh5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release build metadata (creation timestamp) and refreshed container image references/digests for the Lightspeed operator components.

* **Notes**
  * No user-facing functionality changes; behavior remains the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->