### PR TITLE
OLS-2605: Add bedrock provider type to OLM bundle CRD

### DIFF
--- a/bundle/manifests/ols.openshift.io_olsconfigs.yaml
+++ b/bundle/manifests/ols.openshift.io_olsconfigs.yaml
@@ -297,6 +297,7 @@ spec:
                           - fake_provider
                           - google_vertex
                           - google_vertex_anthropic
+                          - bedrock
                           type: string
                         url:
                           description: Provider API URL


### PR DESCRIPTION
## Description

**Summary**
Syncs bundle/manifests/ols.openshift.io_olsconfigs.yaml with the operator CRD after #1749 merged Bedrock support.
Adds bedrock to spec.llm.providers[].type enum so OLM installs accept the new provider type.
Operator-only Bedrock work landed in #1749; this is the minimal bundle follow-up (1 line, 1 file).
No bundle version bump, CSV changes, or catalog updates — those stay for release.


## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
https://redhat.atlassian.net/browse/OLS-2605
- Closes #
https://redhat.atlassian.net/browse/OLS-2605

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
