### PR TITLE
Fixing flakiness in tests

### DIFF
--- a/internal/controller/olsconfig_controller.go
+++ b/internal/controller/olsconfig_controller.go
@@ -592,6 +592,14 @@ func (r *OLSConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// 5. Phase 1: Reconcile independent resources
 	if err := r.reconcileIndependentResources(ctx, olsconfig); err != nil {
+		if isRESTMappingError(err) {
+			// After CRD installation, the API server's discovery cache may not yet
+			// contain the OLSConfig kind. Returning a nil error with RequeueAfter
+			// resets the rate limiter's failure counter (Forget), preventing rapid
+			// self-triggered retries from poisoning the backoff to 1000s.
+			r.Logger.Info("API server discovery cache has not yet registered the OLSConfig CRD, retrying", "requeueAfter", "5s")
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		}
 		return ctrl.Result{}, err
 	}
 

--- a/internal/controller/olsconfig_helpers.go
+++ b/internal/controller/olsconfig_helpers.go
@@ -555,3 +555,13 @@ func (r *OLSConfigReconciler) shouldWatchConfigMap(obj client.Object) bool {
 
 	return false
 }
+
+// isRESTMappingError returns true when the error is caused by the API server's
+// discovery cache not yet containing the OLSConfig CRD. After CRD installation,
+// the API server rejects owner references with blockOwnerDeletion because it
+// cannot resolve the owner's GVK. This is transient — the cache refreshes
+// within seconds — but rapid reconciliation failures during the window can
+// poison the workqueue rate limiter (base 5ms, 45 failures → capped at 1000s).
+func isRESTMappingError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "cannot find RESTMapping")
+}

--- a/internal/controller/olsconfig_helpers_test.go
+++ b/internal/controller/olsconfig_helpers_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -320,6 +321,28 @@ var _ = Describe("Watcher Predicates", func() {
 			result := reconciler.shouldWatchConfigMap(cm)
 			Expect(result).To(BeTrue())
 		})
+	})
+})
+
+var _ = Describe("isRESTMappingError", func() {
+	It("should return true for RESTMapping errors from API server", func() {
+		err := fmt.Errorf("configmaps \"lightspeed-console-plugin\" is forbidden: cannot set blockOwnerDeletion in this case because cannot find RESTMapping for APIVersion ols.openshift.io/v1alpha1 Kind OLSConfig")
+		Expect(isRESTMappingError(err)).To(BeTrue())
+	})
+
+	It("should return true when wrapped in reconciliation error", func() {
+		inner := fmt.Errorf("cannot find RESTMapping for APIVersion ols.openshift.io/v1alpha1 Kind OLSConfig")
+		err := fmt.Errorf("failed to reconcile resources: %w", inner)
+		Expect(isRESTMappingError(err)).To(BeTrue())
+	})
+
+	It("should return false for unrelated errors", func() {
+		err := fmt.Errorf("connection refused")
+		Expect(isRESTMappingError(err)).To(BeFalse())
+	})
+
+	It("should return false for nil error", func() {
+		Expect(isRESTMappingError(nil)).To(BeFalse())
 	})
 })
 


### PR DESCRIPTION
## Description

PR to address rate limiter flakiness in tests.
example failure https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_lightspeed-service/3005/pull-ci-openshift-lightspeed-service-main-e2e-ols-cluster/2079794011987513344/artifacts/e2e-ols-cluster/e2e/artifacts/azure_openai/cluster/podlogs/lightspeed-operator-controller-manager-5c56db955c-88vsl-manager.log

Root cause

  When the OLS operator is installed via OLM, the OLSConfig CRD is registered with the API server. But
  the API server's discovery cache doesn't refresh instantly — there's a brief window where the CRD
  exists but the API server can't resolve its GVK.

  During that window, the operator picks up the OLSConfig CR and tries to create child resources
  (ConfigMaps, ServiceAccounts, etc.) with blockOwnerDeletion: true owner references. The API server
  rejects these because its admission controller can't validate the owner GVK through the stale
  discovery cache:

  ▎ cannot set blockOwnerDeletion ... cannot find RESTMapping for APIVersion ols.openshift.io/v1alpha1 
  ▎ Kind OLSConfig

  Each failed reconciliation updates the OLSConfig CR status, which triggers the watcher, which enqueues
  another reconciliation. This creates a self-triggering loop: 45 failures in 5 seconds.
  controller-runtime's rate limiter uses exponential backoff starting at 5ms base, so after 45 failures:
  5ms * 2^45 → capped at 1000 seconds (16.7 minutes). The next retry is pushed far past the e2e test's
  120-second timeout, so the test never sees the deployment created.

  Fix

  In Reconcile(), detect the RESTMapping error and return ctrl.Result{RequeueAfter: 5 * time.Second}, 
  nil instead of returning the error. Returning a nil error causes controller-runtime to call
  rateLimiter.Forget(), which resets the failure counter. The status is still updated (so the CR
  reflects the failure), but the rate limiter isn't poisoned. After a fixed 5-second wait, the API
  server's discovery cache has refreshed and the next reconciliation succeeds.

  Changes (3 files in lightspeed-operator)

  1. olsconfig_helpers.go — added isRESTMappingError() helper that checks for the specific error string
  2. olsconfig_controller.go — in Reconcile(), Phase 1 error handling now checks isRESTMappingError(err)
  and returns RequeueAfter: 5s with nil error instead of propagating the error
  3. olsconfig_helpers_test.go — 4 test cases covering the helper (matching error, wrapped error,
  unrelated error, nil)

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconciliation reliability after installing custom resources by handling temporary API discovery delays.
  * Prevented unnecessary rapid retry backoff during these transient conditions.
  * Automatically retries reconciliation after a short delay when resource mappings are not yet available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->