### PR TITLE
OLS-3087: Replace wildcard RBAC verb on namespace-scoped roles/rolebindings

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -211,4 +211,6 @@ rules:
   - delete
   - get
   - list
+  - patch
   - update
+  - watch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -207,4 +207,8 @@ rules:
   - rolebindings
   - roles
   verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
+  - update

--- a/internal/controller/olsconfig_controller.go
+++ b/internal/controller/olsconfig_controller.go
@@ -129,7 +129,7 @@ type OLSConfigReconciler struct {
 // Modify console CR to activate console plugin
 // +kubebuilder:rbac:groups=operator.openshift.io,resources=consoles,verbs=watch;list;get;update
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings;rolebindings,verbs=get;list;create;update;patch;delete;watch
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,namespace=openshift-lightspeed,resources=roles;rolebindings,verbs=*
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,namespace=openshift-lightspeed,resources=roles;rolebindings,verbs=get;list;create;update;delete
 // NonResourceURLs for Lightspeed access control and metrics
 // +kubebuilder:rbac:urls=/ls-access,verbs=get
 // +kubebuilder:rbac:urls=/ols-metrics-access,verbs=get

--- a/internal/controller/olsconfig_controller.go
+++ b/internal/controller/olsconfig_controller.go
@@ -129,7 +129,7 @@ type OLSConfigReconciler struct {
 // Modify console CR to activate console plugin
 // +kubebuilder:rbac:groups=operator.openshift.io,resources=consoles,verbs=watch;list;get;update
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings;rolebindings,verbs=get;list;create;update;patch;delete;watch
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,namespace=openshift-lightspeed,resources=roles;rolebindings,verbs=get;list;create;update;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,namespace=openshift-lightspeed,resources=roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
 // NonResourceURLs for Lightspeed access control and metrics
 // +kubebuilder:rbac:urls=/ls-access,verbs=get
 // +kubebuilder:rbac:urls=/ols-metrics-access,verbs=get


### PR DESCRIPTION
## Summary
- Replaces wildcard `*` verb on the namespace-scoped Role for `roles` and `rolebindings` in `openshift-lightspeed` with explicit verbs: `get`, `list`, `create`, `update`, `delete`
- Removes implicit `escalate` and `bind` permissions that the operator never uses (SAR finding [OLS-3087](https://redhat.atlassian.net/browse/OLS-3087))
- Regenerated RBAC manifests via `make manifests`; all unit tests pass

## Test plan
- [x] `make manifests` regenerates `config/rbac/role.yaml` correctly
- [x] `make test` passes — all controller packages green
- [ ] Verify operator reconciles roles/rolebindings successfully on a cluster with the tightened permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened resource permissions for the application’s namespace-managed roles, reducing unnecessary access while keeping normal operations intact.
  * Improved security posture by replacing broad permissions with a more specific set of allowed actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->