### PR TITLE
OLS-3236 update specs for agentic operand deployment

### DIFF
--- a/.ai/spec/what/bundle-composition.md
+++ b/.ai/spec/what/bundle-composition.md
@@ -31,8 +31,13 @@ The lightspeed-operator OLM bundle installs both the lightspeed-operator control
 
 ### Console Plugins
 
-14. Each controller deploys its own, separate console plugin. The lightspeed-operator deploys the Lightspeed chat console plugin. The lightspeed-agentic-operator deploys the agentic console plugin.
-15. The lightspeed-operator never deploys the agentic console plugin, and vice versa.
+14. [PLANNED: OLS-3236] The lightspeed-operator deploys both console plugins: the Lightspeed chat console plugin and the agentic console plugin. The agentic-operator does not deploy any console plugins.
+15. Prior to OLS-3236, the agentic-operator deployed the agentic console plugin via a fire-and-forget `RunnableFunc`. This is being migrated to the lightspeed-operator for full reconciliation lifecycle management.
+
+### Agentic Operand Deployment
+
+16. [PLANNED: OLS-3236] The lightspeed-operator deploys the agentic alerts adapter and the agentic console plugin as fully reconciled operands, with Phase 1/2 reconciliation, status conditions, health monitoring, and finalizer cleanup. The agentic-operator does not deploy these operands.
+17. [PLANNED: OLS-3236] Agentic operand images default to `:main` tags until Konflux onboarding provides SHA-pinned productized images. CLI flags (`--alerts-adapter-image`, `--agentic-console-image`) on the lightspeed-operator deployment override the defaults.
 
 ## Configuration Surface
 
@@ -42,6 +47,9 @@ The lightspeed-operator OLM bundle installs both the lightspeed-operator control
 | Agentic controller image | CSV deployment spec | Container image for the agentic controller |
 | Agentic controller startup flags | CSV deployment spec args | Operand image overrides for the agentic controller |
 | Agentic controller `--sandbox-mode` | CSV deployment spec args | `bare-pod` (default) or `sandbox-claim` — selects sandbox provisioning strategy |
+| Agentic controller `--agentic-sandbox-image` | CSV deployment spec args | [PLANNED: OLS-3236] Sandbox container image (default: `:main` tag, overridable) |
+| Lightspeed controller `--alerts-adapter-image` | CSV deployment spec args | [PLANNED: OLS-3236] Alerts adapter container image (default: `:main` tag) |
+| Lightspeed controller `--agentic-console-image` | CSV deployment spec args | [PLANNED: OLS-3236] Agentic console plugin container image (default: `:main` tag) |
 
 ## Constraints
 
@@ -51,4 +59,6 @@ The lightspeed-operator OLM bundle installs both the lightspeed-operator control
 
 ## Planned Changes
 
-None.
+| Ticket | Summary |
+|---|---|
+| OLS-3236 | Migrate agentic console deployment from agentic-operator to lightspeed-operator. Add alerts-adapter as new operand. Add `--alerts-adapter-image` and `--agentic-console-image` flags to lightspeed-operator CSV deployment. Remove `--agentic-console-image` from agentic-operator CSV deployment. |

--- a/.ai/spec/what/crd-api.md
+++ b/.ai/spec/what/crd-api.md
@@ -106,8 +106,10 @@ Field path (relative to `spec.ols.deployment`) | JSON key | Go type | Notes
 `mcpServer` | `mcpServer` | `ContainerConfig` | MCP server container. Resources only
 `console` | `console` | `Config` | Console container. Has replicas field but operator forces 1
 `database` | `database` | `Config` | Database container. Has replicas field but operator forces 1
+`alertsAdapter` | `alertsAdapter` | `Config` | [PLANNED: OLS-3236] Agentic alerts adapter container. Replicas forced to 1
+`agenticConsole` | `agenticConsole` | `Config` | [PLANNED: OLS-3236] Agentic console plugin container. Replicas forced to 1
 
-20. Replicas are only user-configurable for the API container (`spec.ols.deployment.api.replicas`). For console and database, the operator always overrides replicas to 1 regardless of spec value.
+20. Replicas are only user-configurable for the API container (`spec.ols.deployment.api.replicas`). For console, database, alerts adapter, and agentic console, the operator always overrides replicas to 1 regardless of spec value.
 
 ##### Config Fields
 
@@ -276,6 +278,8 @@ Condition types used by the operator:
 - `ApiReady` -- API server deployment health
 - `CacheReady` -- PostgreSQL cache deployment health
 - `ConsolePluginReady` -- Console UI plugin deployment health
+- `AlertsAdapterReady` -- [PLANNED: OLS-3236] Agentic alerts adapter deployment health
+- `AgenticConsolePluginReady` -- [PLANNED: OLS-3236] Agentic console plugin deployment health
 - `ResourceReconciliation` -- Overall resource reconciliation status (set directly, not deployment-based)
 
 #### Overall Status (status.overallStatus)
@@ -366,6 +370,20 @@ Path | Type | Default | Required | Validation | Description
 `spec.ols.deployment.database.nodeSelector` | `map[string]string` | -- | No | -- | Database node selector
 `spec.ols.deployment.database.affinity` | `*Affinity` | -- | No | -- | Database affinity
 `spec.ols.deployment.database.topologySpreadConstraints` | `[]TopologySpreadConstraint` | -- | No | -- | Database topology spread
+`spec.ols.deployment.alertsAdapter` | `Config` | -- | No | -- | [PLANNED: OLS-3236] Alerts adapter deployment
+`spec.ols.deployment.alertsAdapter.replicas` | `*int32` | `1` | No | Min=0 | Alerts adapter replicas (operator forces 1)
+`spec.ols.deployment.alertsAdapter.resources` | `*ResourceRequirements` | -- | No | -- | Alerts adapter resources
+`spec.ols.deployment.alertsAdapter.tolerations` | `[]Toleration` | -- | No | -- | Alerts adapter tolerations
+`spec.ols.deployment.alertsAdapter.nodeSelector` | `map[string]string` | -- | No | -- | Alerts adapter node selector
+`spec.ols.deployment.alertsAdapter.affinity` | `*Affinity` | -- | No | -- | Alerts adapter affinity
+`spec.ols.deployment.alertsAdapter.topologySpreadConstraints` | `[]TopologySpreadConstraint` | -- | No | -- | Alerts adapter topology spread
+`spec.ols.deployment.agenticConsole` | `Config` | -- | No | -- | [PLANNED: OLS-3236] Agentic console deployment
+`spec.ols.deployment.agenticConsole.replicas` | `*int32` | `1` | No | Min=0 | Agentic console replicas (operator forces 1)
+`spec.ols.deployment.agenticConsole.resources` | `*ResourceRequirements` | -- | No | -- | Agentic console resources
+`spec.ols.deployment.agenticConsole.tolerations` | `[]Toleration` | -- | No | -- | Agentic console tolerations
+`spec.ols.deployment.agenticConsole.nodeSelector` | `map[string]string` | -- | No | -- | Agentic console node selector
+`spec.ols.deployment.agenticConsole.affinity` | `*Affinity` | -- | No | -- | Agentic console affinity
+`spec.ols.deployment.agenticConsole.topologySpreadConstraints` | `[]TopologySpreadConstraint` | -- | No | -- | Agentic console topology spread
 `spec.ols.queryFilters` | `[]QueryFiltersSpec` | -- | No | -- | Query filters
 `spec.ols.queryFilters[].name` | `string` | -- | No | -- | Filter name
 `spec.ols.queryFilters[].pattern` | `string` | -- | No | -- | Regex pattern
@@ -440,7 +458,7 @@ Path | Type | Default | Required | Validation | Description
 1. `.metadata.name` must be `"cluster"` (XValidation on OLSConfig type).
 2. Only `azure_openai` provider type uses `deploymentName`; it is required for that type and forbidden (by convention) for others.
 3. Only `watsonx` provider type uses `projectID`; it is required for that type.
-4. Replicas are only user-configurable for the API container (`spec.ols.deployment.api`). Console and database always run with 1 replica enforced by the operator.
+4. Replicas are only user-configurable for the API container (`spec.ols.deployment.api`). Console, database, alerts adapter, and agentic console always run with 1 replica enforced by the operator.
 5. Period format for quota limiters must match the regex pattern in rule 36, enforcing human-readable duration strings with correct singular/plural agreement.
 6. `credentialKey` if set must contain at least one non-whitespace character.
 7. Tool filtering requires the `ToolFiltering` feature gate in `spec.featureGates`.

--- a/.ai/spec/what/reconciliation.md
+++ b/.ai/spec/what/reconciliation.md
@@ -17,12 +17,16 @@ The operator reconciles the OLSConfig CR into Kubernetes resources through a two
 8. Step 6 (Phase 2): Reconcile deployments and dependent resources -- Deployments, Services, TLS certificates, ServiceMonitors, PrometheusRules. After reconciliation, check deployment health and update CR status.
 
 ### Phase 1: Independent Resources
-9. Three component groups are reconciled in Phase 1: Console UI, PostgreSQL, and the application server.
+9. Five component groups are reconciled in Phase 1: Console UI, PostgreSQL, the application server, the agentic alerts adapter, and the agentic console plugin.
 10. All Phase 1 resource groups are independent and can be reconciled in any order.
 11. If any Phase 1 resource fails, the operator continues reconciling the remaining resources, then reports all failures in the CR status with ResourceReconciliation conditions.
+11a. Alerts adapter Phase 1 resources: ServiceAccount, ClusterRole (`agentic.openshift.io/proposals`: create, list, get), ClusterRoleBinding, RoleBinding in `openshift-monitoring` (binds SA to `monitoring-alertmanager-view`), NetworkPolicy.
+11b. Agentic console Phase 1 resources: ServiceAccount, ConfigMap (nginx.conf), NetworkPolicy.
 
 ### Phase 2: Deployments and Status
-12. Three deployments are reconciled in Phase 2: Console UI (condition: ConsolePluginReady), PostgreSQL (condition: CacheReady), and the active backend (condition: ApiReady).
+12. Five deployments are reconciled in Phase 2: Console UI (condition: ConsolePluginReady), PostgreSQL (condition: CacheReady), the active backend (condition: ApiReady), the agentic alerts adapter (condition: AlertsAdapterReady), and the agentic console plugin (condition: AgenticConsolePluginReady).
+12a. Alerts adapter Phase 2: Deployment (1 replica, `ALERTMANAGER_URL` env hardcoded to `https://alertmanager-main.openshift-monitoring.svc:9094`).
+12b. Agentic console Phase 2: Deployment (1 replica, nginx with TLS via service-ca cert), Service (port 9443, serving-cert annotation), ConsolePlugin CR, Console CR activation.
 13. After each deployment reconciliation, the operator checks the deployment's health status.
 14. Deployment health has three states: Ready (Available condition true), Progressing (not yet available, no terminal failures), Failed (terminal pod failures detected).
 15. Terminal pod failures include: CrashLoopBackOff, ImagePullBackOff, ErrImagePull, OOMKilled, and containers terminated with non-zero exit codes after CrashLoopBackOff.
@@ -33,12 +37,12 @@ The operator reconciles the OLSConfig CR into Kubernetes resources through a two
 ### Finalizer Lifecycle
 19. On CR creation: add finalizer, return immediately (controller-runtime auto-requeues).
 20. On CR deletion: run finalizer cleanup before removing finalizer.
-21. Finalizer cleanup sequence: remove Console UI from Console CR, delete ConsolePlugin CR, list all owned resources by owner reference, explicitly delete them, wait for deletion (polling with timeout).
+21. Finalizer cleanup sequence: remove Console UI from Console CR, delete ConsolePlugin CR, remove agentic console plugin from Console CR, delete agentic ConsolePlugin CR, delete alerts-adapter RoleBinding in `openshift-monitoring`, delete alerts-adapter ClusterRoleBinding, delete alerts-adapter ClusterRole, list all owned resources by owner reference, explicitly delete them, wait for deletion (polling with timeout).
 22. If cleanup times out, the finalizer is removed anyway to prevent the CR from being stuck in Terminating state.
-23. Console UI removal errors during finalization are logged but do not block finalization.
+23. Console UI and agentic component removal errors during finalization are logged but do not block finalization.
 
 ### Status Conditions
-24. The operator sets these condition types: ApiReady, CacheReady, ConsolePluginReady, ResourceReconciliation.
+24. The operator sets these condition types: ApiReady, CacheReady, ConsolePluginReady, AlertsAdapterReady, AgenticConsolePluginReady, ResourceReconciliation.
 25. OverallStatus is Ready only when all deployment conditions are True.
 26. OverallStatus is NotReady if any condition is False.
 27. When deployments are not ready, diagnosticInfo is populated with per-pod failure details including container name, reason, message, exit code, and diagnostic type.
@@ -61,4 +65,6 @@ Reconciliation behavior is not directly user-configurable. It is driven by the O
 
 ## Planned Changes
 
-None.
+| Ticket | Summary |
+|---|---|
+| OLS-3236 | [PLANNED] Add alerts-adapter and agentic-console as reconciled operands with Phase 1/2 steps, status conditions (AlertsAdapterReady, AgenticConsolePluginReady), and finalizer cleanup for cross-namespace resources |


### PR DESCRIPTION
## Summary
- Update reconciliation spec: add alerts-adapter and agentic-console as Phase 1/2 components with status conditions (`AlertsAdapterReady`, `AgenticConsolePluginReady`) and finalizer cleanup
- Update CRD API spec: add `alertsAdapter` and `agenticConsole` deployment config fields to `DeploymentConfig`
- Update bundle-composition spec: migrate agentic-console ownership from agentic-operator, add new CLI flags (`--alerts-adapter-image`, `--agentic-console-image`)

All changes marked `[PLANNED: [OLS-3236](https://redhat.atlassian.net/browse/OLS-3236)]` — no code changes, spec only.

Design spec: `docs/superpowers/specs/2026-06-23-agentic-operand-deployment-design.md` (in parent workspace repo)

## Test plan
- [ ] Spec files render correctly in markdown
- [ ] No contradictions with existing spec content
- [ ] PLANNED markers consistent with [OLS-3236](https://redhat.atlassian.net/browse/OLS-3236)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated specifications to document planned agentic deployment components including alerts adapter and agentic console plugin
  * Added new configuration options for agentic operands and component image overrides
  * Updated reconciliation behavior and status conditions to track health of new agentic components
  * Documented expanded operator responsibilities for managing agentic deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->