### PR TITLE
OLS-3221 Reduce app server liveness probe `failureThreshold` from 15 to 3.

### DIFF
--- a/internal/controller/appserver/assets_test.go
+++ b/internal/controller/appserver/assets_test.go
@@ -1656,6 +1656,8 @@ var _ = Describe("App server assets", func() {
 			Expect(dep.Spec.Template.Spec.Containers[0].LivenessProbe).ToNot(BeNil())
 			Expect(dep.Spec.Template.Spec.Containers[0].LivenessProbe.HTTPGet.Port).To(Equal(intstr.FromString("https")))
 			Expect(dep.Spec.Template.Spec.Containers[0].LivenessProbe.HTTPGet.Path).To(Equal("/liveness"))
+			Expect(dep.Spec.Template.Spec.Containers[0].LivenessProbe.FailureThreshold).To(Equal(int32(3)))
+			Expect(dep.Spec.Template.Spec.Containers[0].LivenessProbe.PeriodSeconds).To(Equal(int32(30)))
 			Expect(dep.Spec.Template.Spec.Containers[0].ReadinessProbe).ToNot(BeNil())
 			Expect(dep.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Port).To(Equal(intstr.FromString("https")))
 			Expect(dep.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Path).To(Equal("/readiness"))

--- a/internal/controller/appserver/deployment.go
+++ b/internal/controller/appserver/deployment.go
@@ -506,7 +506,7 @@ func GenerateOLSDeployment(r reconciler.Reconciler, cr *olsv1alpha1.OLSConfig) (
 								InitialDelaySeconds: 30,
 								PeriodSeconds:       30,
 								TimeoutSeconds:      30,
-								FailureThreshold:    15,
+								FailureThreshold:    3,
 							},
 						},
 					},

--- a/internal/controller/appserver/deployment_test.go
+++ b/internal/controller/appserver/deployment_test.go
@@ -269,6 +269,8 @@ var _ = Describe("App server deployment generation", func() {
 			Expect(dep.Spec.Selector.MatchLabels).To(Equal(utils.GenerateAppServerSelectorLabels()))
 			Expect(dep.Spec.Template.Spec.Containers[0].LivenessProbe).ToNot(BeNil())
 			Expect(dep.Spec.Template.Spec.Containers[0].LivenessProbe.HTTPGet.Port).To(Equal(intstr.FromString("https")))
+			Expect(dep.Spec.Template.Spec.Containers[0].LivenessProbe.FailureThreshold).To(Equal(int32(3)))
+			Expect(dep.Spec.Template.Spec.Containers[0].LivenessProbe.PeriodSeconds).To(Equal(int32(30)))
 			Expect(dep.Spec.Template.Spec.Containers[0].ReadinessProbe).ToNot(BeNil())
 			Expect(dep.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Port).To(Equal(intstr.FromString("https")))
 		})


### PR DESCRIPTION
Reduce app server liveness probe `failureThreshold` from 15 to 3, giving the pod 90 seconds to self-heal via the background
  health-check loop before Kubernetes restarts it                                                                                         
  - Add test assertions for `failureThreshold: 3` and `periodSeconds: 30` to document the 90-second recovery contract

## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the app server container liveness probe to mark pods unhealthy sooner by setting `FailureThreshold` to **3** (from 15).
* **Tests**
  * Expanded deployment tests to validate the liveness probe timing and failure limits (including `PeriodSeconds` **30** and `FailureThreshold` **3**).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->