### PR TITLE
OLS-3402: remove default resource limits on deployments

### DIFF
--- a/internal/controller/alertsadapter/deployment.go
+++ b/internal/controller/alertsadapter/deployment.go
@@ -23,9 +23,6 @@ func getAlertsAdapterResources(cr *olsv1alpha1.OLSConfig) *corev1.ResourceRequir
 				corev1.ResourceCPU:    resource.MustParse("10m"),
 				corev1.ResourceMemory: resource.MustParse("50Mi"),
 			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("100Mi"),
-			},
 		},
 	)
 }

--- a/internal/controller/appserver/assets_test.go
+++ b/internal/controller/appserver/assets_test.go
@@ -566,7 +566,7 @@ var _ = Describe("App server assets", func() {
 			Expect(appSrvConfigFile.MCPServers).NotTo(BeEmpty())
 			Expect(appSrvConfigFile.MCPServers).To(ContainElement(MatchFields(IgnoreExtras, Fields{
 				"Name":    Equal("openshift"),
-				"URL":     Equal(utils.OpenShiftMCPServerServiceURL(utils.OLSNamespaceDefault)),
+				"URL":     Equal("https://openshift-mcp-server.openshift-lightspeed.svc:8443/mcp"),
 				"Timeout": Equal(utils.OpenShiftMCPServerTimeout),
 				"Headers": Equal(map[string]string{
 					utils.K8S_AUTH_HEADER: utils.KUBERNETES_PLACEHOLDER,
@@ -734,7 +734,7 @@ var _ = Describe("App server assets", func() {
 
 			Expect(appSrvConfigFile.MCPServers).To(ContainElement(MatchFields(IgnoreExtras, Fields{
 				"Name":    Equal("openshift"),
-				"URL":     Equal(utils.OpenShiftMCPServerServiceURL(utils.OLSNamespaceDefault)),
+				"URL":     Equal("https://openshift-mcp-server.openshift-lightspeed.svc:8443/mcp"),
 				"Timeout": Equal(utils.OpenShiftMCPServerTimeout),
 			})))
 
@@ -789,7 +789,6 @@ var _ = Describe("App server assets", func() {
 			Expect(dep.Spec.Template.Spec.Containers[0].Env).To(Equal(expectedAppServerEnv()))
 			Expect(dep.Spec.Template.Spec.Containers[0].VolumeMounts).To(ConsistOf(get10RequiredVolumeMounts()))
 			Expect(dep.Spec.Template.Spec.Containers[0].Resources).To(Equal(corev1.ResourceRequirements{
-				Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("4Gi")},
 				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m"), corev1.ResourceMemory: resource.MustParse("1Gi")},
 				Claims:   []corev1.ResourceClaim{},
 			}))
@@ -809,7 +808,6 @@ var _ = Describe("App server assets", func() {
 			}))
 			Expect(dep.Spec.Template.Spec.Containers[1].VolumeMounts).To(ConsistOf(get10RequiredVolumeMounts()))
 			Expect(dep.Spec.Template.Spec.Containers[1].Resources).To(Equal(corev1.ResourceRequirements{
-				Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("200Mi")},
 				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("50m"), corev1.ResourceMemory: resource.MustParse("64Mi")},
 				Claims:   []corev1.ResourceClaim{},
 			}))
@@ -2256,7 +2254,7 @@ var _ = Describe("Helper function unit tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(servers).To(HaveLen(1))
 			Expect(servers[0].Name).To(Equal("openshift"))
-			Expect(servers[0].URL).To(Equal(utils.OpenShiftMCPServerServiceURL(utils.OLSNamespaceDefault)))
+			Expect(servers[0].URL).To(Equal("https://openshift-mcp-server.openshift-lightspeed.svc:8443/mcp"))
 			Expect(servers[0].Headers).To(HaveKey(utils.K8S_AUTH_HEADER))
 		})
 

--- a/internal/controller/appserver/deployment.go
+++ b/internal/controller/appserver/deployment.go
@@ -28,7 +28,6 @@ func getOLSServerResources(cr *olsv1alpha1.OLSConfig) *corev1.ResourceRequiremen
 	return utils.GetResourcesOrDefault(
 		cr.Spec.OLSConfig.DeploymentConfig.APIContainer.Resources,
 		&corev1.ResourceRequirements{
-			Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("4Gi")},
 			Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m"), corev1.ResourceMemory: resource.MustParse("1Gi")},
 			Claims:   []corev1.ResourceClaim{},
 		},
@@ -39,7 +38,6 @@ func getOLSDataCollectorResources(cr *olsv1alpha1.OLSConfig) *corev1.ResourceReq
 	return utils.GetResourcesOrDefault(
 		cr.Spec.OLSConfig.DeploymentConfig.DataCollectorContainer.Resources,
 		&corev1.ResourceRequirements{
-			Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("200Mi")},
 			Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("50m"), corev1.ResourceMemory: resource.MustParse("64Mi")},
 			Claims:   []corev1.ResourceClaim{},
 		},

--- a/internal/controller/console/assets_test.go
+++ b/internal/controller/console/assets_test.go
@@ -61,7 +61,6 @@ var _ = Describe("Console UI assets", func() {
 			Expect(dep.Spec.Template.Spec.Containers[0].Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
 			Expect(dep.Spec.Template.Spec.Containers[0].Resources).To(Equal(corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("10m"), corev1.ResourceMemory: resource.MustParse("50Mi")},
-				Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("100Mi")},
 				Claims:   []corev1.ResourceClaim{},
 			}))
 			Expect(dep.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{

--- a/internal/controller/otelcollector/deployment.go
+++ b/internal/controller/otelcollector/deployment.go
@@ -27,10 +27,6 @@ func getOtelCollectorResources(cr *olsv1alpha1.OLSConfig) *corev1.ResourceRequir
 				corev1.ResourceCPU:    resource.MustParse("100m"),
 				corev1.ResourceMemory: resource.MustParse("128Mi"),
 			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("500m"),
-				corev1.ResourceMemory: resource.MustParse("512Mi"),
-			},
 		},
 	)
 }

--- a/internal/controller/postgres/assets_test.go
+++ b/internal/controller/postgres/assets_test.go
@@ -47,9 +47,6 @@ var _ = Describe("App postgres server assets", func() {
 				corev1.ResourceCPU:    resource.MustParse("30m"),
 				corev1.ResourceMemory: resource.MustParse("300Mi"),
 			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("2Gi"),
-			},
 		}))
 		expectedSecretRef := &corev1.EnvVarSource{
 			SecretKeyRef: &corev1.SecretKeySelector{

--- a/internal/controller/postgres/deployment.go
+++ b/internal/controller/postgres/deployment.go
@@ -24,9 +24,6 @@ func getDatabaseResources(cr *olsv1alpha1.OLSConfig) *corev1.ResourceRequirement
 			corev1.ResourceCPU:    resource.MustParse("30m"),
 			corev1.ResourceMemory: resource.MustParse("300Mi"),
 		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("2Gi"),
-		},
 	}
 	return utils.GetResourcesOrDefault(
 		cr.Spec.OLSConfig.DeploymentConfig.DatabaseContainer.Resources,

--- a/internal/controller/utils/console_plugin_test.go
+++ b/internal/controller/utils/console_plugin_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Console plugin shared utilities", func() {
 			resources := DefaultConsolePluginResourceRequirements()
 			Expect(resources.Requests[corev1.ResourceCPU]).To(Equal(resource.MustParse("10m")))
 			Expect(resources.Requests[corev1.ResourceMemory]).To(Equal(resource.MustParse("50Mi")))
-			Expect(resources.Limits[corev1.ResourceMemory]).To(Equal(resource.MustParse("100Mi")))
+			Expect(resources.Limits).To(BeNil())
 		})
 	})
 

--- a/internal/controller/utils/utils.go
+++ b/internal/controller/utils/utils.go
@@ -1026,9 +1026,6 @@ func DefaultConsolePluginResourceRequirements() *corev1.ResourceRequirements {
 			corev1.ResourceCPU:    resource.MustParse("10m"),
 			corev1.ResourceMemory: resource.MustParse("50Mi"),
 		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("100Mi"),
-		},
 		Claims: []corev1.ResourceClaim{},
 	}
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes # https://redhat.atlassian.net/browse/OLS-3402

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default container resource configuration now applies only resource requests (CPU/memory) and no longer sets hardcoded memory limits for multiple deployed components (app server, OTEL collector, database, console, alerts adapter, and console plugin).  
  * Updated deployment and utility/test assertions to match the new default resource behavior across the affected containers and MCP server URL expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->