### PR TITLE
OLS-3520: Grant operator RBAC for alerts adapter Alertmanager RoleBinding

### DIFF
--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -853,6 +853,15 @@ spec:
                 - update
                 - watch
             - apiGroups:
+                - monitoring.coreos.com
+              resourceNames:
+                - main
+              resources:
+                - alertmanagers/api
+              verbs:
+                - get
+                - list
+            - apiGroups:
                 - networking.k8s.io
               resources:
                 - networkpolicies

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -123,6 +123,15 @@ rules:
   - watch
 - apiGroups:
   - monitoring.coreos.com
+  resourceNames:
+  - main
+  resources:
+  - alertmanagers/api
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - monitoring.coreos.com
   resources:
   - prometheusrules
   - servicemonitors

--- a/internal/controller/olsconfig_controller.go
+++ b/internal/controller/olsconfig_controller.go
@@ -131,6 +131,8 @@ type OLSConfigReconciler struct {
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings;rolebindings,verbs=get;list;create;update;patch;delete;watch
 // AgenticRun API for alerts adapter ClusterRole (operator must hold permissions it grants to operands)
 // +kubebuilder:rbac:groups=agentic.openshift.io,resources=agenticruns,verbs=get;list;create
+// Alertmanager API for alerts adapter RoleBinding to monitoring-alertmanager-view (operator must hold permissions it grants)
+// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=alertmanagers/api,resourceNames=main,verbs=get;list
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,namespace=openshift-lightspeed,resources=roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
 // NonResourceURLs for Lightspeed access control and metrics
 // +kubebuilder:rbac:urls=/ls-access,verbs=get


### PR DESCRIPTION
## Description

**Summary**
- Fixes RBAC escalation when reconciling the alerts adapter Alertmanager RoleBinding to `monitoring-alertmanager-view`.
- Adds `get`/`list` on `monitoring.coreos.com/alertmanagers/api` (`resourceNames: main`) to the operator ClusterRole so it can grant those permissions.
- Updates kubebuilder markers, `config/rbac/role.yaml`, and the CSV.
Fixes: https://redhat.atlassian.net/browse/OLS-3520


## Type of change

- [ ] Refactor
- [ ] New feature
- [ x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
https://redhat.atlassian.net/browse/OLS-3520
- Closes #
https://redhat.atlassian.net/browse/OLS-3520

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved monitoring integration by allowing the application to read the primary Alertmanager API resource.
  * Updated deployment permissions to support retrieving Alertmanager configuration and status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->