### PR TITLE
OLS-3397: Update operator specs to remove default resource limits

### DIFF
--- a/.ai/spec/how/deployment-generation.md
+++ b/.ai/spec/how/deployment-generation.md
@@ -33,7 +33,7 @@ GenerateOLSDeployment(r, cr)
       - Container: "lightspeed-service-api", image: r.GetAppServerImage(), port: 8443
       - Env: OLS_CONFIG_FILE path + proxy vars (HTTP_PROXY, HTTPS_PROXY, NO_PROXY)
       - Probes: HTTPS GET on /readiness, /liveness (initial: 30s, period: 30s, timeout: 30s, failure: 15)
-      - Default resources: 500m CPU request, 1Gi-4Gi memory
+      - Default resources: 500m CPU request, 1Gi memory request (no limits)
   16. Apply pod-level config (replicas, nodeSelector, tolerations)
   17. Set ImageStream triggers annotation (if RAG configured)
   18. Set owner reference to OLSConfig CR
@@ -60,15 +60,15 @@ All deployments use the same pattern in their update functions:
 ## Key Abstractions
 
 ### Resource Requirement Defaults
-Each component defines default CPU/memory requests and limits in local `get*Resources()` functions. User-provided values from the CR override defaults via `utils.GetResourcesOrDefault()` which returns user values if non-nil, otherwise defaults.
+Each component defines default CPU/memory requests in local `get*Resources()` functions. Per [OpenShift conventions](https://github.com/openshift/enhancements/blob/master/CONVENTIONS.md#resources-and-limits), operator defaults set requests only and do not set limits. User-provided values from the CR override defaults via `utils.GetResourcesOrDefault()` which returns user values if non-nil, otherwise defaults. Users may still set limits via the CRD if needed for their environment.
 
 Default resources by container:
-| Container | CPU Request | CPU Limit | Memory Request | Memory Limit |
-|---|---|---|---|---|
-| AppServer `lightspeed-service-api` | 500m | - | 1Gi | 4Gi |
-| Data collector | 50m | - | 64Mi | 200Mi |
-| MCP server | 50m | - | 64Mi | 200Mi |
-| RHOKP `rhokp` | 2000m | 2000m | 2Gi | 2Gi |
+| Container | CPU Request | Memory Request |
+|---|---|---|
+| AppServer `lightspeed-service-api` | 500m | 1Gi |
+| Data collector | 50m | 64Mi |
+| MCP server | 50m | 64Mi |
+| RHOKP `rhokp` | 2000m | 2Gi |
 
 ### Volume/Mount Construction
 Volumes and mounts are built as slices and conditionally appended using inline append patterns.

--- a/.ai/spec/what/app-server.md
+++ b/.ai/spec/what/app-server.md
@@ -83,6 +83,11 @@ The App Server is the backend deployment for OpenShift Lightspeed. It runs the l
 4. RAG init containers run in index order, copying data to subdirectories of the shared RAG volume.
 5. The RHOKP sidecar requires approximately 75 GiB of ephemeral storage for Solr data. This must be documented in product infrastructure requirements.
 
+### Resource Conventions [OLS-3397]
+28. All operator-managed container defaults follow the [OpenShift resource conventions](https://github.com/openshift/enhancements/blob/master/CONVENTIONS.md#resources-and-limits): defaults declare CPU and memory requests only, and do not set resource limits. This applies to the primary API container and all sidecars (data collector, MCP server, RHOKP).
+29. Users may still set limits via the CRD (`spec.ols.deployment.<component>.resources`) if their environment requires it. The CRD uses standard `corev1.ResourceRequirements` which accepts both requests and limits.
+30. The RHOKP sidecar's ~75 GiB ephemeral storage requirement is unchanged by this convention — it applies only to CPU and memory.
+
 ## Planned Changes
 
 - [PLANNED: OLS-3221] Liveness probe now checks PostgreSQL health via the service's background health-check loop status. Probe configuration (failureThreshold, periodSeconds) added to deployment generation. See Rules 24–25.


### PR DESCRIPTION
## Summary
- Updates `deployment-generation.md` resource defaults table to show requests only (removes Limit columns), references OpenShift conventions
- Adds resource convention rules 28-30 to `app-server.md` covering: no default limits, CRD override flexibility, RHOKP ephemeral storage carve-out
- No code changes — spec only

## Test plan
- [ ] Spec-only change — no code affected
- [ ] Verify deployment-generation.md and app-server.md render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified default resource behavior for deployments: CPU and memory are requested by default, with no default limits.
  * Updated resource tables and defaults to show request-only values.
  * Added guidance explaining that limits can still be set through configuration and that sidecar storage expectations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->