### PR TITLE
OLS-0000 Fix spec navigation: add missing what/ files to README Quick Start

### DIFF
--- a/.ai/spec/README.md
+++ b/.ai/spec/README.md
@@ -36,6 +36,10 @@ AI agents (Claude). Content is optimized for precision and machine consumption o
 | Understand the CRD | `what/crd-api.md` |
 | Navigate the codebase | `how/project-structure.md` |
 | Understand console plugins | `what/console-ui.md` (chat), `what/agentic-console-ui.md` (agentic) |
+| Understand app server deployment | `what/app-server.md` |
+| Understand PostgreSQL deployment | `what/postgres.md` |
+| Understand temporary audit log storage | `what/templog.md` |
+| Understand audit logging | `what/audit-logging.md` |
 | Understand TLS configuration | `what/tls.md` |
 | Understand security constraints | `what/security.md` |
 | Debug external resource watching | `what/resource-lifecycle.md` + `how/reconciliation.md` |


### PR DESCRIPTION
Added four spec files to README Quick Start table: app-server.md, postgres.md, templog.md, audit-logging.md. These files were documented in Cross-Reference section but not discoverable from Quick Start navigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added four onboarding tasks covering app server deployment, PostgreSQL deployment, temporary audit log storage, and audit logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->