### PR TITLE
OLS-3509: Regenerate bundle with OTEL collector related image

### DIFF
--- a/.ai/spec/what/templog.md
+++ b/.ai/spec/what/templog.md
@@ -64,7 +64,7 @@ Service continues to use the existing gRPC OTLP trace exporter (`opentelemetry.e
 ## Operator image flag ([OLS-3509](https://redhat.atlassian.net/browse/OLS-3509))
 
 - CLI: `--otel-collector-image`
-- Default: `lightspeed-otel-postgres-collector` from `related_images.json` (Konflux fallback when absent)
+- Default: `lightspeed-otel-collector` from `related_images.json` (Konflux fallback when absent)
 - Reconciler: `GetOtelCollectorImage()` — consumed by collector operand ([OLS-3510](https://redhat.atlassian.net/browse/OLS-3510))
 - Bundle PR adds `related_images.json` entry with `operator_arg: otel-collector-image`
 

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ IMAGE_TAG_BASE ?= quay.io/openshift-lightspeed/lightspeed-operator
 
 # BUNDLE_TAG defines the version of the bundle.
 # You can use it as an arg. (E.g make bundle BUNDLE_TAG=0.0.1)
-BUNDLE_TAG ?= 1.1.1
+BUNDLE_TAG ?= 1.1.2
 
 # set the base image for docker files
 # You can use it as an arg.  (E.g make bundle BASE_IMG=registry.redhat.io/ubi9/ubi-minimal)
@@ -377,7 +377,6 @@ $(ENVTEST): $(LOCALBIN)
 OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk
 operator-sdk: ## Download operator-sdk locally if necessary.
 ifeq (,$(wildcard $(OPERATOR_SDK)))
-ifeq (, $(shell which operator-sdk 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPERATOR_SDK)) ;\
@@ -385,9 +384,6 @@ ifeq (, $(shell which operator-sdk 2>/dev/null))
 	curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH} ;\
 	chmod +x $(OPERATOR_SDK) ;\
 	}
-else
-OPERATOR_SDK = $(shell which operator-sdk)
-endif
 endif
 
 
@@ -398,7 +394,7 @@ endif
 ## to use image digests instead of version tag, set the USE_IMAGE_DIGESTS variable to true
 .PHONY: bundle
 bundle: manifests kustomize operator-sdk yq jq ## Generate bundle manifests and metadata, then validate generated files.
-	YQ=$(YQ) JQ=$(JQ) BUNDLE_GEN_FLAGS="$(BUNDLE_GEN_FLAGS)" ./hack/update_bundle.sh -v $(BUNDLE_TAG) -i related_images.json
+	OPERATOR_SDK=$(OPERATOR_SDK) YQ=$(YQ) JQ=$(JQ) BUNDLE_GEN_FLAGS="$(BUNDLE_GEN_FLAGS)" ./hack/update_bundle.sh -v $(BUNDLE_TAG) -i related_images.json
 
 parking:
 	$(OPERATOR_SDK) generate kustomize manifests -q

--- a/api/v1alpha1/olsconfig_types.go
+++ b/api/v1alpha1/olsconfig_types.go
@@ -412,8 +412,8 @@ type AlertsAdapterSpec struct {
 // Config defines pod configuration using standard Kubernetes types
 type Config struct {
 	// Defines the number of desired OLS pods. Default: "1"
-	// Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console, and Alerts Adapter containers,
-	// the number of replicas will always be set to 1.
+	// Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
+	// Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
 	// +kubebuilder:default=1
 	// +kubebuilder:validation:Minimum=0
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Number of replicas",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:podCount"}

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=lightspeed-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
 LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.33.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.36.1
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 

--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     console.openshift.io/operator-monitoring-default: "true"
-    createdAt: "2026-07-13T15:29:35Z"
+    createdAt: "2026-07-15T08:36:56Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -81,12 +81,21 @@ spec:
           - description: The name of the secret object that stores API provider credentials
             displayName: Credential Secret
             path: llm.providers[0].credentialsSecretRef
-          - description: |-
-              Audit logging and tracing configuration.
-              Logging and OTEL tracing are independent controls.
-              Default: logging enabled, no OTEL export when absent.
+          - description: Audit log and trace export configuration for the OTEL Collector.
             displayName: Audit Settings
             path: audit
+          - description: |-
+              logging enables audit log storage in PostgreSQL via the Collector.
+              Default: true when absent.
+            displayName: Audit Logging
+            path: audit.logging
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+          - description: |-
+              tracingEndpoint is the trace export backend (e.g. "jaeger:4317").
+              The Collector forwards traces here when set. TLS is always used.
+            displayName: Tracing Endpoint
+            path: audit.tracingEndpoint
           - description: |-
               Feature Gates holds list of features to be enabled explicitly, otherwise they are disabled by default.
               possible values: MCPServer, ToolFiltering
@@ -201,6 +210,13 @@ spec:
             path: ols.additionalCAConfigMapRef
             x-descriptors:
               - urn:alm:descriptor:com.tectonic.ui:advanced
+          - description: |-
+              auditEventsEnabled controls structured compliance audit JSON events on stdout.
+              Default: true when absent. Does not affect collector storage (see spec.audit).
+            displayName: Audit Events Enabled
+            path: ols.auditEventsEnabled
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
           - description: Only use BYOK RAG sources. Disables OKP (RHOKP sidecar, solr_hybrid config, and built-in OCP documentation retrieval).
             displayName: Only use BYOK RAG sources
             path: ols.byokRAGOnly
@@ -232,8 +248,8 @@ spec:
             path: ols.deployment.agenticConsole
           - description: |-
               Defines the number of desired OLS pods. Default: "1"
-              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console, and Alerts Adapter containers,
-              the number of replicas will always be set to 1.
+              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
+              Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
             displayName: Number of replicas
             path: ols.deployment.agenticConsole.replicas
             x-descriptors:
@@ -252,8 +268,8 @@ spec:
             path: ols.deployment.alertsAdapter.configMapRef
           - description: |-
               Defines the number of desired OLS pods. Default: "1"
-              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console, and Alerts Adapter containers,
-              the number of replicas will always be set to 1.
+              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
+              Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
             displayName: Number of replicas
             path: ols.deployment.alertsAdapter.replicas
             x-descriptors:
@@ -263,8 +279,8 @@ spec:
             path: ols.deployment.api
           - description: |-
               Defines the number of desired OLS pods. Default: "1"
-              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console, and Alerts Adapter containers,
-              the number of replicas will always be set to 1.
+              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
+              Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
             displayName: Number of replicas
             path: ols.deployment.api.replicas
             x-descriptors:
@@ -274,8 +290,8 @@ spec:
             path: ols.deployment.console
           - description: |-
               Defines the number of desired OLS pods. Default: "1"
-              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console, and Alerts Adapter containers,
-              the number of replicas will always be set to 1.
+              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
+              Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
             displayName: Number of replicas
             path: ols.deployment.console.replicas
             x-descriptors:
@@ -288,8 +304,8 @@ spec:
             path: ols.deployment.database
           - description: |-
               Defines the number of desired OLS pods. Default: "1"
-              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console, and Alerts Adapter containers,
-              the number of replicas will always be set to 1.
+              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
+              Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
             displayName: Number of replicas
             path: ols.deployment.database.replicas
             x-descriptors:
@@ -297,6 +313,17 @@ spec:
           - description: MCP server container settings.
             displayName: MCP Server Container
             path: ols.deployment.mcpServer
+          - description: OTEL Collector deployment settings.
+            displayName: OTEL Collector Deployment
+            path: ols.deployment.otelCollector
+          - description: |-
+              Defines the number of desired OLS pods. Default: "1"
+              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
+              Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
+            displayName: Number of replicas
+            path: ols.deployment.otelCollector.replicas
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:podCount
           - description: RHOKP sidecar container settings (Solr / OKP).
             displayName: RHOKP Container
             path: ols.deployment.rhokp
@@ -928,10 +955,11 @@ spec:
                       - --dataverse-exporter-image=registry.redhat.io/lightspeed-core/dataverse-exporter-rhel9@sha256:1c7ffaead23adfb1dc6bd3adfe75c80f284d6d31f13ca427d754703c78514cb2
                       - --postgres-image=registry.redhat.io/rhel9/postgresql-16@sha256:42f385ac3c9b8913426da7c57e70bc6617cd237aaf697c667f6385a8c0b0118b
                       - --service-image=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service@sha256:f2eed588a48a808f4f4a30319a34d7fcbc30a7383c14e103c0664ea759cc8b75
-                      - --console-image=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console@sha256:36ec4cf72eb7d3f2e6c2af9f7d5612382c9c2dc20d8acee4ccac3ea0ff8bd33d
+                      - --console-image=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console@sha256:9eb2fa1be5845a1c8361f36fc1a84c3c25ea9b903c616cd0841ab00f50814e2c
                       - --openshift-mcp-server-image=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/openshift-mcp-server@sha256:ca69b8efcf97bf02bbcda126b7787dd658841ee00203a86ee22e3f36ff73c7ce
-                      - --agentic-console-image=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-console@sha256:2b472ebdac13b6cdeffe057c9f28b7cb43a4bf767865d781572c4c11dedf4a49
+                      - --agentic-console-image=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-console@sha256:5e516e9525d38691a2b712a278cb3dd09840bea6aa39543c11a41b80f763cb4d
                       - --alerts-adapter-image=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-alerts-adapter@sha256:9d4c8c8e91440ce625c5c936594a9b1048fa7841890906facba6c398da925369
+                      - --otel-collector-image=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-otel-collector@sha256:85e8f70fea5c9005088767f787e39c65ebabac2295f38b3cd846157ef9dcebea
                       - --rhokp-image=registry.redhat.io/offline-knowledge-portal/rhokp-rhel9:latest
                     command:
                       - /manager
@@ -940,7 +968,7 @@ spec:
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.annotations['olm.targetNamespaces']
-                    image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator@sha256:552332d92b58a2082a63e679a4b343e21f67269cd85582dc265b5c6a4379bc13
+                    image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator@sha256:1645c690a39887f85512db58bc4ea422faaf100884948da36090ae0100a83748
                     imagePullPolicy: Always
                     livenessProbe:
                       httpGet:
@@ -1063,14 +1091,16 @@ spec:
     - name: lightspeed-service-api
       image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service@sha256:f2eed588a48a808f4f4a30319a34d7fcbc30a7383c14e103c0664ea759cc8b75
     - name: lightspeed-console-plugin
-      image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console@sha256:36ec4cf72eb7d3f2e6c2af9f7d5612382c9c2dc20d8acee4ccac3ea0ff8bd33d
+      image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console@sha256:9eb2fa1be5845a1c8361f36fc1a84c3c25ea9b903c616cd0841ab00f50814e2c
     - name: lightspeed-operator
-      image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator@sha256:552332d92b58a2082a63e679a4b343e21f67269cd85582dc265b5c6a4379bc13
+      image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator@sha256:1645c690a39887f85512db58bc4ea422faaf100884948da36090ae0100a83748
     - name: openshift-mcp-server
       image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/openshift-mcp-server@sha256:ca69b8efcf97bf02bbcda126b7787dd658841ee00203a86ee22e3f36ff73c7ce
     - name: lightspeed-agentic-console-plugin
-      image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-console@sha256:2b472ebdac13b6cdeffe057c9f28b7cb43a4bf767865d781572c4c11dedf4a49
+      image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-console@sha256:5e516e9525d38691a2b712a278cb3dd09840bea6aa39543c11a41b80f763cb4d
     - name: lightspeed-agentic-alerts-adapter
       image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-alerts-adapter@sha256:9d4c8c8e91440ce625c5c936594a9b1048fa7841890906facba6c398da925369
+    - name: lightspeed-otel-collector
+      image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-otel-collector@sha256:85e8f70fea5c9005088767f787e39c65ebabac2295f38b3cd846157ef9dcebea
     - name: rhokp
       image: registry.redhat.io/offline-knowledge-portal/rhokp-rhel9:latest

--- a/bundle/manifests/ols.openshift.io_olsconfigs.yaml
+++ b/bundle/manifests/ols.openshift.io_olsconfigs.yaml
@@ -41,44 +41,20 @@ spec:
             description: OLSConfigSpec defines the desired state of OLSConfig
             properties:
               audit:
-                description: |-
-                  Audit logging and tracing configuration.
-                  Logging and OTEL tracing are independent controls.
-                  Default: logging enabled, no OTEL export when absent.
-                minProperties: 1
+                description: Audit log and trace export configuration for the OTEL
+                  Collector.
                 properties:
                   logging:
-                    default: Enabled
                     description: |-
-                      logging enables structured JSON audit events to stdout.
-                      Default: Enabled (when field is empty or config CR absent).
-                    enum:
-                    - Enabled
-                    - Disabled
+                      logging enables audit log storage in PostgreSQL via the Collector.
+                      Default: true when absent.
+                    type: boolean
+                  tracingEndpoint:
+                    description: |-
+                      tracingEndpoint is the trace export backend (e.g. "jaeger:4317").
+                      The Collector forwards traces here when set. TLS is always used.
+                    maxLength: 253
                     type: string
-                  otel:
-                    description: |-
-                      otel configures OpenTelemetry tracing export.
-                      When nil or endpoint empty, uses no-op tracer (no export).
-                    minProperties: 1
-                    properties:
-                      endpoint:
-                        description: |-
-                          endpoint is the OTLP gRPC endpoint (e.g., "jaeger-otlp-grpc.observability.svc:4317").
-                          When empty, no OTEL traces are exported (no-op tracer used).
-                        maxLength: 253
-                        minLength: 1
-                        type: string
-                      tlsMode:
-                        default: Secure
-                        description: |-
-                          tlsMode controls TLS for the OTLP connection.
-                          "Secure" (default) requires TLS; "Insecure" disables TLS.
-                        enum:
-                        - Secure
-                        - Insecure
-                        type: string
-                    type: object
                 type: object
               featureGates:
                 description: |-
@@ -489,6 +465,11 @@ spec:
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
+                  auditEventsEnabled:
+                    description: |-
+                      auditEventsEnabled controls structured compliance audit JSON events on stdout.
+                      Default: true when absent. Does not affect collector storage (see spec.audit).
+                    type: boolean
                   byokRAGOnly:
                     description: Only use BYOK RAG sources. Disables OKP (RHOKP sidecar,
                       solr_hybrid config, and built-in OCP documentation retrieval).
@@ -539,8 +520,8 @@ spec:
                             default: 1
                             description: |-
                               Defines the number of desired OLS pods. Default: "1"
-                              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console, and Alerts Adapter containers,
-                              the number of replicas will always be set to 1.
+                              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
+                              Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
                             format: int32
                             minimum: 0
                             type: integer
@@ -682,8 +663,8 @@ spec:
                             default: 1
                             description: |-
                               Defines the number of desired OLS pods. Default: "1"
-                              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console, and Alerts Adapter containers,
-                              the number of replicas will always be set to 1.
+                              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
+                              Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
                             format: int32
                             minimum: 0
                             type: integer
@@ -804,8 +785,8 @@ spec:
                             default: 1
                             description: |-
                               Defines the number of desired OLS pods. Default: "1"
-                              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console, and Alerts Adapter containers,
-                              the number of replicas will always be set to 1.
+                              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
+                              Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
                             format: int32
                             minimum: 0
                             type: integer
@@ -926,8 +907,8 @@ spec:
                             default: 1
                             description: |-
                               Defines the number of desired OLS pods. Default: "1"
-                              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console, and Alerts Adapter containers,
-                              the number of replicas will always be set to 1.
+                              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
+                              Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
                             format: int32
                             minimum: 0
                             type: integer
@@ -1114,8 +1095,8 @@ spec:
                             default: 1
                             description: |-
                               Defines the number of desired OLS pods. Default: "1"
-                              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console, and Alerts Adapter containers,
-                              the number of replicas will always be set to 1.
+                              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
+                              Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
                             format: int32
                             minimum: 0
                             type: integer
@@ -1289,6 +1270,128 @@ spec:
                                   More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                             type: object
+                        type: object
+                      otelCollector:
+                        description: OTEL Collector deployment settings.
+                        properties:
+                          nodeSelector:
+                            additionalProperties:
+                              type: string
+                            description: Node selector constraints
+                            type: object
+                          replicas:
+                            default: 1
+                            description: |-
+                              Defines the number of desired OLS pods. Default: "1"
+                              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
+                              Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          resources:
+                            description: |-
+                              Resource requirements (CPU, memory)
+                              Uses standard corev1.ResourceRequirements
+                            properties:
+                              claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
+
+                                  This field depends on the
+                                  DynamicResourceAllocation feature gate.
+
+                                  This field is immutable. It can only be set for containers.
+                                items:
+                                  description: ResourceClaim references one entry
+                                    in PodSpec.ResourceClaims.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used. It makes that resource available
+                                        inside a container.
+                                      type: string
+                                    request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                            type: object
+                          tolerations:
+                            description: |-
+                              Tolerations for pod scheduling
+                              Uses standard corev1.Toleration
+                            items:
+                              description: |-
+                                The pod this Toleration is attached to tolerates any taint that matches
+                                the triple <key,value,effect> using the matching operator <operator>.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Effect indicates the taint effect to match. Empty means match all taint effects.
+                                    When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: |-
+                                    Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                    If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    Operator represents a key's relationship to the value.
+                                    Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                                    Exists is equivalent to wildcard for value, so that a pod can
+                                    tolerate all taints of a particular category.
+                                    Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                                  type: string
+                                tolerationSeconds:
+                                  description: |-
+                                    TolerationSeconds represents the period of time the toleration (which must be
+                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                    it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                    negative values will be treated as 0 (evict immediately) by the system.
+                                  format: int64
+                                  type: integer
+                                value:
+                                  description: |-
+                                    Value is the taint value the toleration matches to.
+                                    If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                  type: string
+                              type: object
+                            type: array
                         type: object
                       rhokp:
                         description: RHOKP sidecar container settings (Solr / OKP).

--- a/config/crd/bases/ols.openshift.io_olsconfigs.yaml
+++ b/config/crd/bases/ols.openshift.io_olsconfigs.yaml
@@ -520,8 +520,8 @@ spec:
                             default: 1
                             description: |-
                               Defines the number of desired OLS pods. Default: "1"
-                              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console, and Alerts Adapter containers,
-                              the number of replicas will always be set to 1.
+                              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
+                              Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
                             format: int32
                             minimum: 0
                             type: integer
@@ -663,8 +663,8 @@ spec:
                             default: 1
                             description: |-
                               Defines the number of desired OLS pods. Default: "1"
-                              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console, and Alerts Adapter containers,
-                              the number of replicas will always be set to 1.
+                              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
+                              Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
                             format: int32
                             minimum: 0
                             type: integer
@@ -785,8 +785,8 @@ spec:
                             default: 1
                             description: |-
                               Defines the number of desired OLS pods. Default: "1"
-                              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console, and Alerts Adapter containers,
-                              the number of replicas will always be set to 1.
+                              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
+                              Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
                             format: int32
                             minimum: 0
                             type: integer
@@ -907,8 +907,8 @@ spec:
                             default: 1
                             description: |-
                               Defines the number of desired OLS pods. Default: "1"
-                              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console, and Alerts Adapter containers,
-                              the number of replicas will always be set to 1.
+                              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
+                              Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
                             format: int32
                             minimum: 0
                             type: integer
@@ -1095,8 +1095,8 @@ spec:
                             default: 1
                             description: |-
                               Defines the number of desired OLS pods. Default: "1"
-                              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console, and Alerts Adapter containers,
-                              the number of replicas will always be set to 1.
+                              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
+                              Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
                             format: int32
                             minimum: 0
                             type: integer
@@ -1283,8 +1283,8 @@ spec:
                             default: 1
                             description: |-
                               Defines the number of desired OLS pods. Default: "1"
-                              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console, and Alerts Adapter containers,
-                              the number of replicas will always be set to 1.
+                              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
+                              Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
                             format: int32
                             minimum: 0
                             type: integer

--- a/config/default/deployment-patch.yaml
+++ b/config/default/deployment-patch.yaml
@@ -24,6 +24,9 @@
   value: --alerts-adapter-image=__REPLACE_LIGHTSPEED_AGENTIC_ALERTS_ADAPTER__
 - op: add
   path: /spec/template/spec/containers/0/args/-
+  value: --otel-collector-image=__REPLACE_LIGHTSPEED_OTEL_COLLECTOR__
+- op: add
+  path: /spec/template/spec/containers/0/args/-
   value: --rhokp-image=__REPLACE_RHOKP__
 - op: replace
   path: /spec/template/spec/containers/0/image

--- a/config/manifests/bases/lightspeed-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/lightspeed-operator.clusterserviceversion.yaml
@@ -47,12 +47,21 @@ spec:
       - description: The name of the secret object that stores API provider credentials
         displayName: Credential Secret
         path: llm.providers[0].credentialsSecretRef
-      - description: |-
-          Audit logging and tracing configuration.
-          Logging and OTEL tracing are independent controls.
-          Default: logging enabled, no OTEL export when absent.
+      - description: Audit log and trace export configuration for the OTEL Collector.
         displayName: Audit Settings
         path: audit
+      - description: |-
+          logging enables audit log storage in PostgreSQL via the Collector.
+          Default: true when absent.
+        displayName: Audit Logging
+        path: audit.logging
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: |-
+          tracingEndpoint is the trace export backend (e.g. "jaeger:4317").
+          The Collector forwards traces here when set. TLS is always used.
+        displayName: Tracing Endpoint
+        path: audit.tracingEndpoint
       - description: |-
           Feature Gates holds list of features to be enabled explicitly, otherwise they are disabled by default.
           possible values: MCPServer, ToolFiltering
@@ -170,6 +179,13 @@ spec:
         path: ols.additionalCAConfigMapRef
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: |-
+          auditEventsEnabled controls structured compliance audit JSON events on stdout.
+          Default: true when absent. Does not affect collector storage (see spec.audit).
+        displayName: Audit Events Enabled
+        path: ols.auditEventsEnabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Only use BYOK RAG sources. Disables OKP (RHOKP sidecar, solr_hybrid
           config, and built-in OCP documentation retrieval).
         displayName: Only use BYOK RAG sources
@@ -202,8 +218,8 @@ spec:
         path: ols.deployment.agenticConsole
       - description: |-
           Defines the number of desired OLS pods. Default: "1"
-          Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console, and Alerts Adapter containers,
-          the number of replicas will always be set to 1.
+          Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
+          Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
         displayName: Number of replicas
         path: ols.deployment.agenticConsole.replicas
         x-descriptors:
@@ -222,8 +238,8 @@ spec:
         path: ols.deployment.alertsAdapter.configMapRef
       - description: |-
           Defines the number of desired OLS pods. Default: "1"
-          Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console, and Alerts Adapter containers,
-          the number of replicas will always be set to 1.
+          Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
+          Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
         displayName: Number of replicas
         path: ols.deployment.alertsAdapter.replicas
         x-descriptors:
@@ -233,8 +249,8 @@ spec:
         path: ols.deployment.api
       - description: |-
           Defines the number of desired OLS pods. Default: "1"
-          Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console, and Alerts Adapter containers,
-          the number of replicas will always be set to 1.
+          Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
+          Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
         displayName: Number of replicas
         path: ols.deployment.api.replicas
         x-descriptors:
@@ -244,8 +260,8 @@ spec:
         path: ols.deployment.console
       - description: |-
           Defines the number of desired OLS pods. Default: "1"
-          Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console, and Alerts Adapter containers,
-          the number of replicas will always be set to 1.
+          Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
+          Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
         displayName: Number of replicas
         path: ols.deployment.console.replicas
         x-descriptors:
@@ -258,8 +274,8 @@ spec:
         path: ols.deployment.database
       - description: |-
           Defines the number of desired OLS pods. Default: "1"
-          Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console, and Alerts Adapter containers,
-          the number of replicas will always be set to 1.
+          Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
+          Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
         displayName: Number of replicas
         path: ols.deployment.database.replicas
         x-descriptors:
@@ -267,6 +283,17 @@ spec:
       - description: MCP server container settings.
         displayName: MCP Server Container
         path: ols.deployment.mcpServer
+      - description: OTEL Collector deployment settings.
+        displayName: OTEL Collector Deployment
+        path: ols.deployment.otelCollector
+      - description: |-
+          Defines the number of desired OLS pods. Default: "1"
+          Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
+          Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
+        displayName: Number of replicas
+        path: ols.deployment.otelCollector.replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
       - description: RHOKP sidecar container settings (Solr / OKP).
         displayName: RHOKP Container
         path: ols.deployment.rhokp

--- a/hack/bundle.Dockerfile
+++ b/hack/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=lightspeed-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
 LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.33.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.36.1
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 

--- a/internal/controller/utils/constants.go
+++ b/internal/controller/utils/constants.go
@@ -489,7 +489,7 @@ var (
 	DataverseExporterImageDefault  = relatedimages.GetDefaultImage("lightspeed-to-dataverse-exporter")
 	AgenticConsoleUIImageDefault   = imageDefaultOr("lightspeed-agentic-console-plugin", agenticConsoleUIImageFallback)
 	AlertsAdapterImageDefault      = imageDefaultOr("lightspeed-agentic-alerts-adapter", alertsAdapterImageFallback)
-	OtelCollectorImageDefault      = imageDefaultOr("lightspeed-otel-postgres-collector", otelCollectorImageFallback)
+	OtelCollectorImageDefault      = imageDefaultOr("lightspeed-otel-collector", otelCollectorImageFallback)
 	RHOOKPImageDefault             = imageDefaultOr("rhokp", rhokpImageFallback)
 )
 
@@ -497,7 +497,7 @@ const (
 	// Fallbacks when related_images.json is unavailable (e.g. local run outside repo root).
 	agenticConsoleUIImageFallback = "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-console:main"
 	alertsAdapterImageFallback    = "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-alerts-adapter:main"
-	otelCollectorImageFallback    = "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-otel-postgres-collector:main"
+	otelCollectorImageFallback    = "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-otel-collector:main"
 	rhokpImageFallback            = "registry.redhat.io/offline-knowledge-portal/rhokp-rhel9:latest"
 )
 

--- a/related_images.json
+++ b/related_images.json
@@ -13,8 +13,8 @@
   },
   {
     "name": "lightspeed-operator-bundle",
-    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols-bundle@sha256:54f9d45d5e1fddf6faba0e449cc697c5e49ea5e198c26c9b38404187ebce3053",
-    "revision": "9bfa0ce6069f04027647ee2052dc8673206c7edb",
+    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols-bundle@sha256:ac585f495a6662e4124e84a1d871a3aa77335c47709c8deca44fc007d953b34f",
+    "revision": "546d48844ff9ab975d0ab80d0cc666ba94979091",
     "snapshot_component": "ols-bundle",
     "snapshot_source": "bundle",
     "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols-bundle",
@@ -31,8 +31,8 @@
   },
   {
     "name": "lightspeed-console-plugin",
-    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console@sha256:36ec4cf72eb7d3f2e6c2af9f7d5612382c9c2dc20d8acee4ccac3ea0ff8bd33d",
-    "revision": "b7fddb5d4c0f9ca42e868ebbad098ea7c1df6f23",
+    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console@sha256:9eb2fa1be5845a1c8361f36fc1a84c3c25ea9b903c616cd0841ab00f50814e2c",
+    "revision": "a96656b1e95768051dec1a719a6dd5908a02d3a4",
     "operator_arg": "console-image",
     "snapshot_component": "lightspeed-console",
     "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console",
@@ -40,8 +40,8 @@
   },
   {
     "name": "lightspeed-operator",
-    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator@sha256:552332d92b58a2082a63e679a4b343e21f67269cd85582dc265b5c6a4379bc13",
-    "revision": "9bfa0ce6069f04027647ee2052dc8673206c7edb",
+    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator@sha256:1645c690a39887f85512db58bc4ea422faaf100884948da36090ae0100a83748",
+    "revision": "3d2f911238c552a6ebbba43fb81b618119793e2c",
     "operator_target": "image",
     "snapshot_component": "lightspeed-operator",
     "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator",
@@ -58,8 +58,8 @@
   },
   {
     "name": "lightspeed-agentic-console-plugin",
-    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-console@sha256:2b472ebdac13b6cdeffe057c9f28b7cb43a4bf767865d781572c4c11dedf4a49",
-    "revision": "55150e9cb9d7c1edff95cf3f6f6bd8191dca98e3",
+    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-console@sha256:5e516e9525d38691a2b712a278cb3dd09840bea6aa39543c11a41b80f763cb4d",
+    "revision": "e58cf05a807e217458615fc93612295d03c3f79f",
     "operator_arg": "agentic-console-image",
     "snapshot_component": "lightspeed-agentic-console",
     "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-console",
@@ -73,6 +73,15 @@
     "snapshot_component": "lightspeed-agentic-alerts-adapter",
     "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-alerts-adapter",
     "stable_prefix": "registry.redhat.io/openshift-lightspeed/lightspeed-agentic-alerts-adapter-rhel9"
+  },
+  {
+    "name": "lightspeed-otel-collector",
+    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-otel-collector@sha256:85e8f70fea5c9005088767f787e39c65ebabac2295f38b3cd846157ef9dcebea",
+    "revision": "0a1798f2dbeebd36b83a9339b7e02fa015dbab61",
+    "operator_arg": "otel-collector-image",
+    "snapshot_component": "lightspeed-otel-collector",
+    "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-otel-collector",
+    "stable_prefix": "registry.redhat.io/openshift-lightspeed/otelcol-lightspeed-rhel9"
   },
   {
     "name": "rhokp",


### PR DESCRIPTION
## Description

**Summary**
Follow-up to #1830 ([OLS-3509](https://redhat.atlassian.net/browse/OLS-3509)): regenerate the OLM bundle so it matches the merged audit/OTEL CRD and operator wiring.
- Add `lightspeed-otel-collector` to `related_images.json` (pinned revision/digest, `operator_arg: otel-collector-image`)
- Wire `--otel-collector-image` through deployment-patch → CSV deployment args and `spec.relatedImages`
- Regenerate bundle CRD/CSV for the new audit schema (`audit.logging`, `audit.tracingEndpoint`, `ols.auditEventsEnabled`, `ols.deployment.otelCollector`)
- Refresh Konflux operand digests (operator, console, agentic-console, bundle) and align bundle version at **1.1.2**
- Pin `make bundle` to `bin/operator-sdk` v1.36.1 (avoid Homebrew SDK stamping wrong builder version)
- Update `Config.Replicas` CSV/CRD description to include OTEL Collector

**Related work**
- Operator/runtime changes: #1830 (merged)
- Collector deployment reconciler: [OLS-3510](https://redhat.atlassian.net/browse/OLS-3510) — same release train; app-server OTLP targets `lightspeed-otel-collector:4317` once collector is deployed

## Type of change

- [ ] Refactor
- [ x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
https://redhat.atlassian.net/browse/OLS-3509
- Closes #
https://redhat.atlassian.net/browse/OLS-3509


## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added granular OTEL Collector audit configuration (logging toggle and tracing export endpoint).
  - Added an option to enable/disable structured audit JSON event output.
  - Expanded CRD UI descriptors to cover OTEL Collector and MCP server deployment settings, including fixed replica behavior.
- **Bug Fixes**
  - Updated the OTEL Collector image default resolution so missing related-image entries now fall back to the correct OTEL Collector image.
- **Chores**
  - Refreshed bundle/CSV metadata, operator-sdk build logic, and bundle version/tag and image labels; updated deployment arguments and related image digests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->