### PR TITLE
increase cpu capacity 

### DIFF
--- a/.tekton/integration-tests/pipelines/lightspeed-operator-e2e-test-all-features.yaml
+++ b/.tekton/integration-tests/pipelines/lightspeed-operator-e2e-test-all-features.yaml
@@ -77,7 +77,7 @@ spec:
               - name: version
                 value: "$(steps.pick-version.results.version)"
               - name: instanceType
-                value: "m5.large"
+                value: "m5.2xlarge"
     - name: ols-install
       description: Task to install bundle onto ephemeral namespace
       runAfter:

--- a/.tekton/integration-tests/pipelines/lightspeed-operator-e2e-test-pipeline-416.yaml
+++ b/.tekton/integration-tests/pipelines/lightspeed-operator-e2e-test-pipeline-416.yaml
@@ -100,7 +100,7 @@ spec:
               - name: version
                 value: "$(steps.pick-version.results.version)"
               - name: instanceType
-                value: "m5.large"
+                value: "m5.2xlarge"
     - name: ols-install
       description: Install operator (OLM bundle or direct); record SNAPSHOT containerImage and commit for downstream tasks.
       runAfter:

--- a/.tekton/integration-tests/pipelines/lightspeed-operator-e2e-test-pipeline-417.yaml
+++ b/.tekton/integration-tests/pipelines/lightspeed-operator-e2e-test-pipeline-417.yaml
@@ -100,7 +100,7 @@ spec:
               - name: version
                 value: "$(steps.pick-version.results.version)"
               - name: instanceType
-                value: "m5.large"
+                value: "m5.2xlarge"
     - name: ols-install
       description: Install operator (OLM bundle or direct); record SNAPSHOT containerImage and commit for downstream tasks.
       runAfter:

--- a/.tekton/integration-tests/pipelines/lightspeed-operator-e2e-test-pipeline-418.yaml
+++ b/.tekton/integration-tests/pipelines/lightspeed-operator-e2e-test-pipeline-418.yaml
@@ -100,7 +100,7 @@ spec:
               - name: version
                 value: "$(steps.pick-version.results.version)"
               - name: instanceType
-                value: "m5.large"
+                value: "m5.2xlarge"
     - name: ols-install
       description: Install operator (OLM bundle or direct); record SNAPSHOT containerImage and commit for downstream tasks.
       runAfter:

--- a/.tekton/integration-tests/pipelines/lightspeed-operator-e2e-test-pipeline-419.yaml
+++ b/.tekton/integration-tests/pipelines/lightspeed-operator-e2e-test-pipeline-419.yaml
@@ -100,7 +100,7 @@ spec:
               - name: version
                 value: "$(steps.pick-version.results.version)"
               - name: instanceType
-                value: "m5.large"
+                value: "m5.2xlarge"
     - name: ols-install
       description: Install operator (OLM bundle or direct); record SNAPSHOT containerImage and commit for downstream tasks.
       runAfter:

--- a/.tekton/integration-tests/pipelines/lightspeed-operator-upgrade-e2e-test-pipeline-419.yaml
+++ b/.tekton/integration-tests/pipelines/lightspeed-operator-upgrade-e2e-test-pipeline-419.yaml
@@ -93,7 +93,7 @@ spec:
               - name: version
                 value: "$(steps.pick-version.results.version)"
               - name: instanceType
-                value: "m5.large"
+                value: "m5.2xlarge"
     - name: ols-install
       description: Install operator bundle (upgrade base + snapshot); record SNAPSHOT commit for tests.
       runAfter:

--- a/.tekton/integration-tests/pipelines/lightspeed-operator-upgrade-e2e-test-pipeline-420.yaml
+++ b/.tekton/integration-tests/pipelines/lightspeed-operator-upgrade-e2e-test-pipeline-420.yaml
@@ -93,7 +93,7 @@ spec:
               - name: version
                 value: "$(steps.pick-version.results.version)"
               - name: instanceType
-                value: "m5.large"
+                value: "m5.2xlarge"
     - name: ols-install
       description: Install operator bundle (upgrade base + snapshot); record SNAPSHOT commit for tests.
       runAfter:

--- a/.tekton/integration-tests/pipelines/lightspeed-service-integration-test-pipeline-4.16.yaml
+++ b/.tekton/integration-tests/pipelines/lightspeed-service-integration-test-pipeline-4.16.yaml
@@ -103,7 +103,7 @@ spec:
               - name: version
                 value: "$(steps.pick-version.results.version)"
               - name: instanceType
-                value: "m5.large"
+                value: "m5.2xlarge"
     - name: ols-install
       description: Install operator (OLM bundle or direct); record SNAPSHOT image ref and commit for service tests.
       runAfter:

--- a/.tekton/integration-tests/pipelines/lightspeed-service-integration-test-pipeline-4.17.yaml
+++ b/.tekton/integration-tests/pipelines/lightspeed-service-integration-test-pipeline-4.17.yaml
@@ -103,7 +103,7 @@ spec:
               - name: version
                 value: "$(steps.pick-version.results.version)"
               - name: instanceType
-                value: "m5.large"
+                value: "m5.2xlarge"
     - name: ols-install
       description: Install operator (OLM bundle or direct); record SNAPSHOT image ref and commit for service tests.
       runAfter:

--- a/.tekton/integration-tests/pipelines/lightspeed-service-integration-test-pipeline-4.18.yaml
+++ b/.tekton/integration-tests/pipelines/lightspeed-service-integration-test-pipeline-4.18.yaml
@@ -103,7 +103,7 @@ spec:
               - name: version
                 value: "$(steps.pick-version.results.version)"
               - name: instanceType
-                value: "m5.large"
+                value: "m5.2xlarge"
     - name: ols-install
       description: Install operator (OLM bundle or direct); record SNAPSHOT image ref and commit for service tests.
       runAfter:

--- a/.tekton/integration-tests/pipelines/lightspeed-service-integration-test-pipeline-4.19.yaml
+++ b/.tekton/integration-tests/pipelines/lightspeed-service-integration-test-pipeline-4.19.yaml
@@ -103,7 +103,7 @@ spec:
               - name: version
                 value: "$(steps.pick-version.results.version)"
               - name: instanceType
-                value: "m5.large"
+                value: "m5.2xlarge"
     - name: ols-install
       description: Install operator (OLM bundle or direct); record SNAPSHOT image ref and commit for service tests.
       runAfter:

--- a/.tekton/integration-tests/pipelines/rapidast-scan.yaml
+++ b/.tekton/integration-tests/pipelines/rapidast-scan.yaml
@@ -92,7 +92,7 @@ spec:
               - name: version
                 value: "$(steps.pick-version.results.version)"
               - name: instanceType
-                value: "m5.large"
+                value: "m5.2xlarge"
     - name: ols-install
       description: Install operator via OLM bundle (Rapidast); calls run-konflux-operator-install.sh bundle only.
       runAfter:


### PR DESCRIPTION
## Description

Since now we have an assured minimum of 3 cpus (2 for OKP and 1 for OLS), we need at least an xlarge instance. Setting it to a 2xlarge to have some maneuver space.
This PR will unblock tests on lightspeed-operator side of things. 

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated ephemeral test clusters to use larger compute instances.
  * Applied the change across Lightspeed operator, upgrade, service integration, and security scan pipelines.
  * Improved capacity for integration and end-to-end test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->