### PR TITLE
OLS-3705 Fix OTel collector crash: routing/traces table must not be empty

### DIFF
--- a/internal/controller/otelcollector/assets.go
+++ b/internal/controller/otelcollector/assets.go
@@ -379,7 +379,13 @@ func buildCollectorConfigYAML(cr *olsv1alpha1.OLSConfig) ([]byte, error) {
 			},
 		}
 		connectors["routing/traces"] = map[string]interface{}{
-			"default_pipelines": []interface{}{"traces/lightspeed"},
+			"default_pipelines": []interface{}{},
+			"table": []interface{}{
+				map[string]interface{}{
+					"condition": fmt.Sprintf(`resource.attributes["service.name"] == %q`, utils.OtelAppServerServiceName),
+					"pipelines": []interface{}{"traces/lightspeed"},
+				},
+			},
 		}
 		pipelines["traces"] = map[string]interface{}{
 			"receivers":  []interface{}{"otlp"},

--- a/internal/controller/otelcollector/assets_test.go
+++ b/internal/controller/otelcollector/assets_test.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/yaml"
 
 	olsv1alpha1 "github.com/openshift/lightspeed-operator/api/v1alpha1"
 	"github.com/openshift/lightspeed-operator/internal/controller/utils"
@@ -95,6 +96,13 @@ var _ = Describe("OTEL Collector assets", func() {
 		Expect(configYAML).To(ContainSubstring("otlp/tracing"))
 		Expect(configYAML).To(ContainSubstring("${env:TRACES_BACKEND_ENDPOINT}"))
 		Expect(configYAML).To(ContainSubstring("traces/lightspeed"))
+
+		var config map[string]interface{}
+		Expect(yaml.Unmarshal([]byte(configYAML), &config)).To(Succeed())
+		connectors := config["connectors"].(map[string]interface{})
+		routingTraces := connectors["routing/traces"].(map[string]interface{})
+		table := routingTraces["table"].([]interface{})
+		Expect(table).NotTo(BeEmpty(), "routing/traces table must have at least one entry")
 	})
 
 	It("should generate the collector Service with serving-cert annotation", func() {

--- a/internal/controller/utils/constants.go
+++ b/internal/controller/utils/constants.go
@@ -300,6 +300,8 @@ const (
 	OtelCollectorFileStorageMountPath = "/var/lib/otelcol/file_storage"
 	// OtelSandboxServiceName is the OTLP service.name for agentic sandbox audit logs routed to Postgres.
 	OtelSandboxServiceName = "lightspeed-agentic-sandbox"
+	// OtelAppServerServiceName is the OTLP service.name for lightspeed-service traces.
+	OtelAppServerServiceName = "lightspeed-service"
 	// OtelCollectorServingCertTLSFile is the serving certificate path in collector YAML.
 	OtelCollectorServingCertTLSFile = "/var/run/secrets/serving-cert/tls.crt"
 	// OtelCollectorServingCertTLSKeyFile is the serving certificate key path in collector YAML.


### PR DESCRIPTION
## Summary

- The routing connector requires at least one table entry — `routing/traces` was configured with only `default_pipelines` and an empty table, causing the collector to crash on startup with: `invalid routing table: the routing table is empty`
- Add a routing rule for `lightspeed-service` traces, matching the existing `routing/logs` pattern
- Add `OtelAppServerServiceName` constant for the trace routing condition

## Test plan

- [x] `make test` — all unit tests pass
- [x] New assertion verifies `routing/traces` table is non-empty
- [ ] Deploy and confirm collector starts without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * When a tracing endpoint is configured, the collector now uses the in-cluster service CA bundle for secure OTLP TLS connections.
  * Improved trace routing so only traces from the Lightspeed service are sent to the Lightspeed trace pipeline, with routing no longer enabled by default.

* **Tests**
  * Expanded coverage to validate the generated trace-routing connector configuration by parsing the ConfigMap YAML and asserting the connector’s routing table structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->