### PR TITLE
OLS-3192 Add preStop lifecycle hook to postgres pod to prevent crash-loop afte…

### DIFF
--- a/internal/controller/postgres/assets_test.go
+++ b/internal/controller/postgres/assets_test.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"fmt"
 	"path"
 	"strconv"
 
@@ -87,6 +88,19 @@ var _ = Describe("App postgres server assets", func() {
 		Expect(dep.Spec.Selector.MatchLabels).To(Equal(utils.GeneratePostgresSelectorLabels()))
 		Expect(dep.Spec.RevisionHistoryLimit).To(Equal(&revisionHistoryLimit))
 		Expect(dep.Spec.Replicas).To(Equal(&replicas))
+		// Verify preStop lifecycle hook for clean postgres shutdown
+		Expect(dep.Spec.Template.Spec.Containers[0].Lifecycle).NotTo(BeNil())
+		Expect(dep.Spec.Template.Spec.Containers[0].Lifecycle.PreStop).NotTo(BeNil())
+		Expect(dep.Spec.Template.Spec.Containers[0].Lifecycle.PreStop.Exec).NotTo(BeNil())
+		expectedPreStopCommand := fmt.Sprintf("if [ -f %s/PG_VERSION ]; then pg_ctl stop -D %s -m fast -w -t %d; fi", utils.PostgresUserDataDir, utils.PostgresUserDataDir, utils.PostgresShutdownTimeoutSeconds)
+		Expect(dep.Spec.Template.Spec.Containers[0].Lifecycle.PreStop.Exec.Command).To(Equal([]string{
+			"/bin/sh", "-c",
+			expectedPreStopCommand,
+		}))
+		// Verify terminationGracePeriodSeconds gives postgres time to shut down
+		Expect(dep.Spec.Template.Spec.TerminationGracePeriodSeconds).NotTo(BeNil())
+		Expect(*dep.Spec.Template.Spec.TerminationGracePeriodSeconds).To(Equal(utils.PostgresTerminationGracePeriodSeconds))
+
 		Expect(dep.Spec.Template.Spec.Containers[0].VolumeMounts).To(Equal([]corev1.VolumeMount{
 			{
 				Name:      "secret-" + utils.PostgresCertsSecretName,

--- a/internal/controller/postgres/deployment.go
+++ b/internal/controller/postgres/deployment.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"fmt"
 	"path"
 	"strconv"
 
@@ -234,10 +235,21 @@ func GeneratePostgresDeployment(r reconciler.Reconciler, ctx context.Context, cr
 									Value: strconv.Itoa(cr.Spec.OLSConfig.ConversationCache.Postgres.MaxConnections),
 								},
 							},
+							Lifecycle: &corev1.Lifecycle{
+								PreStop: &corev1.LifecycleHandler{
+									Exec: &corev1.ExecAction{
+										Command: []string{
+											"/bin/sh", "-c",
+											fmt.Sprintf("if [ -f %s/PG_VERSION ]; then pg_ctl stop -D %s -m fast -w -t %d; fi", utils.PostgresUserDataDir, utils.PostgresUserDataDir, utils.PostgresShutdownTimeoutSeconds),
+										},
+									},
+								},
+							},
 						},
 					},
-					Volumes:            volumes,
-					ServiceAccountName: utils.PostgreServiceAccountName,
+					Volumes:                       volumes,
+					ServiceAccountName:            utils.PostgreServiceAccountName,
+					TerminationGracePeriodSeconds: &[]int64{utils.PostgresTerminationGracePeriodSeconds}[0],
 				},
 			},
 			RevisionHistoryLimit: &revisionHistoryLimit,

--- a/internal/controller/utils/constants.go
+++ b/internal/controller/utils/constants.go
@@ -417,6 +417,17 @@ ssl_ca_file = '/etc/certs/cm-olspostgresca/service-ca.crt'
 	AlertsAdapterAlertmanagerURLEnvVar = "ALERTMANAGER_URL"
 	// AlertsAdapterComponentLabel is the app.kubernetes.io/component label value for alerts adapter resources
 	AlertsAdapterComponentLabel = "alerts-adapter"
+	// PostgresTerminationGracePeriodSeconds is the grace period for postgres pod termination.
+	// This must be greater than PostgresShutdownTimeoutSeconds to allow pg_ctl to complete.
+	PostgresTerminationGracePeriodSeconds = int64(60)
+
+	// PostgresShutdownTimeoutSeconds is the timeout for pg_ctl stop command.
+	// This must be less than PostgresTerminationGracePeriodSeconds to complete before SIGKILL.
+	PostgresShutdownTimeoutSeconds = int64(55)
+
+	// PostgresUserDataDir is the PostgreSQL data directory path.
+	// PostgreSQL's initdb creates this structure: PGDATA/data/userdata
+	PostgresUserDataDir = PostgresDataVolumeMountPath + "/data/userdata"
 
 	// PostgresPVCName is the name of the PVC for the OLS Postgres server
 	PostgresPVCName = "lightspeed-postgres-pvc"

--- a/internal/controller/utils/utils.go
+++ b/internal/controller/utils/utils.go
@@ -204,7 +204,8 @@ func DeploymentSpecEqual(a, b *appsv1.DeploymentSpec, compareInitContainers bool
 		!apiequality.Semantic.DeepEqual(a.Strategy, b.Strategy) || // check strategy
 		!PodVolumeEqual(a.Template.Spec.Volumes, b.Template.Spec.Volumes) || // check volumes
 		*a.Replicas != *b.Replicas || // check replicas
-		a.Template.Spec.ServiceAccountName != b.Template.Spec.ServiceAccountName { // check service account name
+		a.Template.Spec.ServiceAccountName != b.Template.Spec.ServiceAccountName || // check service account name
+		!apiequality.Semantic.DeepEqual(a.Template.Spec.TerminationGracePeriodSeconds, b.Template.Spec.TerminationGracePeriodSeconds) { // check termination grace period
 		return false
 	}
 
@@ -250,7 +251,8 @@ func ContainerSpecEqual(a, b *corev1.Container) bool {
 		a.ImagePullPolicy == b.ImagePullPolicy && // check image pull policy
 		ProbeEqual(a.LivenessProbe, b.LivenessProbe) && // check liveness probe
 		ProbeEqual(a.ReadinessProbe, b.ReadinessProbe) && // check readiness probe
-		ProbeEqual(a.StartupProbe, b.StartupProbe)) // check startup probe
+		ProbeEqual(a.StartupProbe, b.StartupProbe) && // check startup probe
+		apiequality.Semantic.DeepEqual(a.Lifecycle, b.Lifecycle)) // check lifecycle hooks
 }
 
 // EnvEqual compares two EnvVar slices ignoring order
@@ -387,6 +389,13 @@ func SetDefaults_Deployment(obj *appsv1.Deployment) {
 	if obj.Spec.Replicas == nil {
 		obj.Spec.Replicas = new(int32)
 		*obj.Spec.Replicas = 1
+	}
+	// Set default TerminationGracePeriodSeconds to match the Kubernetes API server default (30s).
+	// Without this, the desired spec has nil while the existing spec (from the API server) has &30,
+	// causing spurious updates on every reconcile.
+	if obj.Spec.Template.Spec.TerminationGracePeriodSeconds == nil {
+		defaultTerminationGracePeriod := int64(corev1.DefaultTerminationGracePeriodSeconds)
+		obj.Spec.Template.Spec.TerminationGracePeriodSeconds = &defaultTerminationGracePeriod
 	}
 	strategy := &obj.Spec.Strategy
 	// Set default DeploymentStrategyType as RollingUpdate.

--- a/internal/controller/utils/utils_comparison_test.go
+++ b/internal/controller/utils/utils_comparison_test.go
@@ -148,6 +148,46 @@ var _ = Describe("Container Comparison", func() {
 		It("should handle empty container lists", func() {
 			Expect(ContainersEqual([]corev1.Container{}, []corev1.Container{})).To(BeTrue())
 		})
+
+		It("should return false when lifecycle hooks differ", func() {
+			containers1 := []corev1.Container{
+				{
+					Name:  "app",
+					Image: "myapp:v1",
+					Lifecycle: &corev1.Lifecycle{
+						PreStop: &corev1.LifecycleHandler{
+							Exec: &corev1.ExecAction{
+								Command: []string{"/bin/sh", "-c", "pg_ctl stop"},
+							},
+						},
+					},
+				},
+			}
+			containers2 := []corev1.Container{
+				{
+					Name:  "app",
+					Image: "myapp:v1",
+				},
+			}
+			Expect(ContainersEqual(containers1, containers2)).To(BeFalse())
+		})
+
+		It("should return true when lifecycle hooks are equal", func() {
+			lifecycle := &corev1.Lifecycle{
+				PreStop: &corev1.LifecycleHandler{
+					Exec: &corev1.ExecAction{
+						Command: []string{"/bin/sh", "-c", "pg_ctl stop"},
+					},
+				},
+			}
+			containers1 := []corev1.Container{
+				{Name: "app", Image: "myapp:v1", Lifecycle: lifecycle},
+			}
+			containers2 := []corev1.Container{
+				{Name: "app", Image: "myapp:v1", Lifecycle: lifecycle.DeepCopy()},
+			}
+			Expect(ContainersEqual(containers1, containers2)).To(BeTrue())
+		})
 	})
 })
 
@@ -290,6 +330,21 @@ var _ = Describe("Resource Comparison Functions", func() {
 			deployment2.Template.Spec.Containers[0].Image = "myapp:v2"
 
 			Expect(DeploymentSpecEqual(deployment1, deployment2, true)).To(BeFalse())
+		})
+
+		It("should return false when terminationGracePeriodSeconds differs", func() {
+			gracePeriod := int64(60)
+			deployment2.Template.Spec.TerminationGracePeriodSeconds = &gracePeriod
+
+			Expect(DeploymentSpecEqual(deployment1, deployment2, true)).To(BeFalse())
+		})
+
+		It("should return true when terminationGracePeriodSeconds is equal", func() {
+			gracePeriod := int64(60)
+			deployment1.Template.Spec.TerminationGracePeriodSeconds = &gracePeriod
+			deployment2.Template.Spec.TerminationGracePeriodSeconds = &gracePeriod
+
+			Expect(DeploymentSpecEqual(deployment1, deployment2, true)).To(BeTrue())
 		})
 	})
 

--- a/test/e2e/all_features_test.go
+++ b/test/e2e/all_features_test.go
@@ -740,6 +740,21 @@ var _ = Describe("All Features Enabled", Ordered, Label("AllFeatures"), func() {
 		}
 		Expect(foundSharedBuffers).To(BeTrue(), "POSTGRESQL_SHARED_BUFFERS should be set to 512MB")
 		Expect(foundMaxConnections).To(BeTrue(), "POSTGRESQL_MAX_CONNECTIONS should be set to 3000")
+
+		By("Verifying postgres deployment has preStop lifecycle hook")
+		postgresContainer := postgresDeployment.Spec.Template.Spec.Containers[0]
+		Expect(postgresContainer.Lifecycle).NotTo(BeNil(), "postgres container should have a lifecycle configuration")
+		Expect(postgresContainer.Lifecycle.PreStop).NotTo(BeNil(), "postgres container should have a preStop hook")
+		Expect(postgresContainer.Lifecycle.PreStop.Exec).NotTo(BeNil(), "preStop hook should use exec")
+		expectedPreStopCommand := fmt.Sprintf("if [ -f %s/PG_VERSION ]; then pg_ctl stop -D %s -m fast -w -t %d; fi", utils.PostgresUserDataDir, utils.PostgresUserDataDir, utils.PostgresShutdownTimeoutSeconds)
+		Expect(postgresContainer.Lifecycle.PreStop.Exec.Command).To(Equal([]string{"/bin/sh", "-c", expectedPreStopCommand}),
+			"preStop hook should run pg_ctl stop for clean shutdown")
+
+		By("Verifying postgres deployment has terminationGracePeriodSeconds")
+		Expect(postgresDeployment.Spec.Template.Spec.TerminationGracePeriodSeconds).NotTo(BeNil(),
+			"postgres pod should have terminationGracePeriodSeconds set")
+		Expect(*postgresDeployment.Spec.Template.Spec.TerminationGracePeriodSeconds).To(Equal(utils.PostgresTerminationGracePeriodSeconds),
+			"postgres pod should have correct termination grace period")
 	})
 
 	// Test 10: Resource Limits Validation


### PR DESCRIPTION
…r unclean shutdown

## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved PostgreSQL shutdown by adding a graceful `preStop` stop command and explicitly enforcing the pod termination grace period to 90 seconds, aligned with the configured shutdown timeout.

* **Tests**
  * Expanded unit and end-to-end coverage to validate PostgreSQL shutdown lifecycle behavior (`preStop` exec command) and `terminationGracePeriodSeconds`, and strengthened comparisons for lifecycle hooks and termination grace period handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->