### PR TITLE
OLS-3696: update templog spec for phase storage

### DIFF
--- a/.ai/spec/what/templog.md
+++ b/.ai/spec/what/templog.md
@@ -79,7 +79,7 @@ Service continues to use the existing gRPC OTLP trace exporter (`opentelemetry.e
 
 The Postgres bootstrap script creates only `quota` and `conversation_cache` schemas. It does **not** create the `templogs` schema or tables.
 
-The OTEL Collector always creates and manages the `templogs` schema, `logs` table, and indexes via the `postgres_admin` extension at collector startup (`postgres_admin` is always enabled for clients). `spec.audit.logging` only controls whether new OTLP logs are exported into that schema. The operator never drops this schema.
+The OTEL Collector always creates and manages the `templogs` schema, `logs` table, and indexes via the `postgres_admin` extension at collector startup (`postgres_admin` is always enabled for clients). `spec.audit.logging` only controls whether new OTLP logs are exported into that schema. The operator never drops this schema. The `logs` table uses `agentic_run_id` (AgenticRun UID, normalized to 32-char hex) and `phase` (audit phase name) as the primary query dimensions, with a composite index on `(agentic_run_id, phase)`.
 
 See `postgres.md` for Postgres bootstrap scope and `templog.md` (lightspeed-service repo) for table DDL semantics.
 


### PR DESCRIPTION
## Summary

Update operator templog spec to reference `agentic_run_id` and `phase` columns with composite index in `templogs.logs` table.

Part of [OLS-3696](https://redhat.atlassian.net/browse/OLS-3696) cross-repo spec update. See central design spec in `openshift/ols` PR.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how the OTEL Collector provisions and maintains the `templogs` schema and `logs` table.
  * Documented the logging toggle behavior for exporting new OTLP logs.
  * Added details about primary query dimensions and indexing.
  * Confirmed that the schema is never automatically dropped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->