### PR TITLE
OLS-3312: Update bundle — RHOKP replaces ocp-rag, refresh images from Quay

### DIFF
--- a/.ai/spec/how/config-generation.md
+++ b/.ai/spec/how/config-generation.md
@@ -209,7 +209,7 @@ These schemas are created by the bootstrap script.
 | TLS certs | Service-ca operator or user-provided secret | Path: `/etc/certs/lightspeed-tls/` |
 | BYOK RAG indexes | CR `spec.ols.rag[]` | Local FAISS indexes only; empty list when no BYOK RAG configured |
 | `solr_hybrid` | Operator defaults + `!byokRAGOnly` | OCP product docs via OKP Solr at `http://localhost:9080` |
-| RHOKP image | `--rhokp-image` flag | Sidecar image; not in `related_images.json` until bundle productization |
+| RHOKP image | `--rhokp-image` flag | Sidecar image; default from `related_images.json` (`rhokp`); listed in bundle `relatedImages` |
 | ROSA product | Console brand + Infrastructure topology (detected at operator startup) | `OLS_ROSA_PRODUCT` env var on app-server when brand is `ROSA` (not in config YAML). `External` → HCP product; otherwise Classic. Omitted on detection failure or non-ROSA. |
 | MCP servers | CR `spec.mcpServers[]` + `spec.ols.introspectionEnabled` | Feature gated by `MCPServer` gate |
 | Tool filtering | CR `spec.ols.toolFilteringConfig` | Feature gated by `ToolFiltering` gate; requires MCP servers |

--- a/.ai/spec/how/deployment-generation.md
+++ b/.ai/spec/how/deployment-generation.md
@@ -109,7 +109,7 @@ Affinity and topology spread constraints are not exposed on `Config` (CRD size);
 | Volume configmaps | Generated ConfigMaps | OLS config, nginx config, MCP server config |
 | Proxy env vars | `utils.GetProxyEnvVars()` | HTTP_PROXY, HTTPS_PROXY, NO_PROXY from cluster |
 | RAG images | CR `spec.ols.rag[].image` | Container images for init containers |
-| RHOKP image | `--rhokp-image` flag | RHOKP sidecar container image (default in code; not in `related_images.json` yet) |
+| RHOKP image | `--rhokp-image` flag | RHOKP sidecar container image; default from `related_images.json` (`rhokp`) |
 
 ## Agentic Controller Deployment (OLM-managed)
 

--- a/.ai/spec/what/app-server.md
+++ b/.ai/spec/what/app-server.md
@@ -103,7 +103,7 @@ The App Server is the backend deployment for OpenShift Lightspeed. It runs the l
 32. The RHOKP sidecar's ~75 GiB ephemeral storage requirement is unchanged by this convention — it applies only to CPU and memory.
 
 ### RHOKP Image
-33. The RHOKP sidecar image is set via the operator `--rhokp-image` startup flag (default in `utils.RHOOKPImageDefault`). It is not listed in `related_images.json` until productized in the OLM bundle.
+33. The RHOKP sidecar image is set via the operator `--rhokp-image` startup flag. Default comes from `related_images.json` entry `rhokp` (`utils.RHOOKPImageDefault` / `imageDefaultOr`). The OLM bundle lists it in CSV `spec.relatedImages` and passes the image via `--rhokp-image` on the manager deployment.
 
 ## Planned Changes
 

--- a/.ai/spec/what/bundle-composition.md
+++ b/.ai/spec/what/bundle-composition.md
@@ -48,6 +48,7 @@ The lightspeed-operator OLM bundle installs both the lightspeed-operator control
 | Agentic controller startup flags | CSV deployment spec args | Operand image overrides for the agentic controller |
 | Agentic controller `--sandbox-mode` | CSV deployment spec args | `bare-pod` (default) or `sandbox-claim` — selects sandbox provisioning strategy |
 | Agentic controller `--agentic-sandbox-image` | CSV deployment spec args | [PLANNED: OLS-3236] Sandbox container image (default: `:main` tag, overridable) |
+| Lightspeed controller `--rhokp-image` | `cmd/main.go` flag; CSV deployment spec args; `related_images.json` (`rhokp`) | RHOKP sidecar image (external product image; `:latest` until digest pinned) |
 | Lightspeed controller `--alerts-adapter-image` | `cmd/main.go` flag; CSV deployment spec args; `related_images.json` (`lightspeed-agentic-alerts-adapter`) | Alerts adapter container image (interim tags until productized) |
 | Lightspeed controller `--agentic-console-image` | CSV deployment spec args; `related_images.json` (`lightspeed-agentic-console-plugin`) | Agentic console plugin container image (interim `:main` until productized) |
 

--- a/.ai/spec/what/system-overview.md
+++ b/.ai/spec/what/system-overview.md
@@ -62,7 +62,7 @@ The OpenShift Lightspeed Operator is a Kubernetes operator that manages the life
 | `--postgres-image` | string | built-in default | Override PostgreSQL image |
 | `--openshift-mcp-server-image` | string | built-in default | Override OpenShift MCP server image |
 | `--dataverse-exporter-image` | string | built-in default | Override dataverse exporter image |
-| `--ocp-rag-image` | string | built-in default | Override OCP RAG database image |
+| `--rhokp-image` | string | `related_images.json` (`rhokp`) | Override RHOKP (Solr / OKP) sidecar image |
 
 ### Environment Variables
 

--- a/.cursor/skills/update-bundle/SKILL.md
+++ b/.cursor/skills/update-bundle/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: update-bundle
 description: >-
-  Sync related_images.json from Konflux and regenerate the OLM bundle. Pass mode
-  dev (CI quay images, current version) or release (stable images, version bump
-  — full steps in /version-update). Use for PR bundle/CI fixes or shipping to
-  main.
+  Sync related_images.json from Quay (oras + konflux_prefix/revision in
+  related_images.json) and regenerate the OLM bundle. Pass mode dev (CI quay) or
+  release (stable images, version bump — /version-update). Do not use oc.
 disable-model-invocation: true
 ---
 
@@ -17,60 +16,53 @@ One entry point, two modes:
 /update-bundle release X.Y.Z    # same as /version-update X.Y.Z
 ```
 
-Releases ship from `main` (no separate release branch).
-
 | | **dev** | **release** |
 |---|---------|-------------|
-| **When** | PR/CI, local e2e, stale Konflux digests | Shipping to `main` |
-| **Snapshot** | `-r ci` | `-r stable` |
+| **When** | PR/CI, local e2e | Shipping to `main` |
+| **Refresh** | `hack/related_images_from_quay.sh -r ci` | `hack/related_images_from_quay.sh -r stable` |
 | **Image hosts** | `quay.io/redhat-user-workloads/...` | `registry.redhat.io/openshift-lightspeed/...` |
-| **Bundle version** | Keep current | Bump to `X.Y.Z` |
-| **Full steps** | Below | [version-update/SKILL.md](../version-update/SKILL.md) |
+| **Bundle version** | Keep current CSV `spec.version` | Bump to `X.Y.Z` |
 
-**Not required** for reconciliation-only changes under `internal/controller/`, tests, or docs.
+**Do not use `oc` or Konflux snapshots** for routine bundle updates. `related_images.json` already carries `konflux_prefix`, `stable_prefix`, and `revision` (git tag on Quay). Resolve digests with `oras`.
 
 ---
 
 ## Development mode (`dev`)
 
-### Step 1: Refresh `related_images.json`
+### Step 1: Refresh `related_images.json` from Quay
 
-Requires Konflux `oc login` in namespace `crt-nshift-lightspeed-tenant`. See `README.md` (Update Bundle from Snapshot).
+**Prerequisite:** `oras` and `jq` on PATH.
 
 ```bash
-./hack/snapshot_to_image_list.sh -s <ols-snapshot> -b <ols-bundle-snapshot> -r ci -o related_images.json
+./hack/related_images_from_quay.sh -l -r ci -o related_images.json
 ```
 
-`-r ci` is the default; images stay on `quay.io/redhat-user-workloads/...`.
+**How it works** (loops `related_images.json`):
 
-**Preserve entries the snapshot does not provide** (script keeps some from the existing file):
+| Field | Role |
+|-------|------|
+| `konflux_prefix` | Quay repo base (e.g. `quay.io/.../ols/lightspeed-operator`) |
+| `revision` | Git SHA tag on Quay → `oras resolve <prefix>:<revision>` |
+| `stable_prefix` | Product registry path; substituted when `-r stable` |
+| (no `konflux_prefix`) | External/manual pin — image left unchanged |
 
-- `lightspeed-to-dataverse-exporter`
-- Operands not yet in Konflux snapshots — merge manually after the script runs
+**`-l` (latest):** for each Konflux operand, discover the newest build on Quay (`:main` digest mapped to a git SHA tag, or the most recently pushed SHA tag), update `revision`, then resolve the digest. Use this for dev/PR bundle updates so operands are not stuck on an old snapshot pin.
 
-**Bundle image:** README documents backing up `lightspeed-operator-bundle` before refresh and restoring it when only operand images change.
+Without `-l`, only re-resolves digests for `revision` values already in the file (legacy pin mode).
 
-If `oc` is unavailable, resolve digests manually (e.g. `oras resolve` against Quay revision tags).
+**Entry types:** see `docs/olm-bundle-management.md` (Related Images Management).
+
+**Optional:** `hack/snapshot_to_image_list.sh` (requires `oc` login) only when you need to **discover new revisions** from a Konflux snapshot; then re-run `related_images_from_quay.sh`.
+
+**Bundle entry:** when only operand images change, back up `lightspeed-operator-bundle` per `README.md` before refresh if you do not intend to update the bundle image.
 
 ### Step 2: Regenerate bundle (current version)
 
 ```bash
-# From bundle/manifests/lightspeed-operator.clusterserviceversion.yaml spec.version
 make bundle BUNDLE_TAG=<current-version>
 ```
 
-If CRD/RBAC changed:
-
-```bash
-make manifests
-make bundle BUNDLE_TAG=<current-version>
-```
-
-Or:
-
-```bash
-hack/update_bundle.sh -v <current-version> -i related_images.json
-```
+If CRD/RBAC changed: `make manifests` first.
 
 ### Step 3: Verify
 
@@ -81,28 +73,39 @@ git diff related_images.json bundle/
 
 Confirm:
 
-- [ ] Images use Konflux quay hosts (not `registry.redhat.io`)
+- [ ] Dev: images on `quay.io/redhat-user-workloads/...` (or external `registry.redhat.io` pins)
+- [ ] `snapshot_component`, `konflux_prefix`, `stable_prefix` preserved; `image` digests updated
 - [ ] CSV `spec.relatedImages` and deployment args match `related_images.json`
-- [ ] Bundle CRD matches source when CRD changed
+- [ ] **Konflux operands current:** dev refresh uses `-l` so `revision` tracks the latest Quay build (not only digest re-resolve for stale SHAs)
+
+**Operator / CSV flag check** (when deployment-patch args changed):
+
+```bash
+REV=$(jq -r '.[] | select(.name=="lightspeed-operator") | .revision' related_images.json)
+git merge-base --is-ancestor <commit-that-added-flag> "$REV" \
+  && echo "operator revision includes flag" || echo "STALE: bump operator revision"
+```
+
+Example: RHOKP flag landed in merge `912ea22c` (#1653); revision `7bc611cb` (Jul 10 mintmaker) is **before** that and must not be used with `--rhokp-image` in the CSV.
+
+Quick Quay check for latest `main`:
+
+```bash
+HEAD_SHA=$(git rev-parse origin/main)
+oras resolve quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator:"$HEAD_SHA" \
+  && echo "latest main is on Quay — consider updating operator revision"
+```
 
 ### Step 4: Commit (only when user asks)
-
-Do not commit unless requested. Dev quay images are for PR validation; **`main` gets stable images via `/version-update`**.
 
 ---
 
 ## Release mode (`release X.Y.Z`)
 
-Use **`/version-update X.Y.Z`** or follow [version-update/SKILL.md](../version-update/SKILL.md) in full. That skill includes:
-
-1. Refresh `related_images.json` with `-r stable`
-2. Bump `bundle.Dockerfile` and CSV version (with `sed` examples)
-3. `make bundle BUNDLE_TAG=X.Y.Z` or `hack/update_bundle.sh`
-4. Verify checklist and common mistakes
-
-Do not skip the version-update steps when releasing.
+Follow `version-update/SKILL.md` in full: `-r stable`, version bump, `make bundle`.
 
 ## Related
 
-- `/version-update` — full release workflow
-- `docs/olm-bundle-management.md` — bundle structure
+- `/version-update` — release workflow
+- `docs/olm-bundle-management.md`
+- `hack/related_images_from_quay.sh`

--- a/.cursor/skills/version-update/SKILL.md
+++ b/.cursor/skills/version-update/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: version-update
 description: >-
-  Release workflow for main: refresh related_images.json with stable Konflux
-  images (-r stable), bump bundle/CSV version, regenerate and validate the
-  bundle. Equivalent to /update-bundle release X.Y.Z. For PR/CI at the current
-  version, use /update-bundle dev instead.
+  Release workflow for main: refresh related_images.json from Quay (-r stable
+  via hack/related_images_from_quay.sh), bump bundle/CSV version, regenerate
+  and validate. Equivalent to /update-bundle release X.Y.Z.
 disable-model-invocation: true
 ---
 
@@ -16,17 +15,19 @@ Not for PR/CI — use `/update-bundle dev`.
 
 ## Step 1: Refresh `related_images.json` (stable)
 
-Requires Konflux `oc login` in namespace `crt-nshift-lightspeed-tenant`. See `README.md` (Update Bundle from Snapshot).
+**Prerequisite:** `oras` and `jq`. Do **not** rely on `oc`.
 
 ```bash
-./hack/snapshot_to_image_list.sh -s <ols-snapshot> -b <ols-bundle-snapshot> -r stable -o related_images.json
+./hack/related_images_from_quay.sh -r stable -o related_images.json
 ```
 
-Use `-r preview` only for tech-preview paths (`registry.redhat.io/openshift-lightspeed-tech-preview/...`).
+Use `-r preview` for tech-preview paths (`registry.redhat.io/openshift-lightspeed-tech-preview/...`).
 
-Images must land on **`registry.redhat.io/openshift-lightspeed/...`** (not Konflux quay).
+Resolves `oras resolve <konflux_prefix>:<revision>`, then rewrites `konflux_prefix` → `stable_prefix` in the digest URL. External entries (no `konflux_prefix`) are unchanged.
 
-Preserve snapshot-less entries per `hack/snapshot_to_image_list.sh` (e.g. dataverse-exporter, interim operands not in Konflux). README documents backing up `lightspeed-operator-bundle` when only operand images change.
+Konflux-managed entries must keep `konflux_prefix` and `stable_prefix`. See `docs/olm-bundle-management.md`.
+
+Optional: `hack/snapshot_to_image_list.sh` only to **discover new `revision` values** from Konflux when `oc` is available; then run `related_images_from_quay.sh` again.
 
 If CRD/RBAC changed since last bundle, run `make manifests` before regenerating the bundle (Step 4).
 
@@ -118,7 +119,8 @@ git diff bundle.Dockerfile related_images.json bundle/
 ```
 
 Confirm:
-- [ ] `related_images.json` uses stable `registry.redhat.io` images
+- [ ] `related_images.json` uses stable `registry.redhat.io` images for Konflux-managed entries (via `konflux_prefix` → `stable_prefix` mapping)
+- [ ] External/manual entries (no `snapshot_component`) are pinned correctly and unchanged by prefix mapping
 - [ ] `bundle.Dockerfile` has `release=X.Y.Z` and `version=X.Y.Z`
 - [ ] CSV `name` field: `lightspeed-operator.vX.Y.Z` (with `v` prefix)
 - [ ] CSV `version` field: `X.Y.Z` (without prefix)
@@ -151,10 +153,12 @@ git commit -m "OLS-XXXX: Release vX.Y.Z"
 ❌ Not regenerating the bundle after changes
 ❌ Mismatched version numbers between files
 ❌ Bumping version without refreshing stable images (`-r stable`)
+❌ Konflux-managed entries missing `konflux_prefix` / `stable_prefix` (stable refresh cannot map to product registry)
 ❌ Merging dev quay images from `/update-bundle dev` to `main` without re-running this skill
 
 ## Related
 
-- `/update-bundle dev` — PR/CI bundle sync (Konflux `-r ci`, current version)
+- `/update-bundle dev` — PR/CI (`related_images_from_quay.sh -r ci`)
 - `docs/olm-bundle-management.md` — bundle structure
+- `hack/related_images_from_quay.sh` — Quay digest refresh
 - `hack/release_tools.md` — release tooling

--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     console.openshift.io/operator-monitoring-default: "true"
-    createdAt: "2026-07-10T02:51:10Z"
+    createdAt: "2026-07-13T15:29:35Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -201,7 +201,7 @@ spec:
             path: ols.additionalCAConfigMapRef
             x-descriptors:
               - urn:alm:descriptor:com.tectonic.ui:advanced
-          - description: Only use BYOK RAG sources, ignore the OpenShift documentation RAG
+          - description: Only use BYOK RAG sources. Disables OKP (RHOKP sidecar, solr_hybrid config, and built-in OCP documentation retrieval).
             displayName: Only use BYOK RAG sources
             path: ols.byokRAGOnly
             x-descriptors:
@@ -297,6 +297,9 @@ spec:
           - description: MCP server container settings.
             displayName: MCP Server Container
             path: ols.deployment.mcpServer
+          - description: RHOKP sidecar container settings (Solr / OKP).
+            displayName: RHOKP Container
+            path: ols.deployment.rhokp
           - description: Pull secrets for BYOK RAG images from image registries requiring authentication
             displayName: Image Pull Secrets
             path: ols.imagePullSecrets
@@ -388,18 +391,18 @@ spec:
           - description: Type of the limiter
             displayName: 'Limiter Type. Accepted Values: cluster_limiter, user_limiter.'
             path: ols.quotaHandlersConfig.limitersConfig[0].type
-          - description: RAG databases
-            displayName: RAG Databases
+          - description: BYOK RAG databases (bring-your-own container images with FAISS vector indexes).
+            displayName: BYOK RAG Databases
             path: ols.rag
             x-descriptors:
               - urn:alm:descriptor:com.tectonic.ui:advanced
-          - description: The URL of the container image to use as a RAG source
+          - description: The URL of the container image to use as a BYOK RAG source
             displayName: Image
             path: ols.rag[0].image
-          - description: The Index ID of the RAG database. Only needed if there are multiple indices in the database.
+          - description: The Index ID of the BYOK RAG database. Only needed if there are multiple indices in the database.
             displayName: Index ID
             path: ols.rag[0].indexID
-          - description: The path to the RAG database inside of the container image
+          - description: The path to the BYOK RAG database inside of the container image
             displayName: Index Path in the Image
             path: ols.rag[0].indexPath
           - description: Persistent Storage Configuration
@@ -422,6 +425,7 @@ spec:
                 - tls.crt: Server certificate (PEM format) - REQUIRED
                 - tls.key: Private key (PEM format) - REQUIRED
                 - ca.crt: CA certificate for console proxy trust (PEM format) - OPTIONAL
+
 
               If ca.crt is not provided, the OpenShift Console proxy will use the default system trust store.
             displayName: TLS Certificate Secret Reference
@@ -779,6 +783,7 @@ spec:
               resources:
                 - apiservers
                 - clusterversions
+                - infrastructures
               verbs:
                 - get
                 - list
@@ -920,14 +925,14 @@ spec:
                       - --metrics-bind-address=:8443
                       - --secure-metrics-server
                       - --cert-dir=/etc/tls/private
-                      - --service-image=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service@sha256:fd5a69605caa32df02095d17ab75a2353e704562e9b521df8632a0ebc50d2a55
-                      - --console-image=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console@sha256:f987b02ad62099c5aee760c038135f50c959249cb09154dd89a27e52df6f77c9
-                      - --postgres-image=registry.redhat.io/rhel9/postgresql-16@sha256:42f385ac3c9b8913426da7c57e70bc6617cd237aaf697c667f6385a8c0b0118b
-                      - --openshift-mcp-server-image=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/openshift-mcp-server@sha256:ca69b8efcf97bf02bbcda126b7787dd658841ee00203a86ee22e3f36ff73c7ce
                       - --dataverse-exporter-image=registry.redhat.io/lightspeed-core/dataverse-exporter-rhel9@sha256:1c7ffaead23adfb1dc6bd3adfe75c80f284d6d31f13ca427d754703c78514cb2
-                      - --ocp-rag-image=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-ocp-rag@sha256:7155419a17b950e48266e18da7328cc127d44a4923e76c66295b6079ea3f93d2
-                      - --agentic-console-image=__REPLACE_LIGHTSPEED_AGENTIC_CONSOLE_PLUGIN__
-                      - --alerts-adapter-image=__REPLACE_LIGHTSPEED_AGENTIC_ALERTS_ADAPTER__
+                      - --postgres-image=registry.redhat.io/rhel9/postgresql-16@sha256:42f385ac3c9b8913426da7c57e70bc6617cd237aaf697c667f6385a8c0b0118b
+                      - --service-image=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service@sha256:f2eed588a48a808f4f4a30319a34d7fcbc30a7383c14e103c0664ea759cc8b75
+                      - --console-image=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console@sha256:36ec4cf72eb7d3f2e6c2af9f7d5612382c9c2dc20d8acee4ccac3ea0ff8bd33d
+                      - --openshift-mcp-server-image=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/openshift-mcp-server@sha256:ca69b8efcf97bf02bbcda126b7787dd658841ee00203a86ee22e3f36ff73c7ce
+                      - --agentic-console-image=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-console@sha256:2b472ebdac13b6cdeffe057c9f28b7cb43a4bf767865d781572c4c11dedf4a49
+                      - --alerts-adapter-image=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-alerts-adapter@sha256:9d4c8c8e91440ce625c5c936594a9b1048fa7841890906facba6c398da925369
+                      - --rhokp-image=registry.redhat.io/offline-knowledge-portal/rhokp-rhel9:latest
                     command:
                       - /manager
                     env:
@@ -935,7 +940,7 @@ spec:
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.annotations['olm.targetNamespaces']
-                    image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator@sha256:71a13f528f4af0ac81841a9b20e4c7391effd2541e354064c9fb6d94a4553513
+                    image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator@sha256:552332d92b58a2082a63e679a4b343e21f67269cd85582dc265b5c6a4379bc13
                     imagePullPolicy: Always
                     livenessProbe:
                       httpGet:
@@ -1056,12 +1061,16 @@ spec:
     - name: lightspeed-postgresql
       image: registry.redhat.io/rhel9/postgresql-16@sha256:42f385ac3c9b8913426da7c57e70bc6617cd237aaf697c667f6385a8c0b0118b
     - name: lightspeed-service-api
-      image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service@sha256:fd5a69605caa32df02095d17ab75a2353e704562e9b521df8632a0ebc50d2a55
+      image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service@sha256:f2eed588a48a808f4f4a30319a34d7fcbc30a7383c14e103c0664ea759cc8b75
     - name: lightspeed-console-plugin
-      image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console@sha256:f987b02ad62099c5aee760c038135f50c959249cb09154dd89a27e52df6f77c9
+      image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console@sha256:36ec4cf72eb7d3f2e6c2af9f7d5612382c9c2dc20d8acee4ccac3ea0ff8bd33d
     - name: lightspeed-operator
-      image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator@sha256:71a13f528f4af0ac81841a9b20e4c7391effd2541e354064c9fb6d94a4553513
+      image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator@sha256:552332d92b58a2082a63e679a4b343e21f67269cd85582dc265b5c6a4379bc13
     - name: openshift-mcp-server
       image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/openshift-mcp-server@sha256:ca69b8efcf97bf02bbcda126b7787dd658841ee00203a86ee22e3f36ff73c7ce
-    - name: lightspeed-ocp-rag
-      image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-ocp-rag@sha256:7155419a17b950e48266e18da7328cc127d44a4923e76c66295b6079ea3f93d2
+    - name: lightspeed-agentic-console-plugin
+      image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-console@sha256:2b472ebdac13b6cdeffe057c9f28b7cb43a4bf767865d781572c4c11dedf4a49
+    - name: lightspeed-agentic-alerts-adapter
+      image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-alerts-adapter@sha256:9d4c8c8e91440ce625c5c936594a9b1048fa7841890906facba6c398da925369
+    - name: rhokp
+      image: registry.redhat.io/offline-knowledge-portal/rhokp-rhel9:latest

--- a/bundle/manifests/ols.openshift.io_olsconfigs.yaml
+++ b/bundle/manifests/ols.openshift.io_olsconfigs.yaml
@@ -462,7 +462,17 @@ spec:
                 maxItems: 20
                 type: array
               ols:
-                description: OLSSpec defines the desired state of OLS deployment.
+                description: |-
+                  OLSSpec defines the desired state of OLS deployment.
+
+                  OKP (Offline Knowledge Portal) / Solr hybrid RAG is operator-managed, not configured on this CR:
+                    - Enabled by default. The operator deploys the RHOKP sidecar and writes ols_config.solr_hybrid
+                      into olsconfig.yaml (Solr URL, hybrid tuning, and related keys use operator defaults).
+                    - The app-server pod receives OCP_CLUSTER_VERSION for Solr chunk_filter_query resolution.
+                    - OCP documentation is retrieved via the search_openshift_documentation tool (Solr hybrid), not
+                      direct prompt RAG. BYOK content remains on spec.rag (FAISS indexes).
+                    - Set byokRAGOnly to disable OKP: no RHOKP sidecar, no solr_hybrid section, and no built-in
+                      OCP documentation retrieval—only BYOK FAISS indexes from spec.rag are used.
                 properties:
                   additionalCAConfigMapRef:
                     description: Additional CA certificates for TLS communication
@@ -480,8 +490,8 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   byokRAGOnly:
-                    description: Only use BYOK RAG sources, ignore the OpenShift documentation
-                      RAG
+                    description: Only use BYOK RAG sources. Disables OKP (RHOKP sidecar,
+                      solr_hybrid config, and built-in OCP documentation retrieval).
                     type: boolean
                   conversationCache:
                     description: Conversation cache settings
@@ -1280,6 +1290,72 @@ spec:
                                 type: object
                             type: object
                         type: object
+                      rhokp:
+                        description: RHOKP sidecar container settings (Solr / OKP).
+                        properties:
+                          resources:
+                            description: |-
+                              Resource requirements (CPU, memory)
+                              Uses standard corev1.ResourceRequirements
+                            properties:
+                              claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
+
+                                  This field depends on the
+                                  DynamicResourceAllocation feature gate.
+
+                                  This field is immutable. It can only be set for containers.
+                                items:
+                                  description: ResourceClaim references one entry
+                                    in PodSpec.ResourceClaims.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used. It makes that resource available
+                                        inside a container.
+                                      type: string
+                                    request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                            type: object
+                        type: object
                     type: object
                   imagePullSecrets:
                     description: Pull secrets for BYOK RAG images from image registries
@@ -1435,23 +1511,25 @@ spec:
                         type: array
                     type: object
                   rag:
-                    description: RAG databases
+                    description: BYOK RAG databases (bring-your-own container images
+                      with FAISS vector indexes).
                     items:
-                      description: RAGSpec defines how to retrieve RAG databases.
+                      description: RAGSpec defines a BYOK RAG database (container
+                        image and index path).
                       properties:
                         image:
                           description: The URL of the container image to use as a
-                            RAG source
+                            BYOK RAG source
                           type: string
                         indexID:
                           default: ""
-                          description: The Index ID of the RAG database. Only needed
-                            if there are multiple indices in the database.
+                          description: The Index ID of the BYOK RAG database. Only
+                            needed if there are multiple indices in the database.
                           type: string
                         indexPath:
                           default: /rag/vector_db
-                          description: The path to the RAG database inside of the
-                            container image
+                          description: The path to the BYOK RAG database inside of
+                            the container image
                           type: string
                       required:
                       - image

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -102,7 +102,6 @@ var (
 		"alerts-adapter":             utils.AlertsAdapterImageDefault,
 		"openshift-mcp-server-image": utils.OpenShiftMCPServerImageDefault,
 		"dataverse-exporter-image":   utils.DataverseExporterImageDefault,
-		"ocp-rag-image":              utils.OcpRagImageDefault,
 		"rhokp-image":                utils.RHOOKPImageDefault,
 	}
 )
@@ -121,7 +120,7 @@ func init() {
 
 // overrideImages overrides the default images with the images provided by the user.
 // If an image is not provided, the default is used.
-func overrideImages(serviceImage string, consoleImage string, agenticConsoleImage string, alertsAdapterImage string, postgresImage string, openshiftMCPServerImage string, dataverseExporterImage string, ocpRagImage string, rhokpImage string) map[string]string {
+func overrideImages(serviceImage string, consoleImage string, agenticConsoleImage string, alertsAdapterImage string, postgresImage string, openshiftMCPServerImage string, dataverseExporterImage string, rhokpImage string) map[string]string {
 	res := defaultImages
 	if serviceImage != "" {
 		res["lightspeed-service"] = serviceImage
@@ -143,9 +142,6 @@ func overrideImages(serviceImage string, consoleImage string, agenticConsoleImag
 	}
 	if dataverseExporterImage != "" {
 		res["dataverse-exporter-image"] = dataverseExporterImage
-	}
-	if ocpRagImage != "" {
-		res["ocp-rag-image"] = ocpRagImage
 	}
 	if rhokpImage != "" {
 		res["rhokp-image"] = rhokpImage
@@ -183,7 +179,6 @@ func main() {
 	var postgresImage string
 	var openshiftMCPServerImage string
 	var dataverseExporterImage string
-	var ocpRagImage string
 	var rhokpImage string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -203,7 +198,6 @@ func main() {
 	flag.StringVar(&postgresImage, "postgres-image", utils.PostgresServerImageDefault, "The image of the PostgreSQL server.")
 	flag.StringVar(&openshiftMCPServerImage, "openshift-mcp-server-image", utils.OpenShiftMCPServerImageDefault, "The image of the OpenShift MCP server container.")
 	flag.StringVar(&dataverseExporterImage, "dataverse-exporter-image", utils.DataverseExporterImageDefault, "The image of the dataverse exporter container.")
-	flag.StringVar(&ocpRagImage, "ocp-rag-image", utils.OcpRagImageDefault, "The image with the OCP RAG databases.")
 	flag.StringVar(&rhokpImage, "rhokp-image", utils.RHOOKPImageDefault, "The RH Offline Knowledge Portal (Solr) sidecar image for Solr hybrid RAG.")
 	opts := zap.Options{
 		Development: true,
@@ -217,7 +211,7 @@ func main() {
 		namespace = getWatchNamespace()
 	}
 
-	imagesMap := overrideImages(serviceImage, consoleImage, agenticConsoleImage, alertsAdapterImage, postgresImage, openshiftMCPServerImage, dataverseExporterImage, ocpRagImage, rhokpImage)
+	imagesMap := overrideImages(serviceImage, consoleImage, agenticConsoleImage, alertsAdapterImage, postgresImage, openshiftMCPServerImage, dataverseExporterImage, rhokpImage)
 	setupLog.Info("Images setting loaded", "images", listImages())
 
 	setupLog.Info("Starting the operator", "metricsAddr", metricsAddr, "probeAddr", probeAddr, "certDir", certDir, "certName", certName, "keyName", keyName, "namespace", namespace)

--- a/config/default/deployment-patch.yaml
+++ b/config/default/deployment-patch.yaml
@@ -18,9 +18,6 @@
   value: --openshift-mcp-server-image=__REPLACE_OPENSHIFT_MCP_SERVER__
 - op: add
   path: /spec/template/spec/containers/0/args/-
-  value: --ocp-rag-image=__REPLACE_LIGHTSPEED_OCP_RAG__
-- op: add
-  path: /spec/template/spec/containers/0/args/-
   value: --agentic-console-image=__REPLACE_LIGHTSPEED_AGENTIC_CONSOLE_PLUGIN__
 - op: add
   path: /spec/template/spec/containers/0/args/-

--- a/config/manifests/bases/lightspeed-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/lightspeed-operator.clusterserviceversion.yaml
@@ -170,8 +170,8 @@ spec:
         path: ols.additionalCAConfigMapRef
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - description: Only use BYOK RAG sources, ignore the OpenShift documentation
-          RAG
+      - description: Only use BYOK RAG sources. Disables OKP (RHOKP sidecar, solr_hybrid
+          config, and built-in OCP documentation retrieval).
         displayName: Only use BYOK RAG sources
         path: ols.byokRAGOnly
         x-descriptors:
@@ -267,6 +267,9 @@ spec:
       - description: MCP server container settings.
         displayName: MCP Server Container
         path: ols.deployment.mcpServer
+      - description: RHOKP sidecar container settings (Solr / OKP).
+        displayName: RHOKP Container
+        path: ols.deployment.rhokp
       - description: Pull secrets for BYOK RAG images from image registries requiring
           authentication
         displayName: Image Pull Secrets
@@ -362,19 +365,20 @@ spec:
       - description: Type of the limiter
         displayName: 'Limiter Type. Accepted Values: cluster_limiter, user_limiter.'
         path: ols.quotaHandlersConfig.limitersConfig[0].type
-      - description: RAG databases
-        displayName: RAG Databases
+      - description: BYOK RAG databases (bring-your-own container images with FAISS
+          vector indexes).
+        displayName: BYOK RAG Databases
         path: ols.rag
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - description: The URL of the container image to use as a RAG source
+      - description: The URL of the container image to use as a BYOK RAG source
         displayName: Image
         path: ols.rag[0].image
-      - description: The Index ID of the RAG database. Only needed if there are multiple
-          indices in the database.
+      - description: The Index ID of the BYOK RAG database. Only needed if there are
+          multiple indices in the database.
         displayName: Index ID
         path: ols.rag[0].indexID
-      - description: The path to the RAG database inside of the container image
+      - description: The path to the BYOK RAG database inside of the container image
         displayName: Index Path in the Image
         path: ols.rag[0].indexPath
       - description: Persistent Storage Configuration
@@ -397,6 +401,7 @@ spec:
             - tls.crt: Server certificate (PEM format) - REQUIRED
             - tls.key: Private key (PEM format) - REQUIRED
             - ca.crt: CA certificate for console proxy trust (PEM format) - OPTIONAL
+
 
           If ca.crt is not provided, the OpenShift Console proxy will use the default system trust store.
         displayName: TLS Certificate Secret Reference

--- a/docs/olm-bundle-management.md
+++ b/docs/olm-bundle-management.md
@@ -114,15 +114,48 @@ make bundle-push BUNDLE_IMG=quay.io/myorg/lightspeed-operator-bundle:v0.1.0
 
 **Purpose:** `related_images.json` is the **single source of truth** for operand images and operator deployment wiring. Each operand entry may include `operator_arg` (passed as `--<operator_arg>=<image>` to the operator) or `operator_target: image` for the operator container itself. `hack/generate_deployment_patch.sh` (via `make manifests`) generates `config/default/deployment-patch.yaml`; `hack/update_bundle.sh` and `make deploy` substitute image digests from the same file.
 
-**Format:**
+**Format:** Each entry has at least `name` and `image`. Optional fields depend on how the image is sourced (see **Entry types** below).
+
+**Entry types:**
+
+Entries fall into two categories. Do not add inline comments to `related_images.json` (JSON does not support them); use this section as the reference.
+
+| Type | When to use | Required fields | Optional Konflux fields |
+|------|-------------|-----------------|-------------------------|
+| **Konflux-managed** | Image built in the OLS Konflux tenant | `name`, `image`, `revision` | `snapshot_component`, `konflux_prefix`, `stable_prefix`; add `snapshot_source: "bundle"` only for `lightspeed-operator-bundle` |
+| **External / manual** | Third-party or Red Hat product images not in the OLS snapshot | `name`, `image`, `revision: ""` | None — pin `image` yourself; snapshot refresh leaves these unchanged |
+
+**Konflux-managed example** (refreshed by `hack/snapshot_to_image_list.sh`; metadata stripped from CSV by `hack/update_bundle.sh`):
+
 ```json
- {
+{
   "name": "lightspeed-service-api",
   "image": "quay.io/.../lightspeed-service@sha256:...",
   "revision": "e5e1454f3fa8b19293200868684abcaf18f38097",
-  "operator_arg": "service-image"
+  "operator_arg": "service-image",
+  "snapshot_component": "lightspeed-service",
+  "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service",
+  "stable_prefix": "registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9"
 }
 ```
+
+**External / manual example** (e.g. PostgreSQL, dataverse exporter, RHOKP):
+
+```json
+{
+  "name": "rhokp",
+  "image": "registry.redhat.io/offline-knowledge-portal/rhokp-rhel9:latest",
+  "revision": "",
+  "operator_arg": "rhokp-image"
+}
+```
+
+Field reference for Konflux-managed entries:
+
+- `snapshot_component` — component name in the Konflux snapshot (`spec.components[].name`)
+- `konflux_prefix` — Quay image prefix in CI/Konflux workloads
+- `stable_prefix` — product registry prefix when refreshing with `-r stable`
+- `snapshot_source` — omit (defaults to OLS snapshot); set to `"bundle"` only for `lightspeed-operator-bundle`
 
 **Workflow:**
 ```
@@ -169,8 +202,8 @@ git commit -m "chore: bump bundle version to v0.2.0"
 ### Update Operator Image
 
 ```bash
-# Get image references from Konflux snapshot
-./hack/snapshot_to_image_list.sh -s <snapshot-ref> -o related_images.json
+# Get image references from Konflux snapshot (pass -b for bundle snapshot when updating ols-bundle)
+./hack/snapshot_to_image_list.sh -s <ols-snapshot-ref> -b <ols-bundle-snapshot-ref> -o related_images.json
 
 # Update bundle (uses version from related_images.json or current CSV)
 make bundle

--- a/hack/related_images_from_quay.sh
+++ b/hack/related_images_from_quay.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+# Refresh related_images.json from Quay using konflux_prefix + revision tags.
+# Does not use oc/Konflux snapshots. Requires oras, jq, and curl.
+set -euo pipefail
+
+usage() {
+	cat <<'EOF'
+Usage: related_images_from_quay.sh [-l] [-o <output-file>] [-r ci|stable|preview]
+
+Resolves Konflux-built entries via oras against:
+  <konflux_prefix>:<revision>   when revision is set (default)
+  <konflux_prefix>:<tag>        otherwise tag from current image (e.g. :main)
+
+With -l (latest), discovers the newest Konflux build on Quay per operand:
+  1. Resolve <konflux_prefix>:main when present
+  2. Map digest to a git SHA tag via the Quay API
+  3. Otherwise use the most recently pushed git SHA tag on Quay
+
+External/manual entries (no konflux_prefix) are unchanged.
+EOF
+}
+
+OUTPUT_FILE=""
+USE_REGISTRY="ci"
+ADVANCE_LATEST=false
+
+while getopts ":lo:r:h" argname; do
+	case "$argname" in
+	l) ADVANCE_LATEST=true ;;
+	o) OUTPUT_FILE=${OPTARG} ;;
+	r)
+		USE_REGISTRY=${OPTARG}
+		if [[ "${USE_REGISTRY}" != "stable" && "${USE_REGISTRY}" != "preview" && "${USE_REGISTRY}" != "ci" ]]; then
+			echo "Invalid registry option: ${USE_REGISTRY}. Use 'stable', 'preview', or 'ci'." >&2
+			usage
+			exit 1
+		fi
+		;;
+	h)
+		usage
+		exit 0
+		;;
+	*)
+		echo "Unknown option ${OPTARG:-}" >&2
+		usage
+		exit 1
+		;;
+	esac
+done
+
+: "${JQ:=$(command -v jq)}"
+: "${ORAS:=$(command -v oras)}"
+: "${CURL:=$(command -v curl)}"
+if [[ -z "${JQ}" ]]; then
+	echo "jq is required" >&2
+	exit 1
+fi
+if [[ -z "${ORAS}" ]]; then
+	echo "oras is required (brew install oras)" >&2
+	exit 1
+fi
+if [[ -z "${CURL}" ]]; then
+	echo "curl is required" >&2
+	exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INPUT_FILE="${SCRIPT_DIR}/../related_images.json"
+if [[ -n "${OUTPUT_FILE}" && -f "${OUTPUT_FILE}" ]]; then
+	INPUT_FILE="${OUTPUT_FILE}"
+elif [[ ! -f "${INPUT_FILE}" ]]; then
+	echo "related images file not found: ${INPUT_FILE}" >&2
+	exit 1
+fi
+
+map_registry_prefix() {
+	local image="$1"
+	local konflux_prefix="$2"
+	local stable_prefix="$3"
+	local target_prefix="${stable_prefix}"
+
+	if [[ "${USE_REGISTRY}" = "preview" ]]; then
+		target_prefix="${stable_prefix/openshift-lightspeed\//openshift-lightspeed-tech-preview/}"
+	fi
+	if [[ "${USE_REGISTRY}" = "stable" || "${USE_REGISTRY}" = "preview" ]]; then
+		if [[ -n "${konflux_prefix}" && "${konflux_prefix}" != "null" && -n "${target_prefix}" && "${target_prefix}" != "null" ]]; then
+			sed "s|${konflux_prefix}|${target_prefix}|g" <<<"${image}"
+			return
+		fi
+	fi
+	printf '%s' "${image}"
+}
+
+image_tag_from_ref() {
+	local image="$1"
+	if [[ "${image}" == *@sha256:* ]]; then
+		printf '%s' ""
+		return
+	fi
+	if [[ "${image}" == *:* ]]; then
+		printf '%s' "${image##*:}"
+		return
+	fi
+	printf '%s' ""
+}
+
+konflux_prefix_to_quay_repo() {
+	local prefix="$1"
+	prefix="${prefix#quay.io/}"
+	printf '%s' "${prefix}"
+}
+
+quay_fetch_tags_page() {
+	local repo="$1"
+	local page="$2"
+	"${CURL}" -fsS "https://quay.io/api/v1/repository/${repo}/tag/?page=${page}&limit=100"
+}
+
+# Find a 40-char git SHA tag whose manifest matches digest (e.g. sha256:abc...).
+quay_find_revision_for_digest() {
+	local prefix="$1"
+	local digest="$2"
+	local repo page=1 json match has_more
+
+	repo="$(konflux_prefix_to_quay_repo "${prefix}")"
+	while [[ "${page}" -le 20 ]]; do
+		json="$(quay_fetch_tags_page "${repo}" "${page}")"
+		match=$("${JQ}" -r --arg d "${digest}" '
+			[.tags[] | select(.name | test("^[0-9a-f]{40}$")) | select(.manifest_digest == $d)] | .[0].name // empty
+		' <<<"${json}")
+		if [[ -n "${match}" ]]; then
+			printf '%s' "${match}"
+			return 0
+		fi
+		has_more=$("${JQ}" -r '.has_additional' <<<"${json}")
+		[[ "${has_more}" != "true" ]] && break
+		page=$((page + 1))
+	done
+	return 1
+}
+
+# Newest git SHA tag by Quay start_ts (fallback when :main is missing or unmapped).
+quay_newest_sha_revision() {
+	local prefix="$1"
+	local repo page=1 json has_more best_ts=0 best_rev="" name ts
+
+	repo="$(konflux_prefix_to_quay_repo "${prefix}")"
+	while [[ "${page}" -le 20 ]]; do
+		json="$(quay_fetch_tags_page "${repo}" "${page}")"
+		while IFS=' ' read -r name ts; do
+			[[ -z "${name}" ]] && continue
+			if [[ "${ts}" -gt "${best_ts}" ]]; then
+				best_ts="${ts}"
+				best_rev="${name}"
+			fi
+		done < <("${JQ}" -r '.tags[] | select(.name | test("^[0-9a-f]{40}$")) | "\(.name) \(.start_ts)"' <<<"${json}")
+		has_more=$("${JQ}" -r '.has_additional' <<<"${json}")
+		[[ "${has_more}" != "true" ]] && break
+		page=$((page + 1))
+	done
+	if [[ -n "${best_rev}" ]]; then
+		printf '%s' "${best_rev}"
+		return 0
+	fi
+	return 1
+}
+
+discover_latest_revision() {
+	local prefix="$1"
+	local digest rev
+
+	if digest=$("${ORAS}" resolve "${prefix}:main" 2>/dev/null); then
+		if rev=$(quay_find_revision_for_digest "${prefix}" "${digest}"); then
+			printf '%s' "${rev}"
+			return 0
+		fi
+		echo "warning: ${prefix}:main resolved but no matching git SHA tag on Quay; using newest SHA tag" >&2
+	fi
+
+	if rev=$(quay_newest_sha_revision "${prefix}"); then
+		printf '%s' "${rev}"
+		return 0
+	fi
+
+	echo "warning: could not discover latest revision for ${prefix}" >&2
+	return 1
+}
+
+resolve_quay_image() {
+	local konflux_prefix="$1"
+	local revision="$2"
+	local fallback_image="$3"
+	local tag ref digest
+
+	if [[ -z "${konflux_prefix}" || "${konflux_prefix}" == "null" ]]; then
+		printf '%s' "${fallback_image}"
+		return
+	fi
+
+	# Already a digest URL with no revision: re-resolve that ref on Quay.
+	if [[ ( -z "${revision}" || "${revision}" == "null" ) && "${fallback_image}" == *@sha256:* ]]; then
+		if digest=$("${ORAS}" resolve "${fallback_image}" 2>&1); then
+			printf '%s' "${konflux_prefix}@${digest}"
+			return
+		fi
+		echo "warning: failed to resolve ${fallback_image}, keeping current image" >&2
+		printf '%s' "${fallback_image}"
+		return
+	fi
+
+	tag="${revision}"
+	if [[ -z "${tag}" || "${tag}" == "null" ]]; then
+		tag="$(image_tag_from_ref "${fallback_image}")"
+	fi
+	if [[ -z "${tag}" ]]; then
+		tag="main"
+	fi
+
+	ref="${konflux_prefix}:${tag}"
+	if ! digest=$("${ORAS}" resolve "${ref}" 2>&1); then
+		echo "warning: failed to resolve ${ref}, keeping current image (${digest})" >&2
+		printf '%s' "${fallback_image}"
+		return
+	fi
+	printf '%s' "${konflux_prefix}@${digest}"
+}
+
+postgres_fixup() {
+	local name="$1"
+	local image="$2"
+	if [[ "${name}" == "lightspeed-postgresql" ]]; then
+		sed 's|quay\.io.*/lightspeed-postgresql|registry.redhat.io/rhel9/postgresql-16|g' <<<"${image}"
+		return
+	fi
+	printf '%s' "${image}"
+}
+
+RESULT='[]'
+while IFS= read -r entry; do
+	name=$("${JQ}" -r '.name' <<<"${entry}")
+	image=$("${JQ}" -r '.image // empty' <<<"${entry}")
+	revision=$("${JQ}" -r '.revision // empty' <<<"${entry}")
+	konflux_prefix=$("${JQ}" -r '.konflux_prefix // empty' <<<"${entry}")
+	stable_prefix=$("${JQ}" -r '.stable_prefix // empty' <<<"${entry}")
+
+	if [[ "${ADVANCE_LATEST}" == "true" && -n "${konflux_prefix}" && "${konflux_prefix}" != "null" ]]; then
+		latest_rev=""
+		if latest_rev=$(discover_latest_revision "${konflux_prefix}"); then
+			if [[ "${latest_rev}" != "${revision}" ]]; then
+				echo "info: ${name}: revision ${revision:-<empty>} -> ${latest_rev}" >&2
+			fi
+			revision="${latest_rev}"
+		fi
+	fi
+
+	if [[ -n "${konflux_prefix}" && "${konflux_prefix}" != "null" ]]; then
+		image=$(resolve_quay_image "${konflux_prefix}" "${revision}" "${image}")
+	fi
+
+	image=$(postgres_fixup "${name}" "${image}")
+	image=$(map_registry_prefix "${image}" "${konflux_prefix}" "${stable_prefix}")
+
+	if [[ -z "${image}" || "${image}" == "null" ]]; then
+		echo "${name} image not found" >&2
+		exit 1
+	fi
+
+	out_entry=$("${JQ}" --arg image "${image}" --arg revision "${revision}" '
+		.image = $image
+		| if $revision != "" then .revision = $revision else . end
+	' <<<"${entry}")
+	RESULT=$("${JQ}" --argjson e "${out_entry}" '. + [$e]' <<<"${RESULT}")
+done < <("${JQ}" -c '.[]' "${INPUT_FILE}")
+
+if [[ -n "${OUTPUT_FILE}" ]]; then
+	"${JQ}" <<<"${RESULT}" >"${OUTPUT_FILE}"
+else
+	"${JQ}" <<<"${RESULT}"
+fi

--- a/hack/snapshot_to_image_list.sh
+++ b/hack/snapshot_to_image_list.sh
@@ -172,7 +172,7 @@ while IFS= read -r entry; do
 
 	out_entry=$(${JQ} --arg image "${image}" --arg revision "${revision}" '
 		.image = $image
-		| if ($revision | length) > 0 then .revision = $revision else . end
+		| .revision = $revision
 	' <<<"${entry}")
 	RESULT=$(${JQ} --argjson e "${out_entry}" '. + [$e]' <<<"${RESULT}")
 done < <(${JQ} -c '.[]' "${INPUT_FILE}")

--- a/hack/update_bundle.sh
+++ b/hack/update_bundle.sh
@@ -143,9 +143,9 @@ while IFS='|' read -r name placeholder target _; do
   [ -z "${IMG}" ] || [ "${IMG}" = "null" ] && continue
   IMG_SAFE=$(printf '%s' "${IMG}" | sed 's/"/\\"/g')
   if [ "${target}" = "image" ]; then
-    ${YQ} "(.spec.install.spec.deployments[].spec.template.spec.containers[].image |= sub(\"${PLACEHOLDER}\", \"${IMG_SAFE}\"))" -i ${CSV_FILE}
+    ${YQ} "(.spec.install.spec.deployments[].spec.template.spec.containers[].image |= sub(\"${placeholder}\", \"${IMG_SAFE}\"))" -i ${CSV_FILE}
   else
-    ${YQ} "(.spec.install.spec.deployments[].spec.template.spec.containers[].args[] |= sub(\"${PLACEHOLDER}\", \"${IMG_SAFE}\"))" -i ${CSV_FILE}
+    ${YQ} "(.spec.install.spec.deployments[].spec.template.spec.containers[].args[] |= sub(\"${placeholder}\", \"${IMG_SAFE}\"))" -i ${CSV_FILE}
   fi
 done < <(image_args::list_patch_entries "${RELATED_IMAGES_FILENAME}" "${JQ}")
 

--- a/internal/controller/appserver/assets.go
+++ b/internal/controller/appserver/assets.go
@@ -304,10 +304,6 @@ func buildOLSConfig(r reconciler.Reconciler, ctx context.Context, cr *olsv1alpha
 		},
 		ConversationCache: conversationCache,
 		TLSConfig:         tlsConfig,
-		ReferenceContent: utils.ReferenceContent{
-			Indexes:             referenceIndexes,
-			EmbeddingsModelPath: "/app-root/embeddings_model",
-		},
 		UserDataCollection: utils.UserDataCollectionConfig{
 			FeedbackDisabled:    cr.Spec.OLSConfig.UserDataCollection.FeedbackDisabled || !dataCollectorEnabled,
 			FeedbackStorage:     "/app-root/ols-user-data/feedback",
@@ -315,6 +311,12 @@ func buildOLSConfig(r reconciler.Reconciler, ctx context.Context, cr *olsv1alpha
 			TranscriptsStorage:  "/app-root/ols-user-data/transcripts",
 		},
 		ProxyConfig: proxyConfig,
+	}
+	if len(referenceIndexes) > 0 {
+		olsConfig.ReferenceContent = &utils.ReferenceContent{
+			Indexes:             referenceIndexes,
+			EmbeddingsModelPath: "/app-root/embeddings_model",
+		}
 	}
 
 	tlsProfile := cr.Spec.OLSConfig.TLSSecurityProfile

--- a/internal/controller/appserver/assets_test.go
+++ b/internal/controller/appserver/assets_test.go
@@ -117,9 +117,6 @@ var _ = Describe("App server assets", func() {
 						MinTLSVersion: string(configv1.TLSProfiles[configv1.TLSProfileIntermediateType].MinTLSVersion),
 						Ciphers:       configv1.TLSProfiles[configv1.TLSProfileIntermediateType].Ciphers,
 					},
-					ReferenceContent: utils.ReferenceContent{
-						EmbeddingsModelPath: "/app-root/embeddings_model",
-					},
 					SolrHybrid: buildSolrHybridSettings(),
 					UserDataCollection: utils.UserDataCollectionConfig{
 						FeedbackDisabled:    false,
@@ -1256,7 +1253,8 @@ var _ = Describe("App server assets", func() {
 			olsconfigGenerated = utils.AppSrvConfigFile{}
 			err = yaml.Unmarshal([]byte(cm.Data[utils.OLSConfigFilename]), &olsconfigGenerated)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(olsconfigGenerated.OLSConfig.ReferenceContent.Indexes).To(BeEmpty())
+			Expect(olsconfigGenerated.OLSConfig.ReferenceContent).To(BeNil())
+			Expect(cm.Data[utils.OLSConfigFilename]).NotTo(ContainSubstring("reference_content:"))
 
 		})
 
@@ -1285,7 +1283,7 @@ var _ = Describe("App server assets", func() {
 			Expect(olsconfigGenerated.OLSConfig.SolrHybrid).NotTo(BeNil())
 		})
 
-		It("should have empty reference indexes and solr_hybrid when OKP is enabled with no BYOK RAG", func() {
+		It("should omit reference_content and include solr_hybrid when OKP is enabled with no BYOK RAG", func() {
 			cr.Spec.OLSConfig.RAG = nil
 
 			cm, err := GenerateOLSConfigMap(testReconcilerInstance, context.TODO(), cr)
@@ -1294,7 +1292,7 @@ var _ = Describe("App server assets", func() {
 			err = yaml.Unmarshal([]byte(cm.Data[utils.OLSConfigFilename]), &olsconfigGenerated)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(olsconfigGenerated.OLSConfig.ReferenceContent.Indexes).To(BeEmpty())
+			Expect(olsconfigGenerated.OLSConfig.ReferenceContent).To(BeNil())
 			Expect(olsconfigGenerated.OLSConfig.SolrHybrid).NotTo(BeNil())
 		})
 
@@ -1557,7 +1555,7 @@ var _ = Describe("App server assets", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(olsconfigGenerated.LLMProviders).To(BeEmpty())
 			Expect(olsconfigGenerated.OLSConfig.SolrHybrid).To(Equal(buildSolrHybridSettings()))
-			Expect(olsconfigGenerated.OLSConfig.ReferenceContent.Indexes).To(BeEmpty())
+			Expect(cm.Data[utils.OLSConfigFilename]).NotTo(ContainSubstring("reference_content:"))
 			Expect(olsconfigGenerated.OLSConfig.Audit).To(Equal(&utils.AuditYAMLConfig{Logging: "Enabled"}))
 			Expect(olsconfigGenerated.OLSConfig.UserDataCollection.FeedbackDisabled).To(BeFalse())
 			Expect(olsconfigGenerated.OLSConfig.UserDataCollection.TranscriptsDisabled).To(BeFalse())
@@ -1580,7 +1578,7 @@ var _ = Describe("App server assets", func() {
 			err = yaml.Unmarshal([]byte(cm.Data[utils.OLSConfigFilename]), &olsconfigGenerated)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(olsconfigGenerated.OLSConfig.SolrHybrid).To(Equal(buildSolrHybridSettings()))
-			Expect(olsconfigGenerated.OLSConfig.ReferenceContent.Indexes).To(BeEmpty())
+			Expect(cm.Data[utils.OLSConfigFilename]).NotTo(ContainSubstring("reference_content:"))
 			Expect(olsconfigGenerated.OLSConfig.UserDataCollection.FeedbackDisabled).To(BeTrue())
 			Expect(olsconfigGenerated.OLSConfig.UserDataCollection.TranscriptsDisabled).To(BeTrue())
 			Expect(olsconfigGenerated.UserDataCollectorConfig).To(Equal(utils.UserDataCollectorConfig{}))
@@ -2242,12 +2240,12 @@ var _ = Describe("Helper function unit tests", func() {
 			Expect(config.ReferenceContent.Indexes[0].ProductDocsIndexId).To(Equal("test-index"))
 		})
 
-		It("should include solr_hybrid with empty reference indexes when BYOK only mode is disabled", func() {
+		It("should include solr_hybrid and omit reference_content when BYOK only mode is disabled and no RAG is configured", func() {
 			cr.Spec.OLSConfig.ByokRAGOnly = false
 			cr.Spec.OLSConfig.RAG = []olsv1alpha1.RAGSpec{}
 			config, err := buildOLSConfig(testReconcilerInstance, ctx, cr, false)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(config.ReferenceContent.Indexes).To(BeEmpty())
+			Expect(config.ReferenceContent).To(BeNil())
 			Expect(config.SolrHybrid).NotTo(BeNil())
 		})
 

--- a/internal/controller/utils/constants.go
+++ b/internal/controller/utils/constants.go
@@ -483,7 +483,6 @@ var (
 	PostgresServerImageDefault     = relatedimages.GetDefaultImage("lightspeed-postgresql")
 	OpenShiftMCPServerImageDefault = relatedimages.GetDefaultImage("openshift-mcp-server")
 	DataverseExporterImageDefault  = relatedimages.GetDefaultImage("lightspeed-to-dataverse-exporter")
-	OcpRagImageDefault             = relatedimages.GetDefaultImage("lightspeed-ocp-rag")
 	AgenticConsoleUIImageDefault   = imageDefaultOr("lightspeed-agentic-console-plugin", agenticConsoleUIImageFallback)
 	AlertsAdapterImageDefault      = imageDefaultOr("lightspeed-agentic-alerts-adapter", alertsAdapterImageFallback)
 	RHOOKPImageDefault             = imageDefaultOr("rhokp", rhokpImageFallback)

--- a/internal/controller/utils/types.go
+++ b/internal/controller/utils/types.go
@@ -189,8 +189,8 @@ type OLSConfig struct {
 	TLSSecurityProfile *TLSSecurityProfileConfig `json:"tlsSecurityProfile,omitempty"`
 	// Query filters
 	QueryFilters []QueryFilters `json:"query_filters,omitempty"`
-	// Reference content for RAG
-	ReferenceContent ReferenceContent `json:"reference_content,omitempty"`
+	// Reference content for BYOK RAG vector indexes; omitted when spec.ols.rag is empty.
+	ReferenceContent *ReferenceContent `json:"reference_content,omitempty"`
 	// User data collection configuration
 	UserDataCollection UserDataCollectionConfig `json:"user_data_collection,omitempty"`
 	// List of Paths to files containing additional CA certificates in the app server container.

--- a/related_images.json
+++ b/related_images.json
@@ -8,12 +8,13 @@
   {
     "name": "lightspeed-postgresql",
     "image": "registry.redhat.io/rhel9/postgresql-16@sha256:42f385ac3c9b8913426da7c57e70bc6617cd237aaf697c667f6385a8c0b0118b",
+    "revision": "",
     "operator_arg": "postgres-image"
   },
   {
     "name": "lightspeed-operator-bundle",
-    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols-bundle@sha256:7165a8679af7aecac039808cf34ef6fb9acce1d22ad6bf8da1bfef28d3a5e904",
-    "revision": "62e3f2883b3fa1455add77c14a7619253dbe4648",
+    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols-bundle@sha256:54f9d45d5e1fddf6faba0e449cc697c5e49ea5e198c26c9b38404187ebce3053",
+    "revision": "9bfa0ce6069f04027647ee2052dc8673206c7edb",
     "snapshot_component": "ols-bundle",
     "snapshot_source": "bundle",
     "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols-bundle",
@@ -21,47 +22,62 @@
   },
   {
     "name": "lightspeed-service-api",
-    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service@sha256:fd5a69605caa32df02095d17ab75a2353e704562e9b521df8632a0ebc50d2a55",
-    "revision": "e2a260e8563b3d3ffc902b0223f882aa7cab4bbc",
-    "operator_arg": "service-image"
+    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service@sha256:f2eed588a48a808f4f4a30319a34d7fcbc30a7383c14e103c0664ea759cc8b75",
+    "revision": "6578cfbbb90c2871911d17685473cde3561a78e1",
+    "operator_arg": "service-image",
+    "snapshot_component": "lightspeed-service",
+    "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service",
+    "stable_prefix": "registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9"
   },
   {
     "name": "lightspeed-console-plugin",
-    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console@sha256:f987b02ad62099c5aee760c038135f50c959249cb09154dd89a27e52df6f77c9",
-    "revision": "6e2fdb76245e7f9d9db0ebd92f0df955926180c3",
-    "operator_arg": "console-image"
+    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console@sha256:36ec4cf72eb7d3f2e6c2af9f7d5612382c9c2dc20d8acee4ccac3ea0ff8bd33d",
+    "revision": "b7fddb5d4c0f9ca42e868ebbad098ea7c1df6f23",
+    "operator_arg": "console-image",
+    "snapshot_component": "lightspeed-console",
+    "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console",
+    "stable_prefix": "registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9"
   },
   {
     "name": "lightspeed-operator",
-    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator@sha256:71a13f528f4af0ac81841a9b20e4c7391effd2541e354064c9fb6d94a4553513",
-    "revision": "7bc611cb27c41687f49d33c7614e652b1af7ff3e",
-    "operator_target": "image"
+    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator@sha256:552332d92b58a2082a63e679a4b343e21f67269cd85582dc265b5c6a4379bc13",
+    "revision": "9bfa0ce6069f04027647ee2052dc8673206c7edb",
+    "operator_target": "image",
+    "snapshot_component": "lightspeed-operator",
+    "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator",
+    "stable_prefix": "registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator"
   },
   {
     "name": "openshift-mcp-server",
     "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/openshift-mcp-server@sha256:ca69b8efcf97bf02bbcda126b7787dd658841ee00203a86ee22e3f36ff73c7ce",
     "revision": "28f017bae33375fe968fef6e035ec05f19b2fcc2",
-    "operator_arg": "openshift-mcp-server-image"
-  },
-  {
-    "name": "lightspeed-ocp-rag",
-    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-ocp-rag@sha256:7155419a17b950e48266e18da7328cc127d44a4923e76c66295b6079ea3f93d2",
-    "revision": "bd294b432c80a6386a90d075201a29253c2aecec",
-    "operator_arg": "ocp-rag-image"
+    "operator_arg": "openshift-mcp-server-image",
+    "snapshot_component": "openshift-mcp-server",
+    "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/openshift-mcp-server",
+    "stable_prefix": "registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9"
   },
   {
     "name": "lightspeed-agentic-console-plugin",
-    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-console:main",
-    "operator_arg": "agentic-console-image"
+    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-console@sha256:2b472ebdac13b6cdeffe057c9f28b7cb43a4bf767865d781572c4c11dedf4a49",
+    "revision": "55150e9cb9d7c1edff95cf3f6f6bd8191dca98e3",
+    "operator_arg": "agentic-console-image",
+    "snapshot_component": "lightspeed-agentic-console",
+    "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-console",
+    "stable_prefix": "registry.redhat.io/openshift-lightspeed/lightspeed-agentic-console-rhel9"
   },
   {
     "name": "lightspeed-agentic-alerts-adapter",
-    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-alerts-adapter:main",
-    "operator_arg": "alerts-adapter-image"
+    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-alerts-adapter@sha256:9d4c8c8e91440ce625c5c936594a9b1048fa7841890906facba6c398da925369",
+    "revision": "d802deed86897db3d76b43a52079e6cff9d5ebbe",
+    "operator_arg": "alerts-adapter-image",
+    "snapshot_component": "lightspeed-agentic-alerts-adapter",
+    "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-alerts-adapter",
+    "stable_prefix": "registry.redhat.io/openshift-lightspeed/lightspeed-agentic-alerts-adapter-rhel9"
   },
   {
     "name": "rhokp",
     "image": "registry.redhat.io/offline-knowledge-portal/rhokp-rhel9:latest",
+    "revision": "",
     "operator_arg": "rhokp-image"
   }
 ]


### PR DESCRIPTION
## Summary

- Refresh `related_images.json` and regenerate the OLM bundle (v1.1.2): bump operator to `b767d48a` (post-RHOKP/ROSA on Quay), wire agentic operand images, remove `lightspeed-ocp-rag`.
- Add `rhokp` to `related_images.json`, CSV `relatedImages`, and manager deployment `--rhokp-image`; remove ocp-rag from deployment wiring and `cmd/main.go`.
- Add `hack/related_images_from_quay.sh` to resolve Konflux operand digests via `oras` + `konflux_prefix`/`revision` (routine bundle updates without `oc`).
- Document Konflux vs external image entry types in `docs/olm-bundle-management.md`; update bundle skills and `.ai/spec` for RHOKP in `related_images.json`.

**18 files changed** (1 added, 17 modified).

## Motivation

Konflux snapshot on Jul 10 pinned operator image `7bc611cb` (pre–okp-support #1653). The bundle CSV added `--rhokp-image` but that pinned operator did not support the flag. This PR aligns image pins, placeholders, and CSV deployment args.

RHOKP replaces the retired `lightspeed-ocp-rag` operand for OKP / Solr hybrid RAG ([OLS-3312](https://redhat.atlassian.net/browse/OLS-3312)).

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related: [OLS-3312](https://redhat.atlassian.net/browse/OLS-3312), [OLS-1894](https://redhat.atlassian.net/browse/OLS-1894)
- Closes: [OLS-3312](https://redhat.atlassian.net/browse/OLS-3312)

## Notes

- **RHOKP** uses `registry.redhat.io/offline-knowledge-portal/rhokp-rhel9:latest` (external product image; no Konflux revisions).
- **Alerts adapter** uses interim `:main` until Konflux productization.
- **Catalog** (`lightspeed-catalog-*`) is not updated here — follow-up catalog publish required for disconnected installs.
- Pinned operator image (`b767d48a`) still accepts `--ocp-rag-image` in the binary; CSV no longer passes it (harmless).

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Test plan

- [x] `make test`
- [x] `make lint`
- [x] `operator-sdk bundle validate ./bundle`
- [x] `./hack/related_images_from_quay.sh -r ci -o related_images.json` + `make bundle BUNDLE_TAG=1.1.2`
- [ ] Install bundle on cluster; manager pod starts with `--rhokp-image`
- [ ] RHOKP sidecar deploys when `byokRAGOnly: false`
- [ ] Follow-up: publish updated catalog entry for 1.1.2 (`rhokp` replaces `lightspeed-ocp-rag`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RHOKP sidecar configuration, including the `--rhokp-image` operator startup flag and UI configuration for RHOKP deployment settings.
* **Changes**
  * Removed the deprecated OCP RAG image configuration (`--ocp-rag-image`).
  * Clarified that the RHOKP sidecar default image is sourced from `related_images.json` (key `rhokp`), and updated related image listings with pinned digests.
  * Expanded operator permissions and refined BYOK RAG help/UI behavior.
* **Documentation**
  * Updated bundle/OLM and image-management guidance, including Quay-driven instructions for regenerating `related_images.json`.
* **Tests**
  * Updated expectations around when RAG `reference_content` is rendered in generated configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->