### PR TITLE
OLS-1894 Add ROSA-aware OKP retrieval spec

### DIFF
--- a/.ai/spec/how/config-generation.md
+++ b/.ai/spec/how/config-generation.md
@@ -209,6 +209,7 @@ These schemas are created by the bootstrap script.
 | TLS certs | Service-ca operator or user-provided secret | Path: `/etc/certs/lightspeed-tls/` |
 | BYOK RAG indexes | CR `spec.ols.rag[]` | File paths in config YAML (BYOK only) |
 | RHOKP image | `--rhokp-image` flag | Image for RHOKP sidecar container |
+| ROSA product | Console brand + Infrastructure topology | `OLS_ROSA_PRODUCT` env var on app-server (not in config YAML). [PLANNED: OLS-1894] |
 | MCP servers | CR `spec.mcpServers[]` + `spec.ols.introspectionEnabled` | Feature gated by `MCPServer` gate |
 | Tool filtering | CR `spec.ols.toolFilteringConfig` | Feature gated by `ToolFiltering` gate; requires MCP servers |
 | Proxy config | CR `spec.ols.proxyConfig` | Proxy URL + optional CA cert configmap |

--- a/.ai/spec/how/deployment-generation.md
+++ b/.ai/spec/how/deployment-generation.md
@@ -32,6 +32,8 @@ GenerateOLSDeployment(r, cr)
   15. Assemble Deployment:
       - Container: "lightspeed-service-api", image: r.GetAppServerImage(), port: 8443
       - Env: OLS_CONFIG_FILE path + proxy vars (HTTP_PROXY, HTTPS_PROXY, NO_PROXY)
+      - Env: OCP_CLUSTER_VERSION (`<major>.<minor>`) when `!byokRAGOnly`
+      - Env: OLS_ROSA_PRODUCT (ROSA OKP product identifier) when `!byokRAGOnly` AND cluster brand is `ROSA`. Value: `red_hat_openshift_service_on_aws` (HCP) or `red_hat_openshift_service_on_aws_classic_architecture` (Classic), determined from Console brand + Infrastructure controlPlaneTopology. [PLANNED: OLS-1894]
       - Probes: HTTPS GET on /readiness, /liveness (initial: 30s, period: 30s, timeout: 30s, failure: 15)
       - Default resources: 500m CPU request, 1Gi memory request (no limits)
   16. Apply pod-level config (replicas, nodeSelector, tolerations)

--- a/.ai/spec/what/app-server.md
+++ b/.ai/spec/what/app-server.md
@@ -21,6 +21,15 @@ The App Server is the backend deployment for OpenShift Lightspeed. It runs the l
 12. If `spec.ols.querySystemPrompt` is set, the custom prompt is written as a second key in the config ConfigMap and referenced by file path in the config.
 13. BYOK reference content indexes from `spec.ols.rag` are configured when present. OCP documentation is served by OKP via the RHOKP sidecar, not via FAISS indexes.
 14. The operator always generates a `solr_hybrid` config section in `olsconfig.yaml` pointing to `http://localhost:8080` with default hybrid retrieval tuning parameters, unless `byokRAGOnly` is true.
+15a. Unless `byokRAGOnly` is true, the app-server container receives `OCP_CLUSTER_VERSION` (`<major>.<minor>` from the operator's cluster-version lookup) for Solr `chunk_filter_query` resolution in lightspeed-service.
+
+### ROSA-Aware OKP Retrieval [PLANNED: OLS-1894]
+15b. Unless `byokRAGOnly` is true, the operator detects whether the cluster is ROSA and, if so, which variant (Classic vs HCP). Detection uses two standard OpenShift API resources, following the same pattern as OCP version detection — determined once and passed to the service as an environment variable:
+  - **ROSA detection:** Read `console.operator.openshift.io/v1` Console `cluster` resource, field `.spec.customization.brand`. Value `ROSA` indicates a ROSA cluster (reliable on OCP 4.16+).
+  - **Variant detection:** Read `infrastructure.config.openshift.io/v1` Infrastructure `cluster` resource, field `.status.controlPlaneTopology`. `External` = HCP, `HighlyAvailable` = Classic.
+  - When ROSA is detected, the operator sets `OLS_ROSA_PRODUCT` on the app-server container: `red_hat_openshift_service_on_aws` for HCP, `red_hat_openshift_service_on_aws_classic_architecture` for Classic.
+  - On non-ROSA clusters the env var is absent and the service uses OCP-only retrieval.
+  - RBAC: requires `get` on `consoles` in the `operator.openshift.io` API group (Infrastructure is already covered by existing cluster-version permissions).
 
 ### MCP Server Integration
 15. When `spec.ols.introspectionEnabled` is true, an "openshift" MCP server entry is added to the config pointing to localhost on the sidecar port.


### PR DESCRIPTION
## Summary
- Add spec documentation for ROSA cluster detection and ROSA-specific OKP product filtering
- Operator detects ROSA via Console `brand` field + Infrastructure `controlPlaneTopology`
- Passes product identifier as `OLS_ROSA_PRODUCT` env var to the service
- No CRD changes — auto-detect only

## Files changed
- `.ai/spec/what/app-server.md` — New rule 15b for ROSA detection
- `.ai/spec/how/deployment-generation.md` — `OLS_ROSA_PRODUCT` env var in deployment flow
- `.ai/spec/how/config-generation.md` — ROSA product in integration points table

## Related
- Epic: [OLS-1679](https://redhat.atlassian.net/browse/OLS-1679)
- Story: [OLS-1894](https://redhat.atlassian.net/browse/OLS-1894)
- Design: `docs/superpowers/specs/2026-07-06-rosa-aware-answering.md` (ols workspace)
- Companion service PR: pending

## Test plan
- [ ] Spec review only — no code changes

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for deployment and app-server behavior covering new environment settings used during cluster setup.
  * Documented how cluster version and ROSA-related values are handled, including when they are present or omitted.
  * Clarified the conditions under which ROSA-specific configuration applies and the access needed for detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->