### PR TITLE
CNV-83516: Enable kubevirt toolset in default MCP server config

### DIFF
--- a/internal/controller/ocpmcp/assets.go
+++ b/internal/controller/ocpmcp/assets.go
@@ -29,7 +29,8 @@ const configTOML = `# Denied resources prevent the MCP server from accessing the
 # Toolsets are pinned explicitly so upstream default changes do not affect OLS.
 
 read_only = false
-toolsets = ["core", "config", "helm", "observability/metrics"]
+toolsets = ["core", "config", "helm", "observability/metrics", "kubevirt"]
+experimental_enable_target_compatibility_tool_filters = true
 
 [[denied_resources]]
 group = ""

--- a/internal/controller/ocpmcp/assets.go
+++ b/internal/controller/ocpmcp/assets.go
@@ -23,7 +23,8 @@ const configTOML = `# Denied resources prevent the MCP server from accessing the
 # User-brought MCP servers (spec.mcpServers) are the user's responsibility to secure.
 # Toolsets are pinned explicitly so upstream default changes do not affect OLS.
 
-toolsets = ["core", "config", "helm", "metrics"]
+toolsets = ["core", "config", "helm", "metrics", "kubevirt"]
+experimental_enable_target_compatibility_tool_filters = true
 
 [[denied_resources]]
 group = ""

--- a/internal/controller/ocpmcp/assets_test.go
+++ b/internal/controller/ocpmcp/assets_test.go
@@ -31,7 +31,8 @@ var _ = Describe("OpenShift MCP Server assets", func() {
 		Expect(cm.Labels).To(Equal(labels))
 
 		toml := cm.Data[utils.OpenShiftMCPServerConfigFilename]
-		Expect(toml).To(ContainSubstring(`toolsets = ["core", "config", "helm", "metrics"]`))
+		Expect(toml).To(ContainSubstring(`toolsets = ["core", "config", "helm", "metrics", "kubevirt"]`))
+		Expect(toml).To(ContainSubstring(`experimental_enable_target_compatibility_tool_filters = true`))
 		Expect(toml).To(ContainSubstring(`kind = "Secret"`))
 		Expect(toml).To(ContainSubstring(`group = ""`))
 		Expect(toml).To(ContainSubstring(`group = "rbac.authorization.k8s.io"`))

--- a/internal/controller/ocpmcp/assets_test.go
+++ b/internal/controller/ocpmcp/assets_test.go
@@ -33,7 +33,8 @@ var _ = Describe("OpenShift MCP Server assets", func() {
 
 		toml := cm.Data[utils.OpenShiftMCPServerConfigFilename]
 		Expect(toml).To(ContainSubstring("read_only = false"))
-		Expect(toml).To(ContainSubstring(`toolsets = ["core", "config", "helm", "observability/metrics"]`))
+		Expect(toml).To(ContainSubstring(`toolsets = ["core", "config", "helm", "observability/metrics", "kubevirt"]`))
+		Expect(toml).To(ContainSubstring(`experimental_enable_target_compatibility_tool_filters = true`))
 		Expect(toml).To(ContainSubstring(`kind = "Secret"`))
 		Expect(toml).To(ContainSubstring(`group = ""`))
 		Expect(toml).To(ContainSubstring(`group = "rbac.authorization.k8s.io"`))


### PR DESCRIPTION
## Description

Enable the kubevirt toolset in the default MCP server config deployed by the operator. The kubevirt toolset is safe to enable unconditionally thanks to two layers of protection:

1. **TargetCompatibilityFilters** ([kubernetes-mcp-server#1298](https://github.com/containers/kubernetes-mcp-server/pull/1298)) — kubevirt tools now declare GVK-based filters that check for `kubevirt.io/v1 VirtualMachine` on connected clusters. When KubeVirt is not installed, the tools are **completely hidden** from the MCP client — they never appear in the tool list.

2. **Graceful error handling** — as a fallback, if a kubevirt tool is somehow invoked on a cluster without CNV, it returns a tool-level error (`IsError: true`) to the LLM rather than crashing the MCP server.

This replaces the previous justification that relied solely on error handling. With target compatibility filtering, there is zero cost to enabling the toolset on clusters without KubeVirt — the tools simply don't appear.

## Type of change

- [x] Configuration Update

## Related Tickets & Documents

- Related Issue: [CNV-83516](https://redhat.atlassian.net/browse/CNV-83516)
- Related Issue: [OBSINTA-1509](https://redhat.atlassian.net/browse/OBSINTA-1509)
- Related PR: [kubernetes-mcp-server#1298](https://github.com/containers/kubernetes-mcp-server/pull/1298) — TargetCompatibilityFilters for kubevirt toolset
- Related PR: [kubernetes-mcp-server#1293](https://github.com/containers/kubernetes-mcp-server/pull/1293) — Config option for toolset prefiltering

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

- Existing Ginkgo spec in `internal/controller/ocpmcp/assets_test.go` updated to validate the kubevirt toolset and `experimental_enable_target_compatibility_tool_filters` in the generated TOML ConfigMap.
- The kubevirt toolset uses the Kubernetes dynamic client to interact with KubeVirt CRDs. When CNV is not installed, tools are hidden via TargetCompatibilityFilters. If somehow invoked directly, tool invocations return a tool-level error result (`IsError: true`) to the LLM — the MCP server process continues running normally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added KubeVirt tools to the standalone OpenShift MCP server.
  * Enabled compatibility-based filtering for experimental tools.
  * Added explicit metrics endpoint configuration and HTTPS monitoring support for improved observability.
* **Bug Fixes**
  * Improved standalone server configuration validation, including read-only mode and configuration volume mounting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->