### PR TITLE
OLS-0000 Fix spec navigation: add missing what/ files to README Quick Start

### DIFF
--- a/.ai/spec/README.md
+++ b/.ai/spec/README.md
@@ -36,6 +36,10 @@ AI agents (Claude). Content is optimized for precision and machine consumption o
 | Understand the CRD | `what/crd-api.md` |
 | Navigate the codebase | `how/project-structure.md` |
 | Understand console plugins | `what/console-ui.md` (chat), `what/agentic-console-ui.md` (agentic) |
+| Understand app server deployment | `what/app-server.md` |
+| Understand PostgreSQL deployment | `what/postgres.md` |
+| Understand temporary audit log storage | `what/templog.md` |
+| Understand audit logging | `what/audit-logging.md` |
 | Understand TLS configuration | `what/tls.md` |
 | Understand security constraints | `what/security.md` |
 | Debug external resource watching | `what/resource-lifecycle.md` + `how/reconciliation.md` |

--- a/.ai/spec/health-report.md
+++ b/.ai/spec/health-report.md
@@ -1,0 +1,25 @@
+# Spec health report
+
+Last evaluated: 2026-07-22
+Trigger: multi-repo child spec evaluation
+Layout: software (.ai/spec/)
+
+## Status: All Issues Fixed ✓
+
+### Fixed Issues
+
+**README Quick Start table missing 4 spec entries** ✓
+- Added rows for `what/app-server.md`, `what/postgres.md`, `what/templog.md`, `what/audit-logging.md`
+- These files were documented in the Cross-Reference section but not discoverable from Quick Start
+- Now Quick Start is complete and all specs are navigable
+
+## Verification
+
+✓ All what/ files now appear in Quick Start or Cross-Reference
+✓ No placeholder text (TBD, TODO, FIXME) in specs
+✓ PLANNED markers properly tracked (4 tickets: OLS-3526, OLS-3572, OLS-3221, OLS-3594)
+✓ No broken cross-references
+
+## Result
+
+Spec structure is healthy. README navigation is now complete.


### PR DESCRIPTION
Added four spec files to README Quick Start table: app-server, postgres, templog, audit-logging. These files were documented in Cross-Reference section but not discoverable from Quick Start navigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Quick Start links for app server deployment, PostgreSQL deployment, temporary audit log storage, and audit logging guidance.
  * Updated the health report to confirm complete specification navigation and resolved documentation issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->