### PR TITLE
OLS-1894: Set OLS_ROSA_PRODUCT on app-server for ROSA OKP retrieval

### DIFF
--- a/.ai/spec/how/config-generation.md
+++ b/.ai/spec/how/config-generation.md
@@ -210,7 +210,7 @@ These schemas are created by the bootstrap script.
 | BYOK RAG indexes | CR `spec.ols.rag[]` | Local FAISS indexes only; empty list when no BYOK RAG configured |
 | `solr_hybrid` | Operator defaults + `!byokRAGOnly` | OCP product docs via OKP Solr at `http://localhost:9080` |
 | RHOKP image | `--rhokp-image` flag | Sidecar image; not in `related_images.json` until bundle productization |
-| ROSA product | Console brand + Infrastructure topology | `OLS_ROSA_PRODUCT` env var on app-server (not in config YAML). [PLANNED: OLS-1894] |
+| ROSA product | Console brand + Infrastructure topology (detected at operator startup) | `OLS_ROSA_PRODUCT` env var on app-server when brand is `ROSA` (not in config YAML). `External` → HCP product; otherwise Classic. Omitted on detection failure or non-ROSA. |
 | MCP servers | CR `spec.mcpServers[]` + `spec.ols.introspectionEnabled` | Feature gated by `MCPServer` gate |
 | Tool filtering | CR `spec.ols.toolFilteringConfig` | Feature gated by `ToolFiltering` gate; requires MCP servers |
 | Proxy config | CR `spec.ols.proxyConfig` | Proxy URL + optional CA cert configmap |

--- a/.ai/spec/how/deployment-generation.md
+++ b/.ai/spec/how/deployment-generation.md
@@ -33,7 +33,7 @@ GenerateOLSDeployment(r, cr)
       - Container: "lightspeed-service-api", image: r.GetAppServerImage(), port: 8443
       - Env: OLS_CONFIG_FILE path + proxy vars (HTTP_PROXY, HTTPS_PROXY, NO_PROXY)
       - Env: OCP_CLUSTER_VERSION (`<major>.<minor>`) when `!byokRAGOnly` (same cluster-version source as console UI)
-      - Env: OLS_ROSA_PRODUCT (ROSA OKP product identifier) when `!byokRAGOnly` AND cluster brand is `ROSA`. Value: `red_hat_openshift_service_on_aws` (HCP) or `red_hat_openshift_service_on_aws_classic_architecture` (Classic), determined from Console brand + Infrastructure controlPlaneTopology. [PLANNED: OLS-1894]
+      - Env: OLS_ROSA_PRODUCT when `!byokRAGOnly` and startup detection finds ROSA brand. `External` topology → `red_hat_openshift_service_on_aws` (HCP); any other topology on ROSA → `red_hat_openshift_service_on_aws_classic_architecture` (Classic). Omitted on non-ROSA or detection failure.
       - Probes: HTTPS GET on /readiness, /liveness (initial: 30s, period: 30s, timeout: 30s, failure: 15)
       - Default resources: 500m CPU request, 1Gi memory request (no limits)
   16. Apply pod-level config (replicas, nodeSelector, tolerations)

--- a/.ai/spec/what/app-server.md
+++ b/.ai/spec/what/app-server.md
@@ -23,13 +23,14 @@ The App Server is the backend deployment for OpenShift Lightspeed. It runs the l
 14. Unless `byokRAGOnly` is true, the operator generates a `solr_hybrid` config section in `olsconfig.yaml` pointing to `http://localhost:9080` with default hybrid retrieval tuning parameters.
 15a. Unless `byokRAGOnly` is true, the app-server container receives `OCP_CLUSTER_VERSION` (`<major>.<minor>` from the operator's cluster-version lookup) for Solr `chunk_filter_query` resolution in lightspeed-service.
 
-### ROSA-Aware OKP Retrieval [PLANNED: OLS-1894]
-15b. Unless `byokRAGOnly` is true, the operator detects whether the cluster is ROSA and, if so, which variant (Classic vs HCP). Detection uses two standard OpenShift API resources, following the same pattern as OCP version detection — determined once and passed to the service as an environment variable:
+### ROSA-Aware OKP Retrieval
+15b. Unless `byokRAGOnly` is true, the operator detects whether the cluster is ROSA and, if so, which OKP product to scope. Detection uses two standard OpenShift API resources — determined once at operator startup and passed to the app-server as an environment variable:
   - **ROSA detection:** Read `console.operator.openshift.io/v1` Console `cluster` resource, field `.spec.customization.brand`. Value `ROSA` indicates a ROSA cluster (reliable on OCP 4.16+).
-  - **Variant detection:** Read `infrastructure.config.openshift.io/v1` Infrastructure `cluster` resource, field `.status.controlPlaneTopology`. `External` = HCP, `HighlyAvailable` = Classic.
+  - **Variant detection:** Read `infrastructure.config.openshift.io/v1` Infrastructure `cluster` resource, field `.status.controlPlaneTopology`. `External` = HCP; any other topology on ROSA = Classic.
   - When ROSA is detected, the operator sets `OLS_ROSA_PRODUCT` on the app-server container: `red_hat_openshift_service_on_aws` for HCP, `red_hat_openshift_service_on_aws_classic_architecture` for Classic.
   - On non-ROSA clusters the env var is absent and the service uses OCP-only retrieval.
-  - RBAC: requires `get` on `consoles` in the `operator.openshift.io` API group (Infrastructure is already covered by existing cluster-version permissions).
+  - If detection fails at startup (API/RBAC error), the operator logs a warning and omits the env var; reconciliation continues.
+  - RBAC: operator requires `get` on `consoles` (`operator.openshift.io`) and `infrastructures` (`config.openshift.io`).
 
 ### MCP Server Integration
 16. When `spec.ols.introspectionEnabled` is true, an "openshift" MCP server entry is added to the config pointing to localhost on the sidecar port.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -331,6 +331,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	rosaOKPProductEnv, err := utils.RosaOKPProductEnv(k8sClient, ctx, setupLog)
+	if err != nil {
+		setupLog.Error(err, "failed to detect ROSA OKP product; app-server will use OCP-only OKP retrieval")
+	} else if rosaOKPProductEnv != nil && rosaOKPProductEnv.Value == utils.RosaOKPProductHCP {
+		setupLog.Info("ROSA OKP product configured for app-server", "product", rosaOKPProductEnv.Value)
+	}
+
 	// Check if Prometheus Operator CRDs are available
 	prometheusAvailable := utils.IsPrometheusOperatorAvailable(ctx, k8sClient)
 	prometheusStatus := "NOT AVAILABLE"
@@ -429,6 +436,7 @@ func main() {
 			OpenShiftMCPServerImage:        imagesMap["openshift-mcp-server-image"],
 			DataverseExporterImage:         imagesMap["dataverse-exporter-image"],
 			RHOOKPImage:                    imagesMap["rhokp-image"],
+			RosaOKPProductEnv:              rosaOKPProductEnv,
 			Namespace:                      namespace,
 			PrometheusAvailable:            prometheusAvailable,
 		},

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -84,6 +84,7 @@ rules:
   resources:
   - apiservers
   - clusterversions
+  - infrastructures
   verbs:
   - get
   - list

--- a/internal/controller/appserver/deployment.go
+++ b/internal/controller/appserver/deployment.go
@@ -66,6 +66,9 @@ func appServerEnv(r reconciler.Reconciler, cr *olsv1alpha1.OLSConfig) []corev1.E
 			Name:  utils.OCPClusterVersionEnvVar,
 			Value: r.GetOpenShiftMajor() + "." + r.GetOpenshiftMinor(),
 		})
+		if rosaEnv := r.GetRosaOKPProductEnv(); rosaEnv != nil {
+			env = append(env, *rosaEnv)
+		}
 	}
 	return env
 }

--- a/internal/controller/appserver/deployment_test.go
+++ b/internal/controller/appserver/deployment_test.go
@@ -760,6 +760,12 @@ var _ = Describe("App server deployment generation", func() {
 				TranscriptsDisabled: true,
 			}
 			cr.Spec.OLSConfig.ByokRAGOnly = true
+			if tr, ok := testReconcilerInstance.(*utils.TestReconciler); ok {
+				tr.SetRosaOKPProductEnv(&corev1.EnvVar{
+					Name:  utils.OLSRosaProductEnvVar,
+					Value: utils.RosaOKPProductHCP,
+				})
+			}
 
 			dep, err := GenerateOLSDeployment(testReconcilerInstance, cr)
 			Expect(err).NotTo(HaveOccurred())
@@ -778,6 +784,58 @@ var _ = Describe("App server deployment generation", func() {
 			Expect(apiContainer).NotTo(BeNil())
 			for _, env := range apiContainer.Env {
 				Expect(env.Name).NotTo(Equal(utils.OCPClusterVersionEnvVar))
+				Expect(env.Name).NotTo(Equal(utils.OLSRosaProductEnvVar))
+			}
+		})
+
+		It("should add OLS_ROSA_PRODUCT when configured on the reconciler", func() {
+			cr.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(false)
+			cr.Spec.OLSConfig.UserDataCollection = olsv1alpha1.UserDataCollectionSpec{
+				FeedbackDisabled:    true,
+				TranscriptsDisabled: true,
+			}
+			rosaEnv := &corev1.EnvVar{
+				Name:  utils.OLSRosaProductEnvVar,
+				Value: utils.RosaOKPProductClassic,
+			}
+			if tr, ok := testReconcilerInstance.(*utils.TestReconciler); ok {
+				tr.SetRosaOKPProductEnv(rosaEnv)
+			}
+
+			dep, err := GenerateOLSDeployment(testReconcilerInstance, cr)
+			Expect(err).NotTo(HaveOccurred())
+
+			var apiContainer *corev1.Container
+			for i := range dep.Spec.Template.Spec.Containers {
+				if dep.Spec.Template.Spec.Containers[i].Name == "lightspeed-service-api" {
+					apiContainer = &dep.Spec.Template.Spec.Containers[i]
+					break
+				}
+			}
+			Expect(apiContainer).NotTo(BeNil())
+			Expect(apiContainer.Env).To(ContainElement(*rosaEnv))
+		})
+
+		It("should not add OLS_ROSA_PRODUCT when reconciler has no ROSA env configured", func() {
+			cr.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(false)
+			cr.Spec.OLSConfig.UserDataCollection = olsv1alpha1.UserDataCollectionSpec{
+				FeedbackDisabled:    true,
+				TranscriptsDisabled: true,
+			}
+
+			dep, err := GenerateOLSDeployment(testReconcilerInstance, cr)
+			Expect(err).NotTo(HaveOccurred())
+
+			var apiContainer *corev1.Container
+			for i := range dep.Spec.Template.Spec.Containers {
+				if dep.Spec.Template.Spec.Containers[i].Name == "lightspeed-service-api" {
+					apiContainer = &dep.Spec.Template.Spec.Containers[i]
+					break
+				}
+			}
+			Expect(apiContainer).NotTo(BeNil())
+			for _, env := range apiContainer.Env {
+				Expect(env.Name).NotTo(Equal(utils.OLSRosaProductEnvVar))
 			}
 		})
 

--- a/internal/controller/appserver/suite_test.go
+++ b/internal/controller/appserver/suite_test.go
@@ -193,6 +193,12 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 })
 
+var _ = BeforeEach(func() {
+	if tr, ok := testReconcilerInstance.(*utils.TestReconciler); ok {
+		tr.SetRosaOKPProductEnv(nil)
+	}
+})
+
 func deploymentContainerCount(base int) int {
 	if !cr.Spec.OLSConfig.ByokRAGOnly {
 		return base + 1

--- a/internal/controller/olsconfig_controller.go
+++ b/internal/controller/olsconfig_controller.go
@@ -144,8 +144,8 @@ type OLSConfigReconciler struct {
 // PrometheusRule for aggregating OLS metrics for telemetry
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules,verbs=get;list;watch;create;update;patch;delete
 
-// clusterversion for checking the openshift cluster version
-// +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions;apiservers,verbs=get;list;watch
+// clusterversion for checking the openshift cluster version; infrastructure for ROSA OKP product detection (OLS-1894)
+// +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions;apiservers;infrastructures,verbs=get;list;watch
 
 // NetworkPolicy for restricting access to OLS pods
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete

--- a/internal/controller/olsconfig_helpers.go
+++ b/internal/controller/olsconfig_helpers.go
@@ -81,6 +81,10 @@ func (r *OLSConfigReconciler) GetRHOOKPImage() string {
 	return r.Options.RHOOKPImage
 }
 
+func (r *OLSConfigReconciler) GetRosaOKPProductEnv() *corev1.EnvVar {
+	return r.Options.RosaOKPProductEnv
+}
+
 func (r *OLSConfigReconciler) IsPrometheusAvailable() bool {
 	return r.Options.PrometheusAvailable
 }

--- a/internal/controller/reconciler/interface.go
+++ b/internal/controller/reconciler/interface.go
@@ -23,6 +23,7 @@ package reconciler
 
 import (
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -72,6 +73,9 @@ type Reconciler interface {
 
 	// GetRHOOKPImage returns the RH Offline Knowledge Portal (Solr) sidecar image
 	GetRHOOKPImage() string
+
+	// GetRosaOKPProductEnv returns the OLS_ROSA_PRODUCT env var on ROSA clusters, or nil.
+	GetRosaOKPProductEnv() *corev1.EnvVar
 
 	// IsPrometheusAvailable returns whether Prometheus Operator CRDs are available
 	IsPrometheusAvailable() bool

--- a/internal/controller/utils/constants.go
+++ b/internal/controller/utils/constants.go
@@ -371,6 +371,12 @@ ssl_ca_file = '/etc/certs/cm-olspostgresca/service-ca.crt'
 	RHOOKPHTTPSPort = 9443
 	// OCPClusterVersionEnvVar is read by lightspeed-service to resolve Solr chunk_filter_query at startup.
 	OCPClusterVersionEnvVar = "OCP_CLUSTER_VERSION"
+	// OLSRosaProductEnvVar is read by lightspeed-service to scope OKP retrieval on ROSA clusters.
+	OLSRosaProductEnvVar = "OLS_ROSA_PRODUCT"
+	// RosaOKPProductHCP is the OKP product identifier for ROSA hosted control planes.
+	RosaOKPProductHCP = "red_hat_openshift_service_on_aws"
+	// RosaOKPProductClassic is the OKP product identifier for ROSA classic architecture.
+	RosaOKPProductClassic = "red_hat_openshift_service_on_aws_classic_architecture"
 	// RHOOKPSolrCollection is the Solr core served by RHOKP (matches lightspeed-service portal-rag client).
 	RHOOKPSolrCollection = "portal-rag"
 	// RHOOKPReadinessHTTPPath hits the portal-rag core admin ping (Apache / alone is not Solr-ready).

--- a/internal/controller/utils/testing.go
+++ b/internal/controller/utils/testing.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -24,6 +25,7 @@ type TestReconciler struct {
 	McpServerImage      string
 	DataverseExporter   string
 	RhokpImage          string
+	rosaOKPProductEnv   *corev1.EnvVar
 	openShiftMajor      string
 	openShiftMinor      string
 	PrometheusAvailable bool
@@ -82,6 +84,10 @@ func (r *TestReconciler) GetRHOOKPImage() string {
 	return r.RhokpImage
 }
 
+func (r *TestReconciler) GetRosaOKPProductEnv() *corev1.EnvVar {
+	return r.rosaOKPProductEnv
+}
+
 func (r *TestReconciler) IsPrometheusAvailable() bool {
 	return r.PrometheusAvailable
 }
@@ -92,6 +98,10 @@ func (r *TestReconciler) GetWatcherConfig() interface{} {
 
 func (r *TestReconciler) SetWatcherConfig(config interface{}) {
 	r.watcherConfig = config
+}
+
+func (r *TestReconciler) SetRosaOKPProductEnv(env *corev1.EnvVar) {
+	r.rosaOKPProductEnv = env
 }
 
 // NewTestReconciler creates a new TestReconciler instance with the provided parameters

--- a/internal/controller/utils/types.go
+++ b/internal/controller/utils/types.go
@@ -3,6 +3,8 @@ package utils
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
+
 	olsv1alpha1 "github.com/openshift/lightspeed-operator/api/v1alpha1"
 	"github.com/openshift/lightspeed-operator/internal/controller/reconciler"
 )
@@ -28,6 +30,7 @@ type OLSConfigReconcilerOptions struct {
 	DataverseExporterImage         string
 	OpenShiftMCPServerImage        string
 	RHOOKPImage                    string
+	RosaOKPProductEnv              *corev1.EnvVar
 	Namespace                      string
 	PrometheusAvailable            bool
 }

--- a/internal/controller/utils/utils.go
+++ b/internal/controller/utils/utils.go
@@ -27,8 +27,10 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/go-logr/logr"
 	configv1 "github.com/openshift/api/config/v1"
 	imagev1 "github.com/openshift/api/image/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -462,6 +464,38 @@ func GetOpenshiftVersion(k8sClient client.Client, ctx context.Context) (string, 
 		return "", "", fmt.Errorf("failed to parse cluster version: %s", clusterVersion.Status.Desired.Version)
 	}
 	return openshift_versions[0], openshift_versions[1], nil
+}
+
+const rosaClusterResourceName = "cluster"
+
+// RosaOKPProductEnv returns the OLS_ROSA_PRODUCT env var for ROSA clusters, or nil when
+// the cluster is not ROSA. On ROSA, External topology maps to HCP; all other topologies
+// map to Classic (OLS-1894).
+func RosaOKPProductEnv(k8sClient client.Client, ctx context.Context, log logr.Logger) (*corev1.EnvVar, error) {
+	console := &operatorv1.Console{}
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: rosaClusterResourceName}, console); err != nil {
+		return nil, fmt.Errorf("failed to get console cluster: %w", err)
+	}
+	if console.Spec.Customization.Brand != operatorv1.BrandROSA {
+		return nil, nil
+	}
+
+	infrastructure := &configv1.Infrastructure{}
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: rosaClusterResourceName}, infrastructure); err != nil {
+		return nil, fmt.Errorf("failed to get infrastructure cluster: %w", err)
+	}
+
+	topology := infrastructure.Status.ControlPlaneTopology
+	product := RosaOKPProductClassic
+	if topology == configv1.ExternalTopologyMode {
+		product = RosaOKPProductHCP
+	} else {
+		log.Info("ROSA detected, using Classic OKP product", "controlPlaneTopology", topology)
+	}
+	return &corev1.EnvVar{
+		Name:  OLSRosaProductEnvVar,
+		Value: product,
+	}, nil
 }
 
 // GeneratePostgresSelectorLabels returns selector labels for Postgres components


### PR DESCRIPTION
## Description

Implements [OLS-1894](https://redhat.atlassian.net/browse/OLS-1894): operator-managed ROSA-aware OKP product scoping for the app-server.

When `!byokRAGOnly`, the operator detects ROSA at startup and sets `OLS_ROSA_PRODUCT` on the app-server container:

| Condition | `OLS_ROSA_PRODUCT` |
|-----------|-------------------|
| Not ROSA | omitted |
| ROSA + `External` topology | `red_hat_openshift_service_on_aws` (HCP) |
| ROSA + any other topology | `red_hat_openshift_service_on_aws_classic_architecture` (Classic) |

Detection reads:
- `console.operator.openshift.io/cluster` → `.spec.customization.brand`
- `infrastructure.config.openshift.io/cluster` → `.status.controlPlaneTopology`

Detection runs once at operator startup (same pattern as cluster version). API/RBAC failures log a warning and omit the env var; reconciliation continues. Classic topology defaulting logs `controlPlaneTopology` at info level for supportability.

**Operator-only PR** — `infrastructures` RBAC is in `config/rbac/role.yaml` only; bundle CSV `clusterPermissions` follow-up required for OLM installs.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
  https://redhat.atlassian.net/browse/OLS-1894
- Closes #
  https://redhat.atlassian.net/browse/OLS-1894
- Spec PR: https://github.com/openshift/lightspeed-operator/pull/1790

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

- `make test` — pass
- `make lint` — pass (0 issues)
- Manual (ROSA Classic): verify app-server pod has `OLS_ROSA_PRODUCT=red_hat_openshift_service_on_aws_classic_architecture`
- Manual (ROSA HCP): verify `OLS_ROSA_PRODUCT=red_hat_openshift_service_on_aws`
- Manual (non-ROSA OCP): verify env var absent
- Manual (`byokRAGOnly: true`): verify env var absent

**Out of scope:** E2E automation; lightspeed-service consumption of `OLS_ROSA_PRODUCT` (separate PR); bundle CSV update for `infrastructures` RBAC.