### PR TITLE
OLS-0000 Fix spec findings from 2026-07-23 verification

### DIFF
--- a/.ai/spec/how/project-structure.md
+++ b/.ai/spec/how/project-structure.md
@@ -54,7 +54,7 @@ main()
   1. Parse flags (images, namespace, leader election, secure metrics)
   2. Get Kubernetes config and client
   3. Detect OpenShift version (major, minor)
-  4. Select console image: if minor < 19 -> PF5, else -> PF6
+  4. Select console image (single image; OCP minor version no longer determines selection)
   5. Check Prometheus Operator availability (probe CRD existence)
   6. Configure metrics TLS (if --secure-metrics-server):
      a. Read client CA from openshift-monitoring/metrics-client-ca

--- a/.ai/spec/how/reconciliation.md
+++ b/.ai/spec/how/reconciliation.md
@@ -18,11 +18,12 @@ Reconcile(ctx, req)
   -> handleFinalizer()                      # Add/remove finalizer, run cleanup
   -> reconcileOperatorResources()           # ServiceMonitor, NetworkPolicy (operator-level)
   -> annotateExternalResources()            # Validate secrets, annotate for watching
-  -> reconcileIndependentResources()        # Phase 1: console, agentic console, postgres, otel collector, appserver, alerts adapter resources
+  -> reconcileIndependentResources()        # Phase 1: console, agentic console, postgres, otel collector, ocpmcp, appserver, alerts adapter resources
   |   |-- console.ReconcileConsoleUIResources()
   |   |-- agenticconsole.ReconcileAgenticConsoleUIResources()
   |   |-- postgres.ReconcilePostgresResources()
   |   |-- otelcollector.ReconcileOtelCollectorResources()
+  |   |-- ocpmcp.ReconcileResources()          # when introspectionEnabled; else Remove()
   |   |-- appserver.ReconcileAppServerResources()
   |   +-- alertsadapter.ReconcileAlertsAdapterResources()
   |       (opt-in via configMapRef; RemoveAlertsAdapter() when disabled; no ConfigMap validation;

--- a/.ai/spec/what/app-server.md
+++ b/.ai/spec/what/app-server.md
@@ -50,7 +50,7 @@ The App Server is the backend deployment for OpenShift Lightspeed. It runs the l
 24. Deployment updates are triggered when: the deployment spec changes, the config ConfigMap resource version changes, the proxy CA certificate hash changes, or (when introspection is enabled) the OpenShift MCP CA ConfigMap content hash changes.
 25. When any of these change, the operator forces a rolling restart by updating a pod template annotation with the current timestamp.
 
-### Health Probes [CHANGED: OLS-3221]
+### Health Probes [PLANNED: OLS-3221]
 26. The app server deployment's liveness probe must point to the `/liveness` endpoint with `failureThreshold: 3` and `periodSeconds: 30`, giving the pod 90 seconds to self-heal via the background health-check loop before Kubernetes restarts it. These values are not currently user-configurable.
 27. The app server deployment's readiness probe must point to the `/readiness` endpoint. The readiness probe checks RAG index, LLM reachability, and cache health status (read from the background health-check loop). No changes to existing readiness probe configuration.
 

--- a/.ai/spec/what/crd-api.md
+++ b/.ai/spec/what/crd-api.md
@@ -104,7 +104,7 @@ Field path (relative to each model) | JSON key | Go type | Required | Descriptio
 Field path (relative to parameters) | JSON key | Go type | Required | Default | Validation
 ---|---|---|---|---|---
 `maxTokensForResponse` | `maxTokensForResponse` | `int` | No | (unset; application default is 2048) | None
-`toolBudgetRatio` | `toolBudgetRatio` | `float64` | No | `0.5` | Minimum=0.1, Maximum=0.5
+`toolBudgetRatio` | `toolBudgetRatio` | `float64` | No | `0.25` | Minimum=0.1, Maximum=0.5
 `reasoningConfig` | `reasoningConfig` | `map[string]interface{}` | No | (unset) | None. [PLANNED: OLS-3442] Freeform map of provider-specific reasoning/thinking parameters. Passed through to the service as `reasoning_config`. Valid keys vary by provider and model generation — see lightspeed-service `what/llm-providers.md` rule 13. When absent, no reasoning params are sent. When present with invalid keys, the provider API returns a clear 400 error.
 
 ### OLS Configuration (spec.ols)

--- a/.ai/spec/what/observability.md
+++ b/.ai/spec/what/observability.md
@@ -18,7 +18,7 @@ The operator configures monitoring, health probes, and status reporting for all 
 8. All probe parameters are set as internal constants in the deployment generation code. They are not configurable via the CR.
 
 ### Status Reporting
-11. The operator reports status via four condition types defined in `utils/types.go`: `ApiReady`, `CacheReady`, `ConsolePluginReady`, and `ResourceReconciliation` (used for Phase 1 failures).
+11. The operator reports status via eight condition types defined in `utils/types.go`: `ApiReady`, `CacheReady`, `ConsolePluginReady`, `AgenticConsolePluginReady`, `OtelCollectorReady`, `MCPServerReady`, `AlertsAdapterReady`, and `ResourceReconciliation` (used for Phase 1 failures).
 12. `status.overallStatus` aggregates all conditions: `Ready` when all deployment conditions are `True`, `NotReady` otherwise. The field is required (no `omitempty`).
 13. When deployments fail health checks, `status.diagnosticInfo` is populated with per-pod diagnostic entries. Diagnostics are collected by listing pods matching the deployment's selector labels and inspecting container and pod statuses.
 14. Each `PodDiagnostic` entry includes: `failedComponent` (matching the condition type, e.g., `ApiReady`), `podName`, `containerName` (empty string for pod-level issues), `reason`, `message`, `exitCode` (pointer, set for terminated containers), `type` (diagnostic category), and `lastUpdated` timestamp.

--- a/.ai/spec/what/security.md
+++ b/.ai/spec/what/security.md
@@ -14,7 +14,7 @@ The operator enforces security boundaries through RBAC, network policies, pod se
 5. Each component has its own NetworkPolicy restricting ingress:
    - Operator (`lightspeed-operator`): allows Prometheus scraping from `openshift-monitoring` namespace on port 8443.
    - Backend/AppServer (`lightspeed-app-server`): allows Prometheus from `openshift-monitoring`, OpenShift Console pods from `openshift-console`, and ingress controllers (namespaces with `network.openshift.io/policy-group: ingress`), all on port 8443.
-   - PostgreSQL (`lightspeed-postgres-server`): allows only backend pods (matched by `app.kubernetes.io/name: lightspeed-service-api` label).
+   - PostgreSQL (`lightspeed-postgres-server`): allows only backend pods (matched by `app.kubernetes.io/name: lightspeed-service-api` label) and OTel Collector pods (matched by the OTel Collector labels).
    - Console UI (`lightspeed-console-plugin`): allows only OpenShift Console pods from `openshift-console` namespace.
    - OTEL Collector (`lightspeed-otel-collector`): allows all pods in the operator namespace (empty `PodSelector`) on OTLP gRPC `:4317` and `postgres_admin` HTTPS `:8080`; allows Prometheus from `openshift-monitoring` on HTTPS metrics `:8888` only.
 6. Network policies use combined pod label selectors and namespace selectors for source filtering.


### PR DESCRIPTION
Spec-only fixes from the 2026-07-23 verification run.

## Changes
- reconciliation.md: add MCP server (ocpmcp) to Phase 1 reconciliation diagram
- crd-api.md: fix toolBudgetRatio default value (0.25, not 0.5)
- observability.md: add AgenticConsolePluginReady, OtelCollectorReady, MCPServerReady, AlertsAdapterReady conditions
- security.md: align Postgres NP description to include OTel Collector
- app-server.md: fix liveness probe rule from [CHANGED] to [PLANNED: [OLS-3221](https://redhat.atlassian.net/browse/OLS-3221)]
- project-structure.md: remove stale PF5/PF6 image selection logic reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated startup documentation to describe console image selection independently of OpenShift minor versions.
  - Documented conditional reconciliation and removal of OCP MCP resources based on introspection settings.
  - Clarified health probes as planned functionality.
  - Updated the default tool budget ratio to **0.25**.
  - Expanded documented operator status conditions to include additional components.
  - Documented PostgreSQL access for backend and OTel Collector pods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->