### PR TITLE
OLS-3448: Create cluster-internal Service for ocp-mcp sidecar

### DIFF
--- a/.ai/spec/what/app-server.md
+++ b/.ai/spec/what/app-server.md
@@ -38,6 +38,7 @@ The App Server is the backend deployment for OpenShift Lightspeed. It runs the l
 
 ### Service and Networking
 18. The service exposes HTTPS on the configured port.
+18a. When `spec.ols.introspectionEnabled` is true, a cluster-internal Service named `openshift-mcp-server` is created targeting port 8080 on app server pods (the MCP sidecar). When introspection is disabled, the Service is deleted. The Service lifecycle follows the same reconciliation pattern as other operator-managed Services.
 19. The network policy allows ingress from: Prometheus (openshift-monitoring), OpenShift Console (openshift-console), and ingress controllers.
 20. Egress is unrestricted (empty egress rules).
 

--- a/config/default/deployment-patch.yaml
+++ b/config/default/deployment-patch.yaml
@@ -2,28 +2,22 @@
 # make deploy and hack/update_bundle.sh substitute these from related_images.json (and IMG for operator).
 - op: add
   path: /spec/template/spec/containers/0/args/-
-  value: --service-image=__REPLACE_LIGHTSPEED_SERVICE_API__
+  value: --service-image=registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9@sha256:92e6c4726f2370ffb222246dd3ec188f15e4d1f99dafdf78a22332cf0bff6733
 - op: add
   path: /spec/template/spec/containers/0/args/-
-  value: --console-image=__REPLACE_LIGHTSPEED_CONSOLE_PLUGIN__
+  value: --console-image=registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:020735d5c17b37c9bff8d586ad52c0057cbaef0d5b28a0a584b83d2dcab73f67
 - op: add
   path: /spec/template/spec/containers/0/args/-
-  value: --postgres-image=__REPLACE_LIGHTSPEED_POSTGRESQL__
+  value: --postgres-image=registry.redhat.io/rhel9/postgresql-16@sha256:42f385ac3c9b8913426da7c57e70bc6617cd237aaf697c667f6385a8c0b0118b
 - op: add
   path: /spec/template/spec/containers/0/args/-
-  value: --openshift-mcp-server-image=__REPLACE_OPENSHIFT_MCP_SERVER__
+  value: --openshift-mcp-server-image=registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9@sha256:41a659779aa434a0c1b3769f0d0a7ae034461de453aa19ed0e4e8134956b0e8e
 - op: add
   path: /spec/template/spec/containers/0/args/-
-  value: --dataverse-exporter-image=__REPLACE_LIGHTSPEED_TO_DATAVERSE_EXPORTER__
+  value: --dataverse-exporter-image=registry.redhat.io/lightspeed-core/dataverse-exporter-rhel9@sha256:1c7ffaead23adfb1dc6bd3adfe75c80f284d6d31f13ca427d754703c78514cb2
 - op: add
   path: /spec/template/spec/containers/0/args/-
-  value: --ocp-rag-image=__REPLACE_LIGHTSPEED_OCP_RAG__
-- op: add
-  path: /spec/template/spec/containers/0/args/-
-  value: --agentic-console-image=__REPLACE_LIGHTSPEED_AGENTIC_CONSOLE_PLUGIN__
-- op: add
-  path: /spec/template/spec/containers/0/args/-
-  value: --alerts-adapter-image=__REPLACE_LIGHTSPEED_AGENTIC_ALERTS_ADAPTER__
+  value: --ocp-rag-image=registry.redhat.io/openshift-lightspeed/lightspeed-ocp-rag-rhel9@sha256:7155419a17b950e48266e18da7328cc127d44a4923e76c66295b6079ea3f93d2
 - op: replace
   path: /spec/template/spec/containers/0/image
-  value: __REPLACE_LIGHTSPEED_OPERATOR__
+  value: quay.io/ometelka/lightspeed-operator:ols-3443

--- a/internal/controller/appserver/assets.go
+++ b/internal/controller/appserver/assets.go
@@ -745,17 +745,21 @@ func GenerateService(r reconciler.Reconciler, cr *olsv1alpha1.OLSConfig) (*corev
 
 // GenerateMCPService generates a cluster-internal Service that exposes the ocp-mcp sidecar
 // so that agentic sandbox pods can reach it via in-cluster DNS.
+// The Service is annotated for the service-ca operator to provision a TLS certificate.
 func GenerateMCPService(r reconciler.Reconciler, cr *olsv1alpha1.OLSConfig) (*corev1.Service, error) {
 	service := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      utils.OpenShiftMCPServerServiceName,
 			Namespace: r.GetNamespace(),
 			Labels:    utils.GenerateAppServerSelectorLabels(),
+			Annotations: map[string]string{
+				utils.ServingCertSecretAnnotationKey: utils.OpenShiftMCPServerCertsSecretName,
+			},
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
 				{
-					Name:       "mcp",
+					Name:       "https",
 					Protocol:   corev1.ProtocolTCP,
 					Port:       utils.OpenShiftMCPServerServicePort,
 					TargetPort: intstr.FromInt32(utils.OpenShiftMCPServerPort),

--- a/internal/controller/appserver/assets.go
+++ b/internal/controller/appserver/assets.go
@@ -969,6 +969,28 @@ func GenerateAppServerNetworkPolicy(r reconciler.Reconciler, cr *olsv1alpha1.OLS
 						},
 					},
 				},
+				{
+					// allow agentic sandbox pods to access the MCP server sidecar
+					From: []networkingv1.NetworkPolicyPeer{
+						{
+							PodSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      "agentic.openshift.io/proposal",
+										Operator: metav1.LabelSelectorOpExists,
+									},
+								},
+							},
+							NamespaceSelector: &metav1.LabelSelector{},
+						},
+					},
+					Ports: []networkingv1.NetworkPolicyPort{
+						{
+							Protocol: &[]corev1.Protocol{corev1.ProtocolTCP}[0],
+							Port:     &[]intstr.IntOrString{intstr.FromInt(utils.OpenShiftMCPServerPort)}[0],
+						},
+					},
+				},
 			},
 			Egress: []networkingv1.NetworkPolicyEgressRule{},
 			PolicyTypes: []networkingv1.PolicyType{

--- a/internal/controller/appserver/assets.go
+++ b/internal/controller/appserver/assets.go
@@ -743,6 +743,34 @@ func GenerateService(r reconciler.Reconciler, cr *olsv1alpha1.OLSConfig) (*corev
 	return &service, nil
 }
 
+// GenerateMCPService generates a cluster-internal Service that exposes the ocp-mcp sidecar
+// so that agentic sandbox pods can reach it via in-cluster DNS.
+func GenerateMCPService(r reconciler.Reconciler, cr *olsv1alpha1.OLSConfig) (*corev1.Service, error) {
+	service := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      utils.OpenShiftMCPServerServiceName,
+			Namespace: r.GetNamespace(),
+			Labels:    utils.GenerateAppServerSelectorLabels(),
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "mcp",
+					Protocol:   corev1.ProtocolTCP,
+					Port:       utils.OpenShiftMCPServerServicePort,
+					TargetPort: intstr.FromInt32(utils.OpenShiftMCPServerPort),
+				},
+			},
+			Selector: utils.GenerateAppServerSelectorLabels(),
+		},
+	}
+	if err := controllerutil.SetControllerReference(cr, &service, r.GetScheme()); err != nil {
+		return nil, err
+	}
+
+	return &service, nil
+}
+
 func GenerateServiceMonitor(r reconciler.Reconciler, cr *olsv1alpha1.OLSConfig) (*monv1.ServiceMonitor, error) {
 	metaLabels := utils.GenerateAppServerSelectorLabels()
 	metaLabels["monitoring.openshift.io/collection-profile"] = "full"

--- a/internal/controller/appserver/assets_test.go
+++ b/internal/controller/appserver/assets_test.go
@@ -1341,8 +1341,6 @@ var _ = Describe("App server assets", func() {
 				"/openshift-mcp-server",
 				"--config", utils.GetOpenShiftMCPServerConfigPath(),
 				"--port", fmt.Sprintf("%d", utils.OpenShiftMCPServerPort),
-				"--tls-cert-file", path.Join(utils.OpenShiftMCPServerTLSMountPath, "tls.crt"),
-				"--tls-key-file", path.Join(utils.OpenShiftMCPServerTLSMountPath, "tls.key"),
 			}))
 			Expect(openshiftMCPServerContainer.SecurityContext).To(Equal(utils.RestrictedContainerSecurityContext()))
 			Expect(openshiftMCPServerContainer.Resources).To(Equal(corev1.ResourceRequirements{
@@ -1448,8 +1446,6 @@ var _ = Describe("App server assets", func() {
 				"/openshift-mcp-server",
 				"--config", utils.GetOpenShiftMCPServerConfigPath(),
 				"--port", fmt.Sprintf("%d", utils.OpenShiftMCPServerPort),
-				"--tls-cert-file", path.Join(utils.OpenShiftMCPServerTLSMountPath, "tls.crt"),
-				"--tls-key-file", path.Join(utils.OpenShiftMCPServerTLSMountPath, "tls.key"),
 			}))
 			Expect(mcpContainer.Resources).To(Equal(corev1.ResourceRequirements{
 				Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("200Mi")},

--- a/internal/controller/appserver/assets_test.go
+++ b/internal/controller/appserver/assets_test.go
@@ -975,7 +975,7 @@ var _ = Describe("App server assets", func() {
 			Expect(np.Name).To(Equal(utils.OLSAppServerNetworkPolicyName))
 			Expect(np.Namespace).To(Equal(utils.OLSNamespaceDefault))
 			Expect(np.Spec.PolicyTypes).To(Equal([]networkingv1.PolicyType{networkingv1.PolicyTypeIngress}))
-			Expect(np.Spec.Ingress).To(HaveLen(3))
+			Expect(np.Spec.Ingress).To(HaveLen(4))
 			// allow prometheus to scrape metrics
 			Expect(np.Spec.Ingress).To(ContainElement(networkingv1.NetworkPolicyIngressRule{
 				From: []networkingv1.NetworkPolicyPeer{
@@ -1047,6 +1047,28 @@ var _ = Describe("App server assets", func() {
 					{
 						Protocol: &[]corev1.Protocol{corev1.ProtocolTCP}[0],
 						Port:     &[]intstr.IntOrString{intstr.FromInt(utils.OLSAppServerContainerPort)}[0],
+					},
+				},
+			}))
+			// allow agentic sandbox pods to access the MCP server sidecar
+			Expect(np.Spec.Ingress).To(ContainElement(networkingv1.NetworkPolicyIngressRule{
+				From: []networkingv1.NetworkPolicyPeer{
+					{
+						PodSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "agentic.openshift.io/proposal",
+									Operator: metav1.LabelSelectorOpExists,
+								},
+							},
+						},
+						NamespaceSelector: &metav1.LabelSelector{},
+					},
+				},
+				Ports: []networkingv1.NetworkPolicyPort{
+					{
+						Protocol: &[]corev1.Protocol{corev1.ProtocolTCP}[0],
+						Port:     &[]intstr.IntOrString{intstr.FromInt(utils.OpenShiftMCPServerPort)}[0],
 					},
 				},
 			}))

--- a/internal/controller/appserver/assets_test.go
+++ b/internal/controller/appserver/assets_test.go
@@ -1341,6 +1341,8 @@ var _ = Describe("App server assets", func() {
 				"/openshift-mcp-server",
 				"--config", utils.GetOpenShiftMCPServerConfigPath(),
 				"--port", fmt.Sprintf("%d", utils.OpenShiftMCPServerPort),
+				"--tls-cert-file", path.Join(utils.OpenShiftMCPServerTLSMountPath, "tls.crt"),
+				"--tls-key-file", path.Join(utils.OpenShiftMCPServerTLSMountPath, "tls.key"),
 			}))
 			Expect(openshiftMCPServerContainer.SecurityContext).To(Equal(utils.RestrictedContainerSecurityContext()))
 			Expect(openshiftMCPServerContainer.Resources).To(Equal(corev1.ResourceRequirements{
@@ -1446,6 +1448,8 @@ var _ = Describe("App server assets", func() {
 				"/openshift-mcp-server",
 				"--config", utils.GetOpenShiftMCPServerConfigPath(),
 				"--port", fmt.Sprintf("%d", utils.OpenShiftMCPServerPort),
+				"--tls-cert-file", path.Join(utils.OpenShiftMCPServerTLSMountPath, "tls.crt"),
+				"--tls-key-file", path.Join(utils.OpenShiftMCPServerTLSMountPath, "tls.key"),
 			}))
 			Expect(mcpContainer.Resources).To(Equal(corev1.ResourceRequirements{
 				Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("200Mi")},
@@ -2369,7 +2373,7 @@ var _ = Describe("Helper function unit tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(servers).To(HaveLen(1))
 			Expect(servers[0].Name).To(Equal("openshift"))
-			Expect(servers[0].URL).To(ContainSubstring("8080"))
+			Expect(servers[0].URL).To(ContainSubstring(fmt.Sprintf("%d", utils.OpenShiftMCPServerPort)))
 			Expect(servers[0].Headers).To(HaveKey(utils.K8S_AUTH_HEADER))
 		})
 

--- a/internal/controller/appserver/deployment.go
+++ b/internal/controller/appserver/deployment.go
@@ -504,24 +504,44 @@ func GenerateOLSDeployment(r reconciler.Reconciler, cr *olsv1alpha1.OLSConfig) (
 
 	// Add OpenShift MCP server sidecar container if introspection is enabled.
 	// The sidecar is configured with a TOML config that denies access to Secret resources,
-	// preventing secret data from reaching the LLM.
+	// preventing secret data from reaching the LLM. TLS is provided by the service-ca operator.
 	if utils.BoolDeref(cr.Spec.OLSConfig.IntrospectionEnabled, true) {
 		configVolume, configMount := utils.GetOpenShiftMCPServerConfigVolumeAndMount()
+
+		tlsCertFile := path.Join(utils.OpenShiftMCPServerTLSMountPath, "tls.crt")
+		tlsKeyFile := path.Join(utils.OpenShiftMCPServerTLSMountPath, "tls.key")
+
+		tlsVolume := corev1.Volume{
+			Name: utils.OpenShiftMCPServerTLSVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  utils.OpenShiftMCPServerCertsSecretName,
+					DefaultMode: &volumeDefaultMode,
+				},
+			},
+		}
+		tlsMount := corev1.VolumeMount{
+			Name:      utils.OpenShiftMCPServerTLSVolumeName,
+			MountPath: utils.OpenShiftMCPServerTLSMountPath,
+			ReadOnly:  true,
+		}
 
 		openshiftMCPServerSidecarContainer := corev1.Container{
 			Name:            "openshift-mcp-server",
 			Image:           r.GetOpenShiftMCPServerImage(),
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			SecurityContext: utils.RestrictedContainerSecurityContext(),
-			VolumeMounts:    []corev1.VolumeMount{configMount},
+			VolumeMounts:    []corev1.VolumeMount{configMount, tlsMount},
 			Command: []string{
 				"/openshift-mcp-server",
 				"--config", utils.GetOpenShiftMCPServerConfigPath(),
 				"--port", fmt.Sprintf("%d", utils.OpenShiftMCPServerPort),
+				"--tls-cert-file", tlsCertFile,
+				"--tls-key-file", tlsKeyFile,
 			},
 			Resources: *mcp_server_resources,
 		}
-		deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, configVolume)
+		deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, configVolume, tlsVolume)
 		deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, openshiftMCPServerSidecarContainer)
 	}
 

--- a/internal/controller/appserver/deployment.go
+++ b/internal/controller/appserver/deployment.go
@@ -508,9 +508,6 @@ func GenerateOLSDeployment(r reconciler.Reconciler, cr *olsv1alpha1.OLSConfig) (
 	if utils.BoolDeref(cr.Spec.OLSConfig.IntrospectionEnabled, true) {
 		configVolume, configMount := utils.GetOpenShiftMCPServerConfigVolumeAndMount()
 
-		tlsCertFile := path.Join(utils.OpenShiftMCPServerTLSMountPath, "tls.crt")
-		tlsKeyFile := path.Join(utils.OpenShiftMCPServerTLSMountPath, "tls.key")
-
 		tlsVolume := corev1.Volume{
 			Name: utils.OpenShiftMCPServerTLSVolumeName,
 			VolumeSource: corev1.VolumeSource{
@@ -536,8 +533,6 @@ func GenerateOLSDeployment(r reconciler.Reconciler, cr *olsv1alpha1.OLSConfig) (
 				"/openshift-mcp-server",
 				"--config", utils.GetOpenShiftMCPServerConfigPath(),
 				"--port", fmt.Sprintf("%d", utils.OpenShiftMCPServerPort),
-				"--tls-cert-file", tlsCertFile,
-				"--tls-key-file", tlsKeyFile,
 			},
 			Resources: *mcp_server_resources,
 		}

--- a/internal/controller/appserver/deployment_test.go
+++ b/internal/controller/appserver/deployment_test.go
@@ -150,8 +150,6 @@ var _ = Describe("App server deployment generation", func() {
 				"/openshift-mcp-server",
 				"--config", utils.GetOpenShiftMCPServerConfigPath(),
 				"--port", fmt.Sprintf("%d", utils.OpenShiftMCPServerPort),
-				"--tls-cert-file", path.Join(utils.OpenShiftMCPServerTLSMountPath, "tls.crt"),
-				"--tls-key-file", path.Join(utils.OpenShiftMCPServerTLSMountPath, "tls.key"),
 			}))
 
 			By("Disabling introspection")
@@ -227,8 +225,6 @@ var _ = Describe("App server deployment generation", func() {
 				"/openshift-mcp-server",
 				"--config", utils.GetOpenShiftMCPServerConfigPath(),
 				"--port", fmt.Sprintf("%d", utils.OpenShiftMCPServerPort),
-				"--tls-cert-file", path.Join(utils.OpenShiftMCPServerTLSMountPath, "tls.crt"),
-				"--tls-key-file", path.Join(utils.OpenShiftMCPServerTLSMountPath, "tls.key"),
 			}))
 		})
 	})

--- a/internal/controller/appserver/deployment_test.go
+++ b/internal/controller/appserver/deployment_test.go
@@ -150,6 +150,8 @@ var _ = Describe("App server deployment generation", func() {
 				"/openshift-mcp-server",
 				"--config", utils.GetOpenShiftMCPServerConfigPath(),
 				"--port", fmt.Sprintf("%d", utils.OpenShiftMCPServerPort),
+				"--tls-cert-file", path.Join(utils.OpenShiftMCPServerTLSMountPath, "tls.crt"),
+				"--tls-key-file", path.Join(utils.OpenShiftMCPServerTLSMountPath, "tls.key"),
 			}))
 
 			By("Disabling introspection")
@@ -225,6 +227,8 @@ var _ = Describe("App server deployment generation", func() {
 				"/openshift-mcp-server",
 				"--config", utils.GetOpenShiftMCPServerConfigPath(),
 				"--port", fmt.Sprintf("%d", utils.OpenShiftMCPServerPort),
+				"--tls-cert-file", path.Join(utils.OpenShiftMCPServerTLSMountPath, "tls.crt"),
+				"--tls-key-file", path.Join(utils.OpenShiftMCPServerTLSMountPath, "tls.key"),
 			}))
 		})
 	})

--- a/internal/controller/appserver/reconciler.go
+++ b/internal/controller/appserver/reconciler.go
@@ -130,6 +130,10 @@ func ReconcileAppServerDeployment(r reconciler.Reconciler, ctx context.Context, 
 			Task: reconcileService,
 		},
 		{
+			Name: "reconcile MCP Server Service",
+			Task: reconcileMCPService,
+		},
+		{
 			Name: "reconcile App TLS Certs",
 			Task: ReconcileTLSSecret,
 		},
@@ -370,6 +374,49 @@ func reconcileService(r reconciler.Reconciler, ctx context.Context, cr *olsv1alp
 	}
 
 	r.GetLogger().Info("OLS service reconciled", "service", service.Name)
+	return nil
+}
+
+// reconcileMCPService creates/updates the cluster-internal Service for the ocp-mcp sidecar
+// when introspection is enabled, and deletes it when introspection is disabled.
+func reconcileMCPService(r reconciler.Reconciler, ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
+	foundService := &corev1.Service{}
+	getErr := r.Get(ctx, client.ObjectKey{Name: utils.OpenShiftMCPServerServiceName, Namespace: r.GetNamespace()}, foundService)
+
+	if !utils.BoolDeref(cr.Spec.OLSConfig.IntrospectionEnabled, true) {
+		if getErr == nil {
+			r.GetLogger().Info("deleting MCP server service", "service", utils.OpenShiftMCPServerServiceName)
+			if err := r.Delete(ctx, foundService); err != nil {
+				return fmt.Errorf("%s: %w", utils.ErrDeleteMCPServerService, err)
+			}
+		}
+		return nil
+	}
+
+	service, err := GenerateMCPService(r, cr)
+	if err != nil {
+		return fmt.Errorf("failed to generate MCP server service: %w", err)
+	}
+
+	if getErr != nil && errors.IsNotFound(getErr) {
+		r.GetLogger().Info("creating MCP server service", "service", service.Name)
+		if err := r.Create(ctx, service); err != nil {
+			return fmt.Errorf("%s: %w", utils.ErrCreateMCPServerService, err)
+		}
+		return nil
+	} else if getErr != nil {
+		return fmt.Errorf("%s: %w", utils.ErrGetMCPServerService, getErr)
+	}
+
+	if utils.ServiceEqual(foundService, service) {
+		r.GetLogger().Info("MCP server service unchanged, reconciliation skipped", "service", service.Name)
+		return nil
+	}
+
+	if err := r.Update(ctx, service); err != nil {
+		return fmt.Errorf("%s: %w", utils.ErrUpdateMCPServerService, err)
+	}
+	r.GetLogger().Info("MCP server service reconciled", "service", service.Name)
 	return nil
 }
 

--- a/internal/controller/appserver/reconciler.go
+++ b/internal/controller/appserver/reconciler.go
@@ -395,7 +395,7 @@ func reconcileMCPService(r reconciler.Reconciler, ctx context.Context, cr *olsv1
 
 	service, err := GenerateMCPService(r, cr)
 	if err != nil {
-		return fmt.Errorf("failed to generate MCP server service: %w", err)
+		return fmt.Errorf("%s: %w", utils.ErrGenerateMCPServerService, err)
 	}
 
 	if getErr != nil && errors.IsNotFound(getErr) {

--- a/internal/controller/appserver/reconciler.go
+++ b/internal/controller/appserver/reconciler.go
@@ -410,13 +410,15 @@ func reconcileMCPService(r reconciler.Reconciler, ctx context.Context, cr *olsv1
 		return fmt.Errorf("%s: %w", utils.ErrGetMCPServerService, getErr)
 	}
 
-	if utils.ServiceEqual(foundService, service) {
+	if utils.ServiceEqual(foundService, service) &&
+		foundService.Annotations[utils.ServingCertSecretAnnotationKey] == service.Annotations[utils.ServingCertSecretAnnotationKey] {
 		r.GetLogger().Info("MCP server service unchanged, reconciliation skipped", "service", service.Name)
 		return nil
 	}
 
 	foundService.Spec = service.Spec
 	foundService.Labels = service.Labels
+	foundService.Annotations = service.Annotations
 	if err := r.Update(ctx, foundService); err != nil {
 		return fmt.Errorf("%s: %w", utils.ErrUpdateMCPServerService, err)
 	}

--- a/internal/controller/appserver/reconciler.go
+++ b/internal/controller/appserver/reconciler.go
@@ -389,6 +389,8 @@ func reconcileMCPService(r reconciler.Reconciler, ctx context.Context, cr *olsv1
 			if err := r.Delete(ctx, foundService); err != nil {
 				return fmt.Errorf("%s: %w", utils.ErrDeleteMCPServerService, err)
 			}
+		} else if !errors.IsNotFound(getErr) {
+			return fmt.Errorf("%s: %w", utils.ErrGetMCPServerService, getErr)
 		}
 		return nil
 	}
@@ -413,7 +415,9 @@ func reconcileMCPService(r reconciler.Reconciler, ctx context.Context, cr *olsv1
 		return nil
 	}
 
-	if err := r.Update(ctx, service); err != nil {
+	foundService.Spec = service.Spec
+	foundService.Labels = service.Labels
+	if err := r.Update(ctx, foundService); err != nil {
 		return fmt.Errorf("%s: %w", utils.ErrUpdateMCPServerService, err)
 	}
 	r.GetLogger().Info("MCP server service reconciled", "service", service.Name)

--- a/internal/controller/appserver/reconciler_test.go
+++ b/internal/controller/appserver/reconciler_test.go
@@ -392,6 +392,56 @@ var _ = Describe("App server reconciliator", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred(), "MCP server Service should be re-created when introspection is re-enabled")
 		})
 
+		It("should create MCP server Service when introspectionEnabled is nil (default true)", func() {
+			By("Set introspectionEnabled to nil")
+			olsConfig := &olsv1alpha1.OLSConfig{}
+			err := k8sClient.Get(ctx, crNamespacedName, olsConfig)
+			Expect(err).NotTo(HaveOccurred())
+			olsConfig.Spec.OLSConfig.IntrospectionEnabled = nil
+
+			By("Reconcile the app server")
+			err = ReconcileAppServer(testReconcilerInstance, ctx, olsConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verify MCP server Service exists")
+			mcpSvc := &corev1.Service{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: utils.OpenShiftMCPServerServiceName, Namespace: utils.OLSNamespaceDefault}, mcpSvc)
+			Expect(err).NotTo(HaveOccurred(), "MCP server Service should exist when introspectionEnabled is nil (defaults to true)")
+			Expect(mcpSvc.Spec.Ports).To(HaveLen(1))
+			Expect(mcpSvc.Spec.Ports[0].Port).To(Equal(int32(utils.OpenShiftMCPServerServicePort)))
+		})
+
+		It("should update MCP server Service when spec drifts", func() {
+			By("Ensure introspection is enabled and service exists")
+			olsConfig := &olsv1alpha1.OLSConfig{}
+			err := k8sClient.Get(ctx, crNamespacedName, olsConfig)
+			Expect(err).NotTo(HaveOccurred())
+			olsConfig.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(true)
+
+			err = ReconcileAppServer(testReconcilerInstance, ctx, olsConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Mutate the service to simulate drift")
+			mcpSvc := &corev1.Service{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: utils.OpenShiftMCPServerServiceName, Namespace: utils.OLSNamespaceDefault}, mcpSvc)
+			Expect(err).NotTo(HaveOccurred())
+			mcpSvc.Spec.Ports[0].Port = 9999
+			err = k8sClient.Update(ctx, mcpSvc)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Reconcile again with introspection still enabled")
+			err = k8sClient.Get(ctx, crNamespacedName, olsConfig)
+			Expect(err).NotTo(HaveOccurred())
+			olsConfig.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(true)
+			err = ReconcileAppServer(testReconcilerInstance, ctx, olsConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verify service was corrected")
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: utils.OpenShiftMCPServerServiceName, Namespace: utils.OLSNamespaceDefault}, mcpSvc)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mcpSvc.Spec.Ports[0].Port).To(Equal(int32(utils.OpenShiftMCPServerServicePort)), "Service port should be restored after drift")
+		})
+
 		It("should trigger rolling update of the deployment when updating the nodeselector ", func() {
 			By("Get the deployment")
 			dep := &appsv1.Deployment{}

--- a/internal/controller/appserver/reconciler_test.go
+++ b/internal/controller/appserver/reconciler_test.go
@@ -362,7 +362,7 @@ var _ = Describe("App server reconciliator", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred(), "MCP server Service should exist when introspection is enabled")
 			Expect(mcpSvc.Spec.Ports).To(HaveLen(1))
 			Expect(mcpSvc.Spec.Ports[0].Port).To(Equal(int32(utils.OpenShiftMCPServerServicePort)))
-			Expect(mcpSvc.Spec.Ports[0].Name).To(Equal("mcp"))
+			Expect(mcpSvc.Spec.Ports[0].Name).To(Equal("https"))
 			Expect(mcpSvc.Spec.Selector).To(Equal(utils.GenerateAppServerSelectorLabels()))
 
 			By("Disable introspection")

--- a/internal/controller/appserver/reconciler_test.go
+++ b/internal/controller/appserver/reconciler_test.go
@@ -345,6 +345,53 @@ var _ = Describe("App server reconciliator", Ordered, func() {
 			Expect(forceReloadValue).NotTo(BeEmpty(), "Pod template restart annotation should be set to trigger rolling update")
 		})
 
+		It("should create MCP server Service when introspection is enabled and delete when disabled", func() {
+			By("Enable introspection")
+			olsConfig := &olsv1alpha1.OLSConfig{}
+			err := k8sClient.Get(ctx, crNamespacedName, olsConfig)
+			Expect(err).NotTo(HaveOccurred())
+			olsConfig.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(true)
+
+			By("Reconcile the app server")
+			err = ReconcileAppServer(testReconcilerInstance, ctx, olsConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verify MCP server Service exists")
+			mcpSvc := &corev1.Service{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: utils.OpenShiftMCPServerServiceName, Namespace: utils.OLSNamespaceDefault}, mcpSvc)
+			Expect(err).NotTo(HaveOccurred(), "MCP server Service should exist when introspection is enabled")
+			Expect(mcpSvc.Spec.Ports).To(HaveLen(1))
+			Expect(mcpSvc.Spec.Ports[0].Port).To(Equal(int32(utils.OpenShiftMCPServerServicePort)))
+			Expect(mcpSvc.Spec.Ports[0].Name).To(Equal("mcp"))
+			Expect(mcpSvc.Spec.Selector).To(Equal(utils.GenerateAppServerSelectorLabels()))
+
+			By("Disable introspection")
+			err = k8sClient.Get(ctx, crNamespacedName, olsConfig)
+			Expect(err).NotTo(HaveOccurred())
+			olsConfig.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(false)
+
+			By("Reconcile with introspection disabled")
+			err = ReconcileAppServer(testReconcilerInstance, ctx, olsConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verify MCP server Service was deleted")
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: utils.OpenShiftMCPServerServiceName, Namespace: utils.OLSNamespaceDefault}, mcpSvc)
+			Expect(apierrors.IsNotFound(err)).To(BeTrue(), "MCP server Service should be deleted when introspection is disabled")
+
+			By("Re-enable introspection")
+			err = k8sClient.Get(ctx, crNamespacedName, olsConfig)
+			Expect(err).NotTo(HaveOccurred())
+			olsConfig.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(true)
+
+			By("Reconcile with introspection re-enabled")
+			err = ReconcileAppServer(testReconcilerInstance, ctx, olsConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verify MCP server Service was re-created")
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: utils.OpenShiftMCPServerServiceName, Namespace: utils.OLSNamespaceDefault}, mcpSvc)
+			Expect(err).NotTo(HaveOccurred(), "MCP server Service should be re-created when introspection is re-enabled")
+		})
+
 		It("should trigger rolling update of the deployment when updating the nodeselector ", func() {
 			By("Get the deployment")
 			dep := &appsv1.Deployment{}

--- a/internal/controller/utils/constants.go
+++ b/internal/controller/utils/constants.go
@@ -361,10 +361,14 @@ ssl_ca_file = '/etc/certs/cm-olspostgresca/service-ca.crt'
 	MetricsReaderServiceAccountTokenSecretName = "metrics-reader-token" // #nosec G101
 	// MetricsReaderServiceAccountName is the name of the service account for the metrics reader
 	MetricsReaderServiceAccountName = "lightspeed-operator-metrics-reader"
-	// MCP server URL
+	// MCP server URL (localhost, used by the app server to reach the co-located sidecar)
 	OpenShiftMCPServerURL = "http://localhost:%d/mcp"
 	// MCP server port
 	OpenShiftMCPServerPort = 8080
+	// OpenShiftMCPServerServiceName is the cluster-internal Service exposing the ocp-mcp sidecar
+	OpenShiftMCPServerServiceName = "openshift-mcp-server"
+	// OpenShiftMCPServerServicePort is the Service port for the ocp-mcp sidecar
+	OpenShiftMCPServerServicePort = 8080
 	// MCP server timeout, sec
 	OpenShiftMCPServerTimeout = 60
 	// MCP server SSE read timeout, sec

--- a/internal/controller/utils/constants.go
+++ b/internal/controller/utils/constants.go
@@ -363,12 +363,19 @@ ssl_ca_file = '/etc/certs/cm-olspostgresca/service-ca.crt'
 	MetricsReaderServiceAccountName = "lightspeed-operator-metrics-reader"
 	// MCP server URL (localhost, used by the app server to reach the co-located sidecar)
 	OpenShiftMCPServerURL = "http://localhost:%d/mcp"
-	// MCP server port
-	OpenShiftMCPServerPort = 8080
+	// MCP server port (HTTPS via service-ca TLS)
+	OpenShiftMCPServerPort = 8443
 	// OpenShiftMCPServerServiceName is the cluster-internal Service exposing the ocp-mcp sidecar
 	OpenShiftMCPServerServiceName = "openshift-mcp-server"
 	// OpenShiftMCPServerServicePort is the Service port for the ocp-mcp sidecar
-	OpenShiftMCPServerServicePort = 8080
+	OpenShiftMCPServerServicePort = 8443
+	// OpenShiftMCPServerCertsSecretName is the TLS secret auto-provisioned by service-ca for the MCP sidecar
+	// #nosec G101
+	OpenShiftMCPServerCertsSecretName = "openshift-mcp-server-tls"
+	// OpenShiftMCPServerTLSMountPath is where the TLS cert/key are mounted in the MCP sidecar
+	OpenShiftMCPServerTLSMountPath = "/etc/certs/mcp-server-tls"
+	// OpenShiftMCPServerTLSVolumeName is the volume name for the MCP server TLS secret
+	OpenShiftMCPServerTLSVolumeName = "mcp-server-tls"
 	// MCP server timeout, sec
 	OpenShiftMCPServerTimeout = 60
 	// MCP server SSE read timeout, sec

--- a/internal/controller/utils/constants.go
+++ b/internal/controller/utils/constants.go
@@ -362,7 +362,7 @@ ssl_ca_file = '/etc/certs/cm-olspostgresca/service-ca.crt'
 	// MetricsReaderServiceAccountName is the name of the service account for the metrics reader
 	MetricsReaderServiceAccountName = "lightspeed-operator-metrics-reader"
 	// MCP server URL (localhost, used by the app server to reach the co-located sidecar)
-	OpenShiftMCPServerURL = "http://localhost:%d/mcp"
+	OpenShiftMCPServerURL = "https://localhost:%d/mcp"
 	// MCP server port (HTTPS via service-ca TLS)
 	OpenShiftMCPServerPort = 8443
 	// OpenShiftMCPServerServiceName is the cluster-internal Service exposing the ocp-mcp sidecar

--- a/internal/controller/utils/errors.go
+++ b/internal/controller/utils/errors.go
@@ -148,8 +148,9 @@ const (
 	ErrUpdateMCPServerConfigMap = "failed to update MCP server config configmap"
 
 	// OpenShift MCP server service errors
-	ErrCreateMCPServerService = "failed to create MCP server service"
-	ErrDeleteMCPServerService = "failed to delete MCP server service"
-	ErrGetMCPServerService    = "failed to get MCP server service"
-	ErrUpdateMCPServerService = "failed to update MCP server service"
+	ErrCreateMCPServerService   = "failed to create MCP server service"
+	ErrDeleteMCPServerService   = "failed to delete MCP server service"
+	ErrGenerateMCPServerService = "failed to generate MCP server service"
+	ErrGetMCPServerService      = "failed to get MCP server service"
+	ErrUpdateMCPServerService   = "failed to update MCP server service"
 )

--- a/internal/controller/utils/errors.go
+++ b/internal/controller/utils/errors.go
@@ -146,4 +146,10 @@ const (
 	ErrDeleteMCPServerConfigMap = "failed to delete MCP server config configmap"
 	ErrGetMCPServerConfigMap    = "failed to get MCP server config configmap"
 	ErrUpdateMCPServerConfigMap = "failed to update MCP server config configmap"
+
+	// OpenShift MCP server service errors
+	ErrCreateMCPServerService = "failed to create MCP server service"
+	ErrDeleteMCPServerService = "failed to delete MCP server service"
+	ErrGetMCPServerService    = "failed to get MCP server service"
+	ErrUpdateMCPServerService = "failed to update MCP server service"
 )

--- a/internal/controller/utils/mcp_server_config.go
+++ b/internal/controller/utils/mcp_server_config.go
@@ -27,6 +27,9 @@ const OpenShiftMCPServerConfigTOML = `# Denied resources prevent the MCP server 
 
 toolsets = ["core", "config", "helm", "metrics"]
 
+tls_cert = "/etc/certs/mcp-server-tls/tls.crt"
+tls_key = "/etc/certs/mcp-server-tls/tls.key"
+
 [[denied_resources]]
 group = ""
 version = "v1"


### PR DESCRIPTION
## Summary
- Expose the `openshift-mcp-server` sidecar via a Kubernetes Service (port 8080) so agentic sandbox pods can reach it via in-cluster DNS
- Service lifecycle follows `introspectionEnabled`: created when true, deleted when disabled
- Adds constants, error messages, generation, reconciliation, and test for the new Service

## Jira
[OLS-3448](https://redhat.atlassian.net/browse/OLS-3448)

## Test plan
- [x] Unit test: create/delete/re-create lifecycle tied to introspection toggle
- [x] All existing operator tests pass (`make test`)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic management of a cluster-internal OpenShift MCP sidecar service when introspection is enabled (service deleted when disabled; defaults to enabled when unset).
  * MCP sidecar connection now uses HTTPS on port 8443 with TLS materials mounted into the sidecar.
* **Bug Fixes**
  * Improved reconciliation to reliably create/delete the MCP service and correct drift if the Service spec is modified.
  * Updated networking so agentic sandbox pods can reach the MCP sidecar over TCP.
* **Tests**
  * Added/extended coverage for MCP Service creation, deletion, defaulting, and drift recovery.
* **Documentation**
  * Updated App Server “Service and Networking” behavioral rules for MCP service introspection behavior.
* **Chores**
  * Pinned deployment patch image references to specific digests and adjusted related container arguments/images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->