### PR TITLE
OLS-0000: Standardize AGENTS.md content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,9 @@
 # OpenShift Lightspeed Operator - AI Assistant Guide
 
+## Specs
+
+All specifications live in `.ai/spec/`. Start with `.ai/spec/README.md` for project overview, reading order, and structure guide.
+
 ## Project Overview
 Kubernetes operator managing OpenShift Lightspeed (AI-powered Virtual Assistant). Go + controller-runtime/kubebuilder + Ginkgo v2/Gomega testing.
 
@@ -163,9 +167,9 @@ When finishing a development branch:
 3. Push to the contributor's fork remote (not `origin`)
 4. Create the PR against `origin/main` using `--head <user>:<branch>`
 
-## Risk Levels
+## Maintaining This Document
 
-Risk levels are enforced via a PreToolUse hook before every Jira create/edit call. The rubric and classification examples live in [lightspeed-team-harness/hooks/risk-rubric.md](https://github.com/openshift/lightspeed-team-harness/blob/main/hooks/risk-rubric.md).
+Always suggest AGENTS.md edits when architectural, structural, or conventional changes are made to the codebase.
 
 ## Maintaining This Document
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,7 +170,3 @@ When finishing a development branch:
 ## Maintaining This Document
 
 Always suggest AGENTS.md edits when architectural, structural, or conventional changes are made to the codebase.
-
-## Maintaining This Document
-
-Always suggest AGENTS.md edits when architectural, structural, or conventional changes are made to the codebase.


### PR DESCRIPTION
## Summary
- Standardize AGENTS.md to include 4 mandatory sections: Specs, Commands, Conventions, Git and PR Workflow
- Normalize file structure: AGENTS.md is the canonical file, CLAUDE.md is a symlink to it
- Remove Risk Levels section (hook doesn't work in all cases)

## Test plan
- [ ] Verify AGENTS.md has all 4 mandatory sections
- [ ] Verify CLAUDE.md is a symlink to AGENTS.md
- [ ] Verify no Risk Levels section remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “Specs” section directing readers to the specifications overview and related documentation.
  * Removed the previously documented “Risk Levels” section and its associated references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->