### PR TITLE
OLS-3185: spec: create Service for ocp-mcp sidecar

### DIFF
--- a/.ai/spec/what/app-server.md
+++ b/.ai/spec/what/app-server.md
@@ -27,6 +27,9 @@ The App Server is the backend deployment for OpenShift Lightspeed. It runs the l
 16. When the MCPServer feature gate is enabled, user-defined servers from `spec.mcpServers` are added to the config.
 17. MCP header values of type "secret" are mounted as files from the referenced secret. Types "kubernetes" and "client" use placeholder strings that the service resolves at runtime.
 
+### MCP Server Service
+18a. When `spec.ols.introspectionEnabled` is true, the operator MUST create a `Service` named `openshift-mcp-server` in the operator namespace that selects the app server pods and targets port 8080 (the MCP sidecar port). This Service exposes the ocp-mcp sidecar to other pods in the cluster (e.g., agentic sandbox pods). When `introspectionEnabled` is false, the Service MUST be deleted if it exists.
+
 ### Service and Networking
 18. The service exposes HTTPS on the configured port.
 19. The network policy allows ingress from: Prometheus (openshift-monitoring), OpenShift Console (openshift-console), and ingress controllers.


### PR DESCRIPTION
## Summary

- Add rule 18a to `what/app-server.md`: when `introspectionEnabled` is true, create a `Service` named `openshift-mcp-server` targeting port 8080 on app server pods
- This exposes the existing ocp-mcp sidecar to agentic sandbox pods via cluster-internal networking
- Service is deleted when `introspectionEnabled` is set to false

## Context

The agentic operator needs to connect sandbox pods to the ocp-mcp server. Today, the sidecar is only accessible via localhost within the app server pod. This Service makes it reachable cluster-wide.

Companion PRs:
- openshift/lightspeed-agentic-sandbox#94 (sandbox MCP consumption)
- openshift/lightspeed-agentic-operator#271 (auto-injection + disableDefaultMCP)

## Test plan

- [ ] Spec review — rule is consistent with existing app-server patterns
- [ ] No code changes — spec only

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for automatically creating an internal service for the MCP sidecar when introspection is enabled.
  * The service is removed when introspection is turned off.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->