### PR TITLE
OLS-3492: Add Cursor skills for bundle dev update and release workflows

### DIFF
--- a/.cursor/skills/update-bundle/SKILL.md
+++ b/.cursor/skills/update-bundle/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: update-bundle
+description: >-
+  Sync related_images.json from Konflux and regenerate the OLM bundle. Pass mode
+  dev (CI quay images, current version) or release (stable images, version bump
+  — full steps in /version-update). Use for PR bundle/CI fixes or shipping to
+  main.
+disable-model-invocation: true
+---
+
+# Update Bundle
+
+One entry point, two modes:
+
+```
+/update-bundle dev
+/update-bundle release X.Y.Z    # same as /version-update X.Y.Z
+```
+
+Releases ship from `main` (no separate release branch).
+
+| | **dev** | **release** |
+|---|---------|-------------|
+| **When** | PR/CI, local e2e, stale Konflux digests | Shipping to `main` |
+| **Snapshot** | `-r ci` | `-r stable` |
+| **Image hosts** | `quay.io/redhat-user-workloads/...` | `registry.redhat.io/openshift-lightspeed/...` |
+| **Bundle version** | Keep current | Bump to `X.Y.Z` |
+| **Full steps** | Below | [version-update/SKILL.md](../version-update/SKILL.md) |
+
+**Not required** for reconciliation-only changes under `internal/controller/`, tests, or docs.
+
+---
+
+## Development mode (`dev`)
+
+### Step 1: Refresh `related_images.json`
+
+Requires Konflux `oc login` in namespace `crt-nshift-lightspeed-tenant`. See `README.md` (Update Bundle from Snapshot).
+
+```bash
+./hack/snapshot_to_image_list.sh -s <ols-snapshot> -b <ols-bundle-snapshot> -r ci -o related_images.json
+```
+
+`-r ci` is the default; images stay on `quay.io/redhat-user-workloads/...`.
+
+**Preserve entries the snapshot does not provide** (script keeps some from the existing file):
+
+- `lightspeed-to-dataverse-exporter`
+- Operands not yet in Konflux snapshots — merge manually after the script runs
+
+**Bundle image:** README documents backing up `lightspeed-operator-bundle` before refresh and restoring it when only operand images change.
+
+If `oc` is unavailable, resolve digests manually (e.g. `oras resolve` against Quay revision tags).
+
+### Step 2: Regenerate bundle (current version)
+
+```bash
+# From bundle/manifests/lightspeed-operator.clusterserviceversion.yaml spec.version
+make bundle BUNDLE_TAG=<current-version>
+```
+
+If CRD/RBAC changed:
+
+```bash
+make manifests
+make bundle BUNDLE_TAG=<current-version>
+```
+
+Or:
+
+```bash
+hack/update_bundle.sh -v <current-version> -i related_images.json
+```
+
+### Step 3: Verify
+
+```bash
+operator-sdk bundle validate ./bundle
+git diff related_images.json bundle/
+```
+
+Confirm:
+
+- [ ] Images use Konflux quay hosts (not `registry.redhat.io`)
+- [ ] CSV `spec.relatedImages` and deployment args match `related_images.json`
+- [ ] Bundle CRD matches source when CRD changed
+
+### Step 4: Commit (only when user asks)
+
+Do not commit unless requested. Dev quay images are for PR validation; **`main` gets stable images via `/version-update`**.
+
+---
+
+## Release mode (`release X.Y.Z`)
+
+Use **`/version-update X.Y.Z`** or follow [version-update/SKILL.md](../version-update/SKILL.md) in full. That skill includes:
+
+1. Refresh `related_images.json` with `-r stable`
+2. Bump `bundle.Dockerfile` and CSV version (with `sed` examples)
+3. `make bundle BUNDLE_TAG=X.Y.Z` or `hack/update_bundle.sh`
+4. Verify checklist and common mistakes
+
+Do not skip the version-update steps when releasing.
+
+## Related
+
+- `/version-update` — full release workflow
+- `docs/olm-bundle-management.md` — bundle structure

--- a/.cursor/skills/version-update/SKILL.md
+++ b/.cursor/skills/version-update/SKILL.md
@@ -1,10 +1,36 @@
 ---
 name: version-update
-description: Updates the operator version number across all required files and regenerates the bundle. Use when bumping the version for a release or when the user asks to update, bump, or change the version number.
+description: >-
+  Release workflow for main: refresh related_images.json with stable Konflux
+  images (-r stable), bump bundle/CSV version, regenerate and validate the
+  bundle. Equivalent to /update-bundle release X.Y.Z. For PR/CI at the current
+  version, use /update-bundle dev instead.
 disable-model-invocation: true
 ---
 
-# Version Update
+# Version Update (Release)
+
+Invoke with `/version-update X.Y.Z` or `/update-bundle release X.Y.Z`.
+
+Not for PR/CI — use `/update-bundle dev`.
+
+## Step 1: Refresh `related_images.json` (stable)
+
+Requires Konflux `oc login` in namespace `crt-nshift-lightspeed-tenant`. See `README.md` (Update Bundle from Snapshot).
+
+```bash
+./hack/snapshot_to_image_list.sh -s <ols-snapshot> -b <ols-bundle-snapshot> -r stable -o related_images.json
+```
+
+Use `-r preview` only for tech-preview paths (`registry.redhat.io/openshift-lightspeed-tech-preview/...`).
+
+Images must land on **`registry.redhat.io/openshift-lightspeed/...`** (not Konflux quay).
+
+Preserve snapshot-less entries per `hack/snapshot_to_image_list.sh` (e.g. dataverse-exporter, interim operands not in Konflux). README documents backing up `lightspeed-operator-bundle` when only operand images change.
+
+If CRD/RBAC changed since last bundle, run `make manifests` before regenerating the bundle (Step 4).
+
+---
 
 Update the version in **two** files. They must all match.
 
@@ -43,7 +69,7 @@ version: X.Y.Z
 
 ## Step-by-Step Process
 
-### Step 1: Update bundle.Dockerfile
+### Step 2: Update bundle.Dockerfile
 
 ```bash
 # Update both LABEL release and LABEL version
@@ -53,7 +79,7 @@ sed -i '' 's/^LABEL version=.*/LABEL version=X.Y.Z/' bundle.Dockerfile
 
 Or manually edit lines 63 and 66.
 
-### Step 2: Update CSV metadata
+### Step 3: Update CSV metadata
 
 **Line ~58** (name field with `v` prefix):
 ```yaml
@@ -65,49 +91,57 @@ name: lightspeed-operator.vX.Y.Z
 version: X.Y.Z
 ```
 
-### Step 3: Regenerate Bundle
+### Step 4: Regenerate Bundle
 
 After updating both files, regenerate the bundle:
 
 ```bash
-make bundle
+make bundle BUNDLE_TAG=X.Y.Z
 ```
 
 Or use the script:
 
 ```bash
-hack/update_bundle.sh -v X.Y.Z
+hack/update_bundle.sh -v X.Y.Z -i related_images.json
 ```
 
-This ensures all generated files are consistent with the new version.
-
-### Step 4: Verify Changes
+This ensures all generated files are consistent with the new version and stable images.
 
 ```bash
-git diff bundle.Dockerfile bundle/manifests/
+operator-sdk bundle validate ./bundle
+```
+
+### Step 5: Verify Changes
+
+```bash
+git diff bundle.Dockerfile related_images.json bundle/
 ```
 
 Confirm:
+- [ ] `related_images.json` uses stable `registry.redhat.io` images
 - [ ] `bundle.Dockerfile` has `release=X.Y.Z` and `version=X.Y.Z`
 - [ ] CSV `name` field: `lightspeed-operator.vX.Y.Z` (with `v` prefix)
 - [ ] CSV `version` field: `X.Y.Z` (without prefix)
+- [ ] CSV `relatedImages` and deployment args match `related_images.json`
 - [ ] All generated bundle files are updated
 
-### Step 5: Commit
+### Step 6: Commit (only when user asks)
 
 ```bash
-git add bundle.Dockerfile bundle/
-git commit -m "Bump version to X.Y.Z"
+git add bundle.Dockerfile related_images.json bundle/
+git commit -m "OLS-XXXX: Release vX.Y.Z"
 ```
 
 ## Checklist
 
+- [ ] `related_images.json` refreshed with `-r stable`
 - [ ] `bundle.Dockerfile` updated (lines 63, 66)
 - [ ] `bundle/manifests/lightspeed-operator.clusterserviceversion.yaml` name updated (line ~58, with `v` prefix)
 - [ ] `bundle/manifests/lightspeed-operator.clusterserviceversion.yaml` version updated (line ~715, without prefix)
-- [ ] Bundle regenerated with `make bundle` or `hack/update_bundle.sh`
-- [ ] Both files have matching versions
-- [ ] Changes committed
+- [ ] Bundle regenerated with `make bundle BUNDLE_TAG=X.Y.Z` or `hack/update_bundle.sh -v X.Y.Z -i related_images.json`
+- [ ] `operator-sdk bundle validate ./bundle` passes
+- [ ] Both version files have matching `X.Y.Z`
+- [ ] Changes committed (when requested)
 
 ## Common Mistakes to Avoid
 
@@ -116,3 +150,11 @@ git commit -m "Bump version to X.Y.Z"
 ❌ Updating only one file
 ❌ Not regenerating the bundle after changes
 ❌ Mismatched version numbers between files
+❌ Bumping version without refreshing stable images (`-r stable`)
+❌ Merging dev quay images from `/update-bundle dev` to `main` without re-running this skill
+
+## Related
+
+- `/update-bundle dev` — PR/CI bundle sync (Konflux `-r ci`, current version)
+- `docs/olm-bundle-management.md` — bundle structure
+- `hack/release_tools.md` — release tooling

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,12 @@ make test-e2e   # E2E tests (requires cluster)
 
 ## AI Assistant Skills
 
-Available skills for code review:
+Available skills:
+
+- **`/update-bundle dev`** - PR/CI: Konflux CI images (`-r ci`), regen bundle at current version
+- **`/update-bundle release X.Y.Z`** or **`/version-update X.Y.Z`** - Ship to `main`: see `version-update` skill for full release steps (stable images, version bump, bundle regen)
+
+Code review:
 
 - **`/go-code-review`** - Review Go code for error handling, concurrency, resource leaks, naming conventions
 - **`/go-testing-code-review`** - Review test code for table-driven tests, cleanup patterns, error messages


### PR DESCRIPTION
## Description

**Summary**
Documents OLM bundle and related_images.json refresh workflows as Cursor skills so dev (PR/CI) and release (main) paths are explicit and harder to mix up.

Changes:

Add .cursor/skills/update-bundle/SKILL.md — /update-bundle dev for Konflux CI images (-r ci), bundle regen at the current version, validation checklist
Extend .cursor/skills/version-update/SKILL.md — release workflow: stable snapshot (-r stable), version bump, bundle regen, validation; keeps original version-update steps and renumbers them
Update AGENTS.md — list /update-bundle dev and /version-update X.Y.Z (alias: /update-bundle release X.Y.Z)
Why: Bundle refresh steps are spread across README, CONTRIBUTING, hack/release_tools.md, and docs/olm-bundle-management.md. Dev work needs -r ci quay images at the current version; shipping to main needs -r stable registry images plus a version bump. Konflux release automation helps on main but doesn’t unblock feature PRs that need an in-sync bundle for CI/e2e.

This is documentation/skills only — no CI hooks or pipeline changes.<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
https://redhat.atlassian.net/browse/OLS-3492
- Closes #
https://redhat.atlassian.net/browse/OLS-3492

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for syncing release bundle inputs and regenerating the bundle in both development and release flows.
  * Expanded release instructions with clearer step ordering, validation checks, common pitfalls, and commit guidance.
  * Updated the assistant skills reference section to use clearer headings and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->