### PR TITLE
konflux: Replace release-bot service account with konflux-bot-0 in release pipelines

### DIFF
--- a/.tekton/release/bundle-update/pipeline.yaml
+++ b/.tekton/release/bundle-update/pipeline.yaml
@@ -81,7 +81,7 @@ spec:
               - name: KONFLUX_TOKEN
                 valueFrom:
                   secretKeyRef:
-                    name: release-bot-konflux-token
+                    name: konflux-bot-0-konflux-token
                     key: konflux-token
               - name: HOME
                 value: /workspace
@@ -114,7 +114,7 @@ spec:
               - name: KONFLUX_TOKEN
                 valueFrom:
                   secretKeyRef:
-                    name: release-bot-konflux-token
+                    name: konflux-bot-0-konflux-token
                     key: konflux-token
               - name: HOME
                 value: /workspace
@@ -138,7 +138,7 @@ spec:
               - name: GITHUB_TOKEN
                 valueFrom:
                   secretKeyRef:
-                    name: release-bot-github-token
+                    name: konflux-bot-0-github-token
                     key: github-token
             script: |
               cd repo

--- a/.tekton/release/bundle-update/pipelinerun.yaml
+++ b/.tekton/release/bundle-update/pipelinerun.yaml
@@ -8,7 +8,7 @@ metadata:
     These 3 parameters are passed by Konflux: snapshot, release and releasePlan. 
     Other parameters are set by the release plan.
 spec:
-  serviceAccountName: release-bot
+  serviceAccountName: konflux-bot-0
   pipelineRef:
     params:
       - name: url

--- a/.tekton/release/catalog-update/pipeline.yaml
+++ b/.tekton/release/catalog-update/pipeline.yaml
@@ -82,7 +82,7 @@ spec:
               - name: KONFLUX_TOKEN
                 valueFrom:
                   secretKeyRef:
-                    name: release-bot-konflux-token
+                    name: konflux-bot-0-konflux-token
                     key: konflux-token
               - name: HOME
                 value: /workspace
@@ -114,7 +114,7 @@ spec:
               - name: KONFLUX_TOKEN
                 valueFrom:
                   secretKeyRef:
-                    name: release-bot-konflux-token
+                    name: konflux-bot-0-konflux-token
                     key: konflux-token
               - name: HOME
                 value: /workspace
@@ -135,7 +135,7 @@ spec:
               - name: GITHUB_TOKEN
                 valueFrom:
                   secretKeyRef:
-                    name: release-bot-github-token
+                    name: konflux-bot-0-github-token
                     key: github-token
             script: |
               set -e

--- a/.tekton/release/catalog-update/pipelinerun.yaml
+++ b/.tekton/release/catalog-update/pipelinerun.yaml
@@ -8,7 +8,7 @@ metadata:
     These 3 parameters are passed by Konflux: snapshot, release and releasePlan Update the catalog with the released bundle. 
     Other parameters are set by the release plan.
 spec:
-  serviceAccountName: release-bot
+  serviceAccountName: konflux-bot-0
   pipelineRef:
     params:
       - name: url

--- a/.tekton/release/push-to-release/bundle-to-release-pipeline.yaml
+++ b/.tekton/release/push-to-release/bundle-to-release-pipeline.yaml
@@ -130,7 +130,7 @@ spec:
               - name: KONFLUX_TOKEN
                 valueFrom:
                   secretKeyRef:
-                    name: release-bot-konflux-token
+                    name: konflux-bot-0-konflux-token
                     key: konflux-token
             script: |
               set -e

--- a/.tekton/release/release-bot/role.yaml
+++ b/.tekton/release/release-bot/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: release-bot
+  name: konflux-bot-0
   namespace: crt-nshift-lightspeed-tenant
 rules:
   - apiGroups:

--- a/.tekton/release/release-bot/rolebinding.yaml
+++ b/.tekton/release/release-bot/rolebinding.yaml
@@ -1,15 +1,15 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: release-bot
+  name: konflux-bot-0
   namespace: crt-nshift-lightspeed-tenant
 subjects:
 - kind: ServiceAccount
-  name: release-bot
+  name: konflux-bot-0
   apiGroup: ""
 roleRef:
   kind: Role
-  name: release-bot
+  name: konflux-bot-0
   apiGroup: rbac.authorization.k8s.io
 
 

--- a/.tekton/release/release-bot/service-account.yaml
+++ b/.tekton/release/release-bot/service-account.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: release-bot
+  name: konflux-bot-0
   namespace: crt-nshift-lightspeed-tenant

--- a/.tekton/release/secrets/secret-github-token.yaml
+++ b/.tekton/release/secrets/secret-github-token.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: release-bot-github-token
+  name: konflux-bot-0-github-token
   namespace: crt-nshift-lightspeed-tenant
 type: Opaque
 stringData:

--- a/.tekton/release/secrets/secret-konflux-token.yaml
+++ b/.tekton/release/secrets/secret-konflux-token.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: release-bot-konflux-token
+  name: konflux-bot-0-konflux-token
   namespace: crt-nshift-lightspeed-tenant
 type: Opaque
 stringData:


### PR DESCRIPTION

## Description


As requested from Konflux team, we should name our service accounts as "konfluxt-bot-[0-9]+" 

This PR changes service account name from `release-bot` to `konflux-bot-0` . 

The related resources in our Konflux Openshift Cluster have been created.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
