### PR TITLE
Bundle Update from Snapshot crt-nshift-lightspeed-tenant/ols-20260723-073100-000

### DIFF
--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     console.openshift.io/operator-monitoring-default: "true"
-    createdAt: "2026-07-20T21:19:08Z"
+    createdAt: "2026-07-23T22:54:06Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -247,9 +247,10 @@ spec:
             displayName: Agentic Console Deployment
             path: ols.deployment.agenticConsole
           - description: |-
-              Defines the number of desired OLS pods. Default: "1"
-              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
-              Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
+              Defines the number of desired pods. Default: "1"
+              Note: Replicas are configurable for APIContainer and MCP server (mcpServer).
+              For PostgreSQL, Console, Agentic Console, Alerts Adapter, and OTEL Collector,
+              the number of replicas is always set to 1.
             displayName: Number of replicas
             path: ols.deployment.agenticConsole.replicas
             x-descriptors:
@@ -267,9 +268,10 @@ spec:
             displayName: Alerts Adapter ConfigMap Reference
             path: ols.deployment.alertsAdapter.configMapRef
           - description: |-
-              Defines the number of desired OLS pods. Default: "1"
-              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
-              Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
+              Defines the number of desired pods. Default: "1"
+              Note: Replicas are configurable for APIContainer and MCP server (mcpServer).
+              For PostgreSQL, Console, Agentic Console, Alerts Adapter, and OTEL Collector,
+              the number of replicas is always set to 1.
             displayName: Number of replicas
             path: ols.deployment.alertsAdapter.replicas
             x-descriptors:
@@ -278,9 +280,10 @@ spec:
             displayName: API Deployment
             path: ols.deployment.api
           - description: |-
-              Defines the number of desired OLS pods. Default: "1"
-              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
-              Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
+              Defines the number of desired pods. Default: "1"
+              Note: Replicas are configurable for APIContainer and MCP server (mcpServer).
+              For PostgreSQL, Console, Agentic Console, Alerts Adapter, and OTEL Collector,
+              the number of replicas is always set to 1.
             displayName: Number of replicas
             path: ols.deployment.api.replicas
             x-descriptors:
@@ -289,9 +292,10 @@ spec:
             displayName: Console Deployment
             path: ols.deployment.console
           - description: |-
-              Defines the number of desired OLS pods. Default: "1"
-              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
-              Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
+              Defines the number of desired pods. Default: "1"
+              Note: Replicas are configurable for APIContainer and MCP server (mcpServer).
+              For PostgreSQL, Console, Agentic Console, Alerts Adapter, and OTEL Collector,
+              the number of replicas is always set to 1.
             displayName: Number of replicas
             path: ols.deployment.console.replicas
             x-descriptors:
@@ -303,23 +307,34 @@ spec:
             displayName: Database Deployment
             path: ols.deployment.database
           - description: |-
-              Defines the number of desired OLS pods. Default: "1"
-              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
-              Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
+              Defines the number of desired pods. Default: "1"
+              Note: Replicas are configurable for APIContainer and MCP server (mcpServer).
+              For PostgreSQL, Console, Agentic Console, Alerts Adapter, and OTEL Collector,
+              the number of replicas is always set to 1.
             displayName: Number of replicas
             path: ols.deployment.database.replicas
             x-descriptors:
               - urn:alm:descriptor:com.tectonic.ui:podCount
-          - description: MCP server container settings.
-            displayName: MCP Server Container
+          - description: MCP server deployment settings.
+            displayName: MCP Server Deployment
             path: ols.deployment.mcpServer
+          - description: |-
+              Defines the number of desired pods. Default: "1"
+              Note: Replicas are configurable for APIContainer and MCP server (mcpServer).
+              For PostgreSQL, Console, Agentic Console, Alerts Adapter, and OTEL Collector,
+              the number of replicas is always set to 1.
+            displayName: Number of replicas
+            path: ols.deployment.mcpServer.replicas
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:podCount
           - description: OTEL Collector deployment settings.
             displayName: OTEL Collector Deployment
             path: ols.deployment.otelCollector
           - description: |-
-              Defines the number of desired OLS pods. Default: "1"
-              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
-              Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
+              Defines the number of desired pods. Default: "1"
+              Note: Replicas are configurable for APIContainer and MCP server (mcpServer).
+              For PostgreSQL, Console, Agentic Console, Alerts Adapter, and OTEL Collector,
+              the number of replicas is always set to 1.
             displayName: Number of replicas
             path: ols.deployment.otelCollector.replicas
             x-descriptors:
@@ -331,8 +346,8 @@ spec:
             displayName: Image Pull Secrets
             path: ols.imagePullSecrets
           - description: |-
-              Enable introspection features (e.g. built-in OpenShift MCP server). Omitted means use the
-              CRD default (true); explicit false disables introspection.
+              Enable introspection features (e.g. built-in OpenShift MCP server).
+              Default: true when absent. Explicit false disables introspection.
             displayName: Introspection Enabled
             path: ols.introspectionEnabled
             x-descriptors:
@@ -963,12 +978,12 @@ spec:
                       - --cert-dir=/etc/tls/private
                       - --dataverse-exporter-image=registry.redhat.io/lightspeed-core/dataverse-exporter-rhel9@sha256:1c7ffaead23adfb1dc6bd3adfe75c80f284d6d31f13ca427d754703c78514cb2
                       - --postgres-image=registry.redhat.io/rhel9/postgresql-16@sha256:42f385ac3c9b8913426da7c57e70bc6617cd237aaf697c667f6385a8c0b0118b
-                      - --service-image=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service@sha256:2cda2f011996b457462ac3da3b00b37d854bc8bd48c60a8879a386a3e54b9b79
-                      - --console-image=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console@sha256:91b7c5316e44e414f0256c276cf975ce5525f0a1ca7c1683730c66f271632f5e
-                      - --openshift-mcp-server-image=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/openshift-mcp-server@sha256:5b8e3b6a9d46e4825f731819274efbc88dc63f1dc47e8eefe9339bf90da4c02d
-                      - --agentic-console-image=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-console@sha256:a7900060ec7928f03559bd2300bc1642ae0a57b10e30ce9f9804e8102a84b7f7
-                      - --alerts-adapter-image=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-alerts-adapter@sha256:9049b11048de0717523b27e0c23ae283245df34b5dfb2d24571148e730cca4e2
-                      - --otel-collector-image=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-otel-collector@sha256:85e8f70fea5c9005088767f787e39c65ebabac2295f38b3cd846157ef9dcebea
+                      - --service-image=registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9@sha256:73fa6825f8f24c4b893fba177ac415ad4322de56af7940b4a4084a9bc72a7910
+                      - --console-image=registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:f53e11c14e291fb19f87a24fb512bbf59ec350bcb3af7a114663febc77b4c1b9
+                      - --openshift-mcp-server-image=registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9@sha256:5b8e3b6a9d46e4825f731819274efbc88dc63f1dc47e8eefe9339bf90da4c02d
+                      - --agentic-console-image=registry.redhat.io/openshift-lightspeed/lightspeed-agentic-console-rhel9@sha256:b08ceeb59e29b55ceab15e87700ac6173ccf59d146dd616a3e2e7ed5ddc8927e
+                      - --alerts-adapter-image=registry.redhat.io/openshift-lightspeed/lightspeed-agentic-alerts-adapter-rhel9@sha256:10af58d31ab3add2e6ec1058ba5d10a87e2d5a4d77258b3f47a0ffc84eff3770
+                      - --otel-collector-image=registry.redhat.io/openshift-lightspeed/otelcol-lightspeed-rhel9@sha256:fb86a2c82c959e8ec72e707ce6cc0c4005f806da38ec50da5606557346549cd3
                       - --rhokp-image=registry.redhat.io/offline-knowledge-portal/rhokp-rhel9:latest
                     command:
                       - /manager
@@ -977,7 +992,7 @@ spec:
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.annotations['olm.targetNamespaces']
-                    image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator@sha256:0f4eac671fafd4f27d683e150b6d767c701484c129f983c0d68fd1fb5ce790b1
+                    image: registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:cf864a9f6cd3af1ac3f539b982239fff4aafe576c518e3e189cfd9bd6733c4f7
                     imagePullPolicy: Always
                     livenessProbe:
                       httpGet:
@@ -1098,18 +1113,18 @@ spec:
     - name: lightspeed-postgresql
       image: registry.redhat.io/rhel9/postgresql-16@sha256:42f385ac3c9b8913426da7c57e70bc6617cd237aaf697c667f6385a8c0b0118b
     - name: lightspeed-service-api
-      image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service@sha256:2cda2f011996b457462ac3da3b00b37d854bc8bd48c60a8879a386a3e54b9b79
+      image: registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9@sha256:73fa6825f8f24c4b893fba177ac415ad4322de56af7940b4a4084a9bc72a7910
     - name: lightspeed-console-plugin
-      image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console@sha256:91b7c5316e44e414f0256c276cf975ce5525f0a1ca7c1683730c66f271632f5e
+      image: registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:f53e11c14e291fb19f87a24fb512bbf59ec350bcb3af7a114663febc77b4c1b9
     - name: lightspeed-operator
-      image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator@sha256:0f4eac671fafd4f27d683e150b6d767c701484c129f983c0d68fd1fb5ce790b1
+      image: registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:cf864a9f6cd3af1ac3f539b982239fff4aafe576c518e3e189cfd9bd6733c4f7
     - name: openshift-mcp-server
-      image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/openshift-mcp-server@sha256:5b8e3b6a9d46e4825f731819274efbc88dc63f1dc47e8eefe9339bf90da4c02d
+      image: registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9@sha256:5b8e3b6a9d46e4825f731819274efbc88dc63f1dc47e8eefe9339bf90da4c02d
     - name: lightspeed-agentic-console-plugin
-      image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-console@sha256:a7900060ec7928f03559bd2300bc1642ae0a57b10e30ce9f9804e8102a84b7f7
+      image: registry.redhat.io/openshift-lightspeed/lightspeed-agentic-console-rhel9@sha256:b08ceeb59e29b55ceab15e87700ac6173ccf59d146dd616a3e2e7ed5ddc8927e
     - name: lightspeed-agentic-alerts-adapter
-      image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-alerts-adapter@sha256:9049b11048de0717523b27e0c23ae283245df34b5dfb2d24571148e730cca4e2
+      image: registry.redhat.io/openshift-lightspeed/lightspeed-agentic-alerts-adapter-rhel9@sha256:10af58d31ab3add2e6ec1058ba5d10a87e2d5a4d77258b3f47a0ffc84eff3770
     - name: lightspeed-otel-collector
-      image: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-otel-collector@sha256:85e8f70fea5c9005088767f787e39c65ebabac2295f38b3cd846157ef9dcebea
+      image: registry.redhat.io/openshift-lightspeed/otelcol-lightspeed-rhel9@sha256:fb86a2c82c959e8ec72e707ce6cc0c4005f806da38ec50da5606557346549cd3
     - name: rhokp
       image: registry.redhat.io/offline-knowledge-portal/rhokp-rhel9:latest

--- a/bundle/manifests/ols.openshift.io_olsconfigs.yaml
+++ b/bundle/manifests/ols.openshift.io_olsconfigs.yaml
@@ -519,9 +519,10 @@ spec:
                           replicas:
                             default: 1
                             description: |-
-                              Defines the number of desired OLS pods. Default: "1"
-                              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
-                              Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
+                              Defines the number of desired pods. Default: "1"
+                              Note: Replicas are configurable for APIContainer and MCP server (mcpServer).
+                              For PostgreSQL, Console, Agentic Console, Alerts Adapter, and OTEL Collector,
+                              the number of replicas is always set to 1.
                             format: int32
                             minimum: 0
                             type: integer
@@ -662,9 +663,10 @@ spec:
                           replicas:
                             default: 1
                             description: |-
-                              Defines the number of desired OLS pods. Default: "1"
-                              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
-                              Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
+                              Defines the number of desired pods. Default: "1"
+                              Note: Replicas are configurable for APIContainer and MCP server (mcpServer).
+                              For PostgreSQL, Console, Agentic Console, Alerts Adapter, and OTEL Collector,
+                              the number of replicas is always set to 1.
                             format: int32
                             minimum: 0
                             type: integer
@@ -784,9 +786,10 @@ spec:
                           replicas:
                             default: 1
                             description: |-
-                              Defines the number of desired OLS pods. Default: "1"
-                              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
-                              Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
+                              Defines the number of desired pods. Default: "1"
+                              Note: Replicas are configurable for APIContainer and MCP server (mcpServer).
+                              For PostgreSQL, Console, Agentic Console, Alerts Adapter, and OTEL Collector,
+                              the number of replicas is always set to 1.
                             format: int32
                             minimum: 0
                             type: integer
@@ -906,9 +909,10 @@ spec:
                           replicas:
                             default: 1
                             description: |-
-                              Defines the number of desired OLS pods. Default: "1"
-                              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
-                              Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
+                              Defines the number of desired pods. Default: "1"
+                              Note: Replicas are configurable for APIContainer and MCP server (mcpServer).
+                              For PostgreSQL, Console, Agentic Console, Alerts Adapter, and OTEL Collector,
+                              the number of replicas is always set to 1.
                             format: int32
                             minimum: 0
                             type: integer
@@ -1094,9 +1098,10 @@ spec:
                           replicas:
                             default: 1
                             description: |-
-                              Defines the number of desired OLS pods. Default: "1"
-                              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
-                              Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
+                              Defines the number of desired pods. Default: "1"
+                              Note: Replicas are configurable for APIContainer and MCP server (mcpServer).
+                              For PostgreSQL, Console, Agentic Console, Alerts Adapter, and OTEL Collector,
+                              the number of replicas is always set to 1.
                             format: int32
                             minimum: 0
                             type: integer
@@ -1206,8 +1211,23 @@ spec:
                             type: array
                         type: object
                       mcpServer:
-                        description: MCP server container settings.
+                        description: MCP server deployment settings.
                         properties:
+                          nodeSelector:
+                            additionalProperties:
+                              type: string
+                            description: Node selector constraints
+                            type: object
+                          replicas:
+                            default: 1
+                            description: |-
+                              Defines the number of desired pods. Default: "1"
+                              Note: Replicas are configurable for APIContainer and MCP server (mcpServer).
+                              For PostgreSQL, Console, Agentic Console, Alerts Adapter, and OTEL Collector,
+                              the number of replicas is always set to 1.
+                            format: int32
+                            minimum: 0
+                            type: integer
                           resources:
                             description: |-
                               Resource requirements (CPU, memory)
@@ -1270,6 +1290,48 @@ spec:
                                   More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                             type: object
+                          tolerations:
+                            description: |-
+                              Tolerations for pod scheduling
+                              Uses standard corev1.Toleration
+                            items:
+                              description: |-
+                                The pod this Toleration is attached to tolerates any taint that matches
+                                the triple <key,value,effect> using the matching operator <operator>.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Effect indicates the taint effect to match. Empty means match all taint effects.
+                                    When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: |-
+                                    Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                    If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    Operator represents a key's relationship to the value.
+                                    Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                                    Exists is equivalent to wildcard for value, so that a pod can
+                                    tolerate all taints of a particular category.
+                                    Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                                  type: string
+                                tolerationSeconds:
+                                  description: |-
+                                    TolerationSeconds represents the period of time the toleration (which must be
+                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                    it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                    negative values will be treated as 0 (evict immediately) by the system.
+                                  format: int64
+                                  type: integer
+                                value:
+                                  description: |-
+                                    Value is the taint value the toleration matches to.
+                                    If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                  type: string
+                              type: object
+                            type: array
                         type: object
                       otelCollector:
                         description: OTEL Collector deployment settings.
@@ -1282,9 +1344,10 @@ spec:
                           replicas:
                             default: 1
                             description: |-
-                              Defines the number of desired OLS pods. Default: "1"
-                              Note: Replicas can only be changed for APIContainer. For PostgreSQL, Console, Agentic Console,
-                              Alerts Adapter, and OTEL Collector containers, the number of replicas will always be set to 1.
+                              Defines the number of desired pods. Default: "1"
+                              Note: Replicas are configurable for APIContainer and MCP server (mcpServer).
+                              For PostgreSQL, Console, Agentic Console, Alerts Adapter, and OTEL Collector,
+                              the number of replicas is always set to 1.
                             format: int32
                             minimum: 0
                             type: integer
@@ -1482,8 +1545,8 @@ spec:
                     type: array
                   introspectionEnabled:
                     description: |-
-                      Enable introspection features (e.g. built-in OpenShift MCP server). Omitted means use the
-                      CRD default (true); explicit false disables introspection.
+                      Enable introspection features (e.g. built-in OpenShift MCP server).
+                      Default: true when absent. Explicit false disables introspection.
                     type: boolean
                   logLevel:
                     default: INFO

--- a/related_images.json
+++ b/related_images.json
@@ -12,18 +12,9 @@
     "operator_arg": "postgres-image"
   },
   {
-    "name": "lightspeed-operator-bundle",
-    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols-bundle@sha256:2fe89ecff69893e25d8c8a3af6c4ad138286daaa1ad4582d0c390f21ba7aa57e",
-    "revision": "08c3f24500e22d5c1d0c47301a620f4638a49abb",
-    "snapshot_component": "ols-bundle",
-    "snapshot_source": "bundle",
-    "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols-bundle",
-    "stable_prefix": "registry.redhat.io/openshift-lightspeed/lightspeed-operator-bundle"
-  },
-  {
     "name": "lightspeed-service-api",
-    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service@sha256:2cda2f011996b457462ac3da3b00b37d854bc8bd48c60a8879a386a3e54b9b79",
-    "revision": "ee21f5e63e4afb4a6860d23f077d8a9dfee8af48",
+    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9@sha256:73fa6825f8f24c4b893fba177ac415ad4322de56af7940b4a4084a9bc72a7910",
+    "revision": "b6f2a8cd7aa17d40e50d082a5ecad02f300a7cb2",
     "operator_arg": "service-image",
     "snapshot_component": "lightspeed-service",
     "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service",
@@ -31,8 +22,8 @@
   },
   {
     "name": "lightspeed-console-plugin",
-    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console@sha256:91b7c5316e44e414f0256c276cf975ce5525f0a1ca7c1683730c66f271632f5e",
-    "revision": "9db906ea2dbd9250b9eb4665988cb93400269066",
+    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:f53e11c14e291fb19f87a24fb512bbf59ec350bcb3af7a114663febc77b4c1b9",
+    "revision": "b3189adf502af3463e80482cb362e5b3b0028c9f",
     "operator_arg": "console-image",
     "snapshot_component": "lightspeed-console",
     "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console",
@@ -40,8 +31,8 @@
   },
   {
     "name": "lightspeed-operator",
-    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator@sha256:0f4eac671fafd4f27d683e150b6d767c701484c129f983c0d68fd1fb5ce790b1",
-    "revision": "a3e82a3fd3da358f0705262b13b9754cef8ca045",
+    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:cf864a9f6cd3af1ac3f539b982239fff4aafe576c518e3e189cfd9bd6733c4f7",
+    "revision": "515489760f95c134dc4d3c8adaa1baae7f14aeb4",
     "operator_target": "image",
     "snapshot_component": "lightspeed-operator",
     "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator",
@@ -49,7 +40,7 @@
   },
   {
     "name": "openshift-mcp-server",
-    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/openshift-mcp-server@sha256:5b8e3b6a9d46e4825f731819274efbc88dc63f1dc47e8eefe9339bf90da4c02d",
+    "image": "registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9@sha256:5b8e3b6a9d46e4825f731819274efbc88dc63f1dc47e8eefe9339bf90da4c02d",
     "revision": "70cd646adb525a80da0fe5f74082ea0671f0a829",
     "operator_arg": "openshift-mcp-server-image",
     "snapshot_component": "openshift-mcp-server",
@@ -58,8 +49,8 @@
   },
   {
     "name": "lightspeed-agentic-console-plugin",
-    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-console@sha256:a7900060ec7928f03559bd2300bc1642ae0a57b10e30ce9f9804e8102a84b7f7",
-    "revision": "5298501031d9af6c977dcbaac519a4384af8793c",
+    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-agentic-console-rhel9@sha256:b08ceeb59e29b55ceab15e87700ac6173ccf59d146dd616a3e2e7ed5ddc8927e",
+    "revision": "0f61a2b3c3b1966a26986d60fae1cdfb33235a1c",
     "operator_arg": "agentic-console-image",
     "snapshot_component": "lightspeed-agentic-console",
     "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-console",
@@ -67,8 +58,8 @@
   },
   {
     "name": "lightspeed-agentic-alerts-adapter",
-    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-alerts-adapter@sha256:9049b11048de0717523b27e0c23ae283245df34b5dfb2d24571148e730cca4e2",
-    "revision": "dac6da9f1cd5f85981b9d602cdedf24d92d5da52",
+    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-agentic-alerts-adapter-rhel9@sha256:10af58d31ab3add2e6ec1058ba5d10a87e2d5a4d77258b3f47a0ffc84eff3770",
+    "revision": "39bfcdcd8bc7963fe0caa0a6b99c1ad9c919a13d",
     "operator_arg": "alerts-adapter-image",
     "snapshot_component": "lightspeed-agentic-alerts-adapter",
     "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-alerts-adapter",
@@ -76,8 +67,8 @@
   },
   {
     "name": "lightspeed-otel-collector",
-    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-otel-collector@sha256:85e8f70fea5c9005088767f787e39c65ebabac2295f38b3cd846157ef9dcebea",
-    "revision": "0a1798f2dbeebd36b83a9339b7e02fa015dbab61",
+    "image": "registry.redhat.io/openshift-lightspeed/otelcol-lightspeed-rhel9@sha256:fb86a2c82c959e8ec72e707ce6cc0c4005f806da38ec50da5606557346549cd3",
+    "revision": "8bc5f3bbc050e5912c113e485453e342ecea2d8c",
     "operator_arg": "otel-collector-image",
     "snapshot_component": "lightspeed-otel-collector",
     "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-otel-collector",
@@ -88,5 +79,14 @@
     "image": "registry.redhat.io/offline-knowledge-portal/rhokp-rhel9:latest",
     "revision": "",
     "operator_arg": "rhokp-image"
+  },
+  {
+    "name": "lightspeed-operator-bundle",
+    "image": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols-bundle@sha256:2fe89ecff69893e25d8c8a3af6c4ad138286daaa1ad4582d0c390f21ba7aa57e",
+    "revision": "08c3f24500e22d5c1d0c47301a620f4638a49abb",
+    "snapshot_component": "ols-bundle",
+    "snapshot_source": "bundle",
+    "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols-bundle",
+    "stable_prefix": "registry.redhat.io/openshift-lightspeed/lightspeed-operator-bundle"
   }
 ]


### PR DESCRIPTION
This PR is triggered by the release crt-nshift-lightspeed-tenant/ols-20260723-073100-000-5d4acb5-4htpv.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the operator’s deployment container images to newer Red Hat registry references for core services and related components.
  * Refreshed the operator release manifest image metadata to align with the updated references.
  * Updated the release manifest creation timestamp.

* **Documentation**
  * Adjusted CRD schema wording to clarify replica configuration behavior for each component.
  * Updated CRD description text for `ols.introspectionEnabled` to explicitly state the default and how `false` disables it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->