### PR TITLE
OLS-3752 - Removing agentic operator image references.

### DIFF
--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -1004,8 +1004,6 @@ spec:
                       - --service-image=registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9@sha256:73fa6825f8f24c4b893fba177ac415ad4322de56af7940b4a4084a9bc72a7910
                       - --console-image=registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:f53e11c14e291fb19f87a24fb512bbf59ec350bcb3af7a114663febc77b4c1b9
                       - --openshift-mcp-server-image=registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9@sha256:5b8e3b6a9d46e4825f731819274efbc88dc63f1dc47e8eefe9339bf90da4c02d
-                      - --agentic-console-image=registry.redhat.io/openshift-lightspeed/lightspeed-agentic-console-rhel9@sha256:b08ceeb59e29b55ceab15e87700ac6173ccf59d146dd616a3e2e7ed5ddc8927e
-                      - --alerts-adapter-image=registry.redhat.io/openshift-lightspeed/lightspeed-agentic-alerts-adapter-rhel9@sha256:10af58d31ab3add2e6ec1058ba5d10a87e2d5a4d77258b3f47a0ffc84eff3770
                       - --otel-collector-image=registry.redhat.io/openshift-lightspeed/otelcol-lightspeed-rhel9@sha256:fb86a2c82c959e8ec72e707ce6cc0c4005f806da38ec50da5606557346549cd3
                       - --rhokp-image=registry.redhat.io/offline-knowledge-portal/rhokp-rhel9:latest
                       - --agentic-sandbox-image=quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-sandbox@sha256:7921997a9cc1e5cc1c72e293a235a43bf2177e8c40d1ad3505c1ef5954c9980c
@@ -1144,10 +1142,6 @@ spec:
       image: registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:cf864a9f6cd3af1ac3f539b982239fff4aafe576c518e3e189cfd9bd6733c4f7
     - name: openshift-mcp-server
       image: registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9@sha256:5b8e3b6a9d46e4825f731819274efbc88dc63f1dc47e8eefe9339bf90da4c02d
-    - name: lightspeed-agentic-console-plugin
-      image: registry.redhat.io/openshift-lightspeed/lightspeed-agentic-console-rhel9@sha256:b08ceeb59e29b55ceab15e87700ac6173ccf59d146dd616a3e2e7ed5ddc8927e
-    - name: lightspeed-agentic-alerts-adapter
-      image: registry.redhat.io/openshift-lightspeed/lightspeed-agentic-alerts-adapter-rhel9@sha256:10af58d31ab3add2e6ec1058ba5d10a87e2d5a4d77258b3f47a0ffc84eff3770
     - name: lightspeed-otel-collector
       image: registry.redhat.io/openshift-lightspeed/otelcol-lightspeed-rhel9@sha256:fb86a2c82c959e8ec72e707ce6cc0c4005f806da38ec50da5606557346549cd3
     - name: rhokp

--- a/config/default/deployment-patch.yaml
+++ b/config/default/deployment-patch.yaml
@@ -18,12 +18,6 @@
   value: --openshift-mcp-server-image=__REPLACE_OPENSHIFT_MCP_SERVER__
 - op: add
   path: /spec/template/spec/containers/0/args/-
-  value: --agentic-console-image=__REPLACE_LIGHTSPEED_AGENTIC_CONSOLE_PLUGIN__
-- op: add
-  path: /spec/template/spec/containers/0/args/-
-  value: --alerts-adapter-image=__REPLACE_LIGHTSPEED_AGENTIC_ALERTS_ADAPTER__
-- op: add
-  path: /spec/template/spec/containers/0/args/-
   value: --otel-collector-image=__REPLACE_LIGHTSPEED_OTEL_COLLECTOR__
 - op: add
   path: /spec/template/spec/containers/0/args/-

--- a/internal/controller/agenticconsole/assets_test.go
+++ b/internal/controller/agenticconsole/assets_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Agentic Console UI assets", func() {
 				"app.kubernetes.io/name": utils.AgenticConsoleUIPluginName,
 			}))
 			Expect(dep.Spec.Template.Spec.Containers[0].Name).To(Equal(utils.AgenticConsoleUIContainerName))
-			Expect(dep.Spec.Template.Spec.Containers[0].Image).To(Equal(utils.AgenticConsoleUIImageDefault))
+			Expect(dep.Spec.Template.Spec.Containers[0].Image).To(Equal(testReconcilerInstance.GetAgenticConsoleImage()))
 			Expect(dep.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort).To(Equal(int32(utils.AgenticConsoleUIHTTPSPort)))
 			Expect(dep.Spec.Template.Spec.Containers[0].Ports[0].Name).To(BeEmpty())
 			Expect(dep.Spec.Template.Spec.Containers[0].Resources).To(Equal(*utils.DefaultConsolePluginResourceRequirements()))

--- a/internal/controller/agenticconsole/suite_test.go
+++ b/internal/controller/agenticconsole/suite_test.go
@@ -105,12 +105,14 @@ var _ = BeforeSuite(func() {
 		Expect(k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})).To(Succeed())
 	}
 
-	testReconcilerInstance = utils.NewTestReconciler(
+	tr := utils.NewTestReconciler(
 		k8sClient,
 		logf.Log.WithName("controller").WithName("OLSConfig"),
 		scheme.Scheme,
 		utils.OLSNamespaceDefault,
 	)
+	tr.AgenticConsoleImage = "registry.redhat.io/openshift-lightspeed/lightspeed-agentic-console-rhel9:latest"
+	testReconcilerInstance = tr
 
 	cr = &olsv1alpha1.OLSConfig{}
 	crNamespacedName = types.NamespacedName{Name: "cluster"}

--- a/internal/controller/alertsadapter/assets_test.go
+++ b/internal/controller/alertsadapter/assets_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Alerts adapter assets", func() {
 		Expect(deployment.Spec.Template.Spec.ServiceAccountName).To(Equal(utils.AlertsAdapterServiceAccountName))
 		Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
 		Expect(deployment.Spec.Template.Spec.Containers[0].Name).To(Equal(utils.AlertsAdapterContainerName))
-		Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(Equal(utils.AlertsAdapterImageDefault))
+		Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(Equal(testReconcilerInstance.GetAlertsAdapterImage()))
 		Expect(deployment.Spec.Template.Spec.Volumes).To(HaveLen(1))
 		Expect(deployment.Spec.Template.Spec.Volumes[0].Name).To(Equal(utils.TmpVolumeName))
 	})

--- a/internal/controller/alertsadapter/suite_test.go
+++ b/internal/controller/alertsadapter/suite_test.go
@@ -112,12 +112,14 @@ var _ = BeforeSuite(func() {
 		Expect(err).NotTo(HaveOccurred())
 	}
 
-	testReconcilerInstance = utils.NewTestReconciler(
+	tr := utils.NewTestReconciler(
 		k8sClient,
 		logf.Log.WithName("controller").WithName("OLSConfig"),
 		scheme.Scheme,
 		utils.OLSNamespaceDefault,
 	)
+	tr.AlertsAdapterImage = "registry.redhat.io/openshift-lightspeed/lightspeed-agentic-alerts-adapter-rhel9:latest"
+	testReconcilerInstance = tr
 
 	cr = &olsv1alpha1.OLSConfig{}
 	crNamespacedName = types.NamespacedName{Name: utils.OLSConfigName}

--- a/internal/controller/olsconfig_controller.go
+++ b/internal/controller/olsconfig_controller.go
@@ -302,18 +302,13 @@ func (r *OLSConfigReconciler) reconcileOperatorResources(ctx context.Context) er
 // Agentic integration handoff runs at the end of Phase 2 (after Services/TLS).
 // Uses continue-on-error to reconcile as many resources as possible, even if some fail.
 func (r *OLSConfigReconciler) reconcileIndependentResources(ctx context.Context, olsconfig *olsv1alpha1.OLSConfig) error {
+	resourceFailures := make(map[string]error)
 	resourceSteps := []utils.ReconcileSteps{
-		{Name: "postgres resources", Fn: func(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
-			return postgres.ReconcilePostgresResources(r, ctx, cr)
-		}},
 		{Name: "console UI resources", Fn: func(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
 			return console.ReconcileConsoleUIResources(r, ctx, cr)
 		}},
-		{Name: "agentic console UI resources", Fn: func(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
-			return agenticconsole.ReconcileAgenticConsoleUIResources(r, ctx, cr)
-		}},
-		{Name: "alerts adapter resources", Fn: func(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
-			return alertsadapter.ReconcileAlertsAdapterResources(r, ctx, cr)
+		{Name: "postgres resources", Fn: func(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
+			return postgres.ReconcilePostgresResources(r, ctx, cr)
 		}},
 		{Name: "OTEL Collector resources", Fn: func(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
 			return otelcollector.ReconcileOtelCollectorResources(r, ctx, cr)
@@ -321,13 +316,43 @@ func (r *OLSConfigReconciler) reconcileIndependentResources(ctx context.Context,
 		{Name: "openshift-mcp-server resources", Fn: func(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
 			return ocpmcp.ReconcileResources(r, ctx, cr)
 		}},
-		{Name: "application server resources", Fn: func(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
-			return appserver.ReconcileAppServerResources(r, ctx, cr)
-		}},
 	}
 
+	if r.Options.AgenticConsoleUIImage != "" {
+		resourceSteps = append(resourceSteps, utils.ReconcileSteps{
+			Name: "agentic console UI resources",
+			Fn: func(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
+				return agenticconsole.ReconcileAgenticConsoleUIResources(r, ctx, cr)
+			},
+		})
+	} else if wasComponentEnabled(olsconfig, utils.TypeAgenticConsolePluginReady) {
+		if err := agenticconsole.RemoveAgenticConsole(r, ctx); err != nil {
+			resourceFailures["agentic console UI cleanup"] = fmt.Errorf("failed to remove agentic console UI resources: %w", err)
+		}
+	}
+
+	_, alertsAdapterConfigMapEnabled := utils.AlertsAdapterConfigMapRef(olsconfig)
+	if r.Options.AlertsAdapterImage != "" && alertsAdapterConfigMapEnabled {
+		resourceSteps = append(resourceSteps, utils.ReconcileSteps{
+			Name: "alerts adapter resources",
+			Fn: func(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
+				return alertsadapter.ReconcileAlertsAdapterResources(r, ctx, cr)
+			},
+		})
+	} else if wasComponentEnabled(olsconfig, utils.TypeAlertsAdapterReady) {
+		if err := alertsadapter.RemoveAlertsAdapter(r, ctx); err != nil {
+			resourceFailures["alerts adapter cleanup"] = fmt.Errorf("failed to remove alerts adapter resources: %w", err)
+		}
+	}
+
+	resourceSteps = append(resourceSteps, utils.ReconcileSteps{
+		Name: "application server resources",
+		Fn: func(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
+			return appserver.ReconcileAppServerResources(r, ctx, cr)
+		},
+	})
+
 	// Reconcile all independent resources (continue on error to reconcile as many as possible)
-	resourceFailures := make(map[string]error)
 	for _, step := range resourceSteps {
 		if err := step.Fn(ctx, olsconfig); err != nil {
 			r.Logger.Error(err, "Resource reconciliation failed", "resource", step.Name)
@@ -387,9 +412,6 @@ func (r *OLSConfigReconciler) reconcileDeploymentsAndStatus(ctx context.Context,
 		{Name: "console UI deployment", Fn: func(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
 			return console.ReconcileConsoleUIDeploymentAndPlugin(r, ctx, cr)
 		}, ConditionType: utils.TypeConsolePluginReady, Deployment: utils.ConsoleUIDeploymentName},
-		{Name: "agentic console UI deployment", Fn: func(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
-			return agenticconsole.ReconcileAgenticConsoleUIDeploymentAndPlugin(r, ctx, cr)
-		}, ConditionType: utils.TypeAgenticConsolePluginReady, Deployment: utils.AgenticConsoleUIDeploymentName},
 		{Name: "postgres deployment", Fn: func(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
 			return postgres.ReconcilePostgresDeployment(r, ctx, cr)
 		}, ConditionType: utils.TypeCacheReady, Deployment: utils.PostgresDeploymentName},
@@ -430,30 +452,70 @@ func (r *OLSConfigReconciler) reconcileDeploymentsAndStatus(ctx context.Context,
 	if !utils.BoolDeref(olsconfig.Spec.OLSConfig.IntrospectionEnabled, true) {
 		newStatus.Conditions = append(newStatus.Conditions, metav1.Condition{
 			Type:               utils.TypeMCPServerReady,
-			Status:             metav1.ConditionTrue,
+			Status:             metav1.ConditionFalse,
 			ObservedGeneration: olsconfig.Generation,
-			Reason:             "NotConfigured",
+			Reason:             "Disabled",
 			Message:            "OpenShift MCP server is disabled; spec.ols.introspectionEnabled is false",
 			LastTransitionTime: metav1.Now(),
 		})
 	}
 
-	if _, enabled := utils.AlertsAdapterConfigMapRef(olsconfig); enabled {
+	if r.Options.AgenticConsoleUIImage != "" {
 		deploymentSteps = append(deploymentSteps, utils.ReconcileSteps{
-			Name: "alerts adapter deployment",
+			Name: "agentic console UI deployment",
 			Fn: func(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
-				return alertsadapter.ReconcileAlertsAdapterDeployment(r, ctx, cr)
+				return agenticconsole.ReconcileAgenticConsoleUIDeploymentAndPlugin(r, ctx, cr)
 			},
-			ConditionType: utils.TypeAlertsAdapterReady,
-			Deployment:    utils.AlertsAdapterDeploymentName,
+			ConditionType: utils.TypeAgenticConsolePluginReady,
+			Deployment:    utils.AgenticConsoleUIDeploymentName,
 		})
 	} else {
 		newStatus.Conditions = append(newStatus.Conditions, metav1.Condition{
-			Type:               utils.TypeAlertsAdapterReady,
-			Status:             metav1.ConditionTrue,
+			Type:               utils.TypeAgenticConsolePluginReady,
+			Status:             metav1.ConditionFalse,
 			ObservedGeneration: olsconfig.Generation,
-			Reason:             "NotConfigured",
-			Message:            "Alerts adapter is disabled; spec.ols.deployment.alertsAdapter.configMapRef is not set",
+			Reason:             "Disabled",
+			Message:            "Agentic console plugin is disabled; image not provided",
+			LastTransitionTime: metav1.Now(),
+		})
+	}
+
+	if r.Options.AlertsAdapterImage != "" {
+		if _, enabled := utils.AlertsAdapterConfigMapRef(olsconfig); enabled {
+			deploymentSteps = append(deploymentSteps, utils.ReconcileSteps{
+				Name: "alerts adapter deployment",
+				Fn: func(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
+					return alertsadapter.ReconcileAlertsAdapterDeployment(r, ctx, cr)
+				},
+				ConditionType: utils.TypeAlertsAdapterReady,
+				Deployment:    utils.AlertsAdapterDeploymentName,
+			})
+		} else {
+			cleanupFailed := false
+			if wasComponentEnabled(olsconfig, utils.TypeAlertsAdapterReady) {
+				if err := alertsadapter.RemoveAlertsAdapter(r, ctx); err != nil {
+					failedTasks["alerts adapter cleanup"] = fmt.Errorf("failed to remove alerts adapter resources: %w", err)
+					cleanupFailed = true
+				}
+			}
+			if !cleanupFailed {
+				newStatus.Conditions = append(newStatus.Conditions, metav1.Condition{
+					Type:               utils.TypeAlertsAdapterReady,
+					Status:             metav1.ConditionFalse,
+					ObservedGeneration: olsconfig.Generation,
+					Reason:             "Disabled",
+					Message:            "Alerts adapter is disabled; spec.ols.deployment.alertsAdapter.configMapRef is not set",
+					LastTransitionTime: metav1.Now(),
+				})
+			}
+		}
+	} else {
+		newStatus.Conditions = append(newStatus.Conditions, metav1.Condition{
+			Type:               utils.TypeAlertsAdapterReady,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: olsconfig.Generation,
+			Reason:             "Disabled",
+			Message:            "Alerts adapter is disabled; image not provided",
 			LastTransitionTime: metav1.Now(),
 		})
 	}
@@ -955,6 +1017,18 @@ func (r *OLSConfigReconciler) waitForOwnedResourcesDeletion(ctx context.Context,
 
 		return false, nil // Not all deleted yet, keep polling
 	})
+}
+
+// wasComponentEnabled returns true if the CR has an existing status condition for the given
+// type that is not in the "Disabled" state, indicating the component was previously active.
+// This prevents unnecessary Remove calls on every reconcile loop when a component was never enabled.
+func wasComponentEnabled(cr *olsv1alpha1.OLSConfig, conditionType string) bool {
+	for _, c := range cr.Status.Conditions {
+		if c.Type == conditionType {
+			return c.Reason != "Disabled"
+		}
+	}
+	return false
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/olsconfig_reconciler_test.go
+++ b/internal/controller/olsconfig_reconciler_test.go
@@ -6,7 +6,10 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	consolev1 "github.com/openshift/api/console/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -256,6 +259,205 @@ var _ = Describe("OLSConfig Reconciler Helper Functions", Ordered, func() {
 	PDescribe("reconcileDeploymentsAndStatus", func() {
 		It("integration test - skipped in unit tests", func() {
 			// This function is tested via integration/E2E tests
+		})
+	})
+
+	Describe("agentic component gating", func() {
+		var emptyImageReconciler *OLSConfigReconciler
+
+		BeforeEach(func() {
+			opts := getDefaultReconcilerOptions(namespace)
+			opts.AgenticConsoleUIImage = ""
+			opts.AlertsAdapterImage = ""
+			emptyImageReconciler = &OLSConfigReconciler{
+				Client:  k8sClient,
+				Options: opts,
+				Logger:  logf.Log.WithName("test.reconciler.empty-images"),
+			}
+
+			err := k8sClient.Create(ctx, cr)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("when AgenticConsoleUIImage is empty (Phase 1 - resources)", func() {
+			It("should not create agentic console ServiceAccount", func() {
+				_ = emptyImageReconciler.reconcileIndependentResources(ctx, cr)
+
+				sa := &corev1.ServiceAccount{}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      utils.AgenticConsoleUIServiceAccountName,
+					Namespace: namespace,
+				}, sa)
+				Expect(apierrors.IsNotFound(err)).To(BeTrue(),
+					"agentic console ServiceAccount should not exist when image is empty")
+			})
+		})
+
+		Context("when AlertsAdapterImage is empty (Phase 1 - resources)", func() {
+			It("should not create alerts adapter ServiceAccount", func() {
+				_ = emptyImageReconciler.reconcileIndependentResources(ctx, cr)
+
+				sa := &corev1.ServiceAccount{}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      utils.AlertsAdapterServiceAccountName,
+					Namespace: namespace,
+				}, sa)
+				Expect(apierrors.IsNotFound(err)).To(BeTrue(),
+					"alerts adapter ServiceAccount should not exist when image is empty")
+			})
+
+			It("should not create alerts adapter ClusterRole", func() {
+				_ = emptyImageReconciler.reconcileIndependentResources(ctx, cr)
+
+				role := &rbacv1.ClusterRole{}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name: utils.AlertsAdapterAgenticRunsClusterRoleName,
+				}, role)
+				Expect(apierrors.IsNotFound(err)).To(BeTrue(),
+					"alerts adapter ClusterRole should not exist when image is empty")
+			})
+		})
+
+		Context("Phase 2 gating: disabled components should not create deployments and should set Disabled status", func() {
+			It("should not create agentic console or alerts adapter Deployments and should set Disabled conditions", func() {
+				_, _ = emptyImageReconciler.reconcileDeploymentsAndStatus(ctx, cr)
+
+				By("verifying agentic console Deployment is absent")
+				dep := &appsv1.Deployment{}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      utils.AgenticConsoleUIDeploymentName,
+					Namespace: namespace,
+				}, dep)
+				Expect(apierrors.IsNotFound(err)).To(BeTrue(),
+					"agentic console Deployment should not exist when image is empty")
+
+				By("verifying agentic console ConsolePlugin is absent")
+				plugin := &consolev1.ConsolePlugin{}
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name: utils.AgenticConsoleUIPluginName,
+				}, plugin)
+				Expect(apierrors.IsNotFound(err)).To(BeTrue(),
+					"agentic console ConsolePlugin should not exist when image is empty")
+
+				By("verifying alerts adapter Deployment is absent")
+				dep = &appsv1.Deployment{}
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      utils.AlertsAdapterDeploymentName,
+					Namespace: namespace,
+				}, dep)
+				Expect(apierrors.IsNotFound(err)).To(BeTrue(),
+					"alerts adapter Deployment should not exist when image is empty")
+
+				By("verifying AgenticConsolePluginReady=False with reason Disabled")
+				updatedCR := &olsv1alpha1.OLSConfig{}
+				err = k8sClient.Get(ctx, types.NamespacedName{Name: cr.Name}, updatedCR)
+				Expect(err).NotTo(HaveOccurred())
+
+				agenticFound := false
+				alertsFound := false
+				for _, c := range updatedCR.Status.Conditions {
+					if c.Type == utils.TypeAgenticConsolePluginReady {
+						agenticFound = true
+						Expect(string(c.Status)).To(Equal("False"))
+						Expect(c.Reason).To(Equal("Disabled"))
+					}
+					if c.Type == utils.TypeAlertsAdapterReady {
+						alertsFound = true
+						Expect(string(c.Status)).To(Equal("False"))
+						Expect(c.Reason).To(Equal("Disabled"))
+					}
+				}
+				Expect(agenticFound).To(BeTrue(),
+					"AgenticConsolePluginReady condition should be present")
+				Expect(alertsFound).To(BeTrue(),
+					"AlertsAdapterReady condition should be present")
+			})
+		})
+
+		Context("when AlertsAdapterImage is set but configMapRef is absent", func() {
+			var imageNoRefReconciler *OLSConfigReconciler
+
+			BeforeEach(func() {
+				opts := getDefaultReconcilerOptions(namespace)
+				opts.AgenticConsoleUIImage = ""
+				opts.AlertsAdapterImage = "alerts-adapter:latest"
+				imageNoRefReconciler = &OLSConfigReconciler{
+					Client:  k8sClient,
+					Options: opts,
+					Logger:  logf.Log.WithName("test.reconciler.image-no-ref"),
+				}
+			})
+
+			It("Phase 1 should skip alerts adapter resources when configMapRef is absent", func() {
+				_ = imageNoRefReconciler.reconcileIndependentResources(ctx, cr)
+
+				sa := &corev1.ServiceAccount{}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      utils.AlertsAdapterServiceAccountName,
+					Namespace: namespace,
+				}, sa)
+				Expect(apierrors.IsNotFound(err)).To(BeTrue(),
+					"alerts adapter ServiceAccount should not exist when configMapRef is absent")
+			})
+
+			It("Phase 2 should set AlertsAdapterReady=Disabled when configMapRef is absent", func() {
+				_, _ = imageNoRefReconciler.reconcileDeploymentsAndStatus(ctx, cr)
+
+				updatedCR := &olsv1alpha1.OLSConfig{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: cr.Name}, updatedCR)
+				Expect(err).NotTo(HaveOccurred())
+
+				found := false
+				for _, c := range updatedCR.Status.Conditions {
+					if c.Type == utils.TypeAlertsAdapterReady {
+						found = true
+						Expect(string(c.Status)).To(Equal("False"))
+						Expect(c.Reason).To(Equal("Disabled"))
+						Expect(c.Message).To(ContainSubstring("configMapRef"))
+					}
+				}
+				Expect(found).To(BeTrue(),
+					"AlertsAdapterReady condition should be present with Disabled reason")
+			})
+		})
+
+		Context("previously-enabled component cleanup", func() {
+			It("Phase 1 should remove alerts adapter resources when image becomes empty and prior condition exists", func() {
+				By("seeding a ServiceAccount as if the alerts adapter was previously enabled")
+				seedSA := &corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      utils.AlertsAdapterServiceAccountName,
+						Namespace: namespace,
+					},
+				}
+				err := k8sClient.Create(ctx, seedSA)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("seeding a prior non-Disabled status condition on the CR")
+				cr.Status.Conditions = []metav1.Condition{
+					{
+						Type:               utils.TypeAlertsAdapterReady,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Available",
+						Message:            "Ready",
+						LastTransitionTime: metav1.Now(),
+					},
+				}
+				err = k8sClient.Status().Update(ctx, cr)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("running Phase 1 with empty alerts adapter image")
+				_ = emptyImageReconciler.reconcileIndependentResources(ctx, cr)
+
+				By("verifying the seeded ServiceAccount was removed by cleanup")
+				sa := &corev1.ServiceAccount{}
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      utils.AlertsAdapterServiceAccountName,
+					Namespace: namespace,
+				}, sa)
+				Expect(apierrors.IsNotFound(err)).To(BeTrue(),
+					"alerts adapter ServiceAccount should be removed during disabled-state cleanup")
+			})
 		})
 	})
 })

--- a/related_images.json
+++ b/related_images.json
@@ -48,24 +48,6 @@
     "stable_prefix": "registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9"
   },
   {
-    "name": "lightspeed-agentic-console-plugin",
-    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-agentic-console-rhel9@sha256:b08ceeb59e29b55ceab15e87700ac6173ccf59d146dd616a3e2e7ed5ddc8927e",
-    "revision": "0f61a2b3c3b1966a26986d60fae1cdfb33235a1c",
-    "operator_arg": "agentic-console-image",
-    "snapshot_component": "lightspeed-agentic-console",
-    "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-console",
-    "stable_prefix": "registry.redhat.io/openshift-lightspeed/lightspeed-agentic-console-rhel9"
-  },
-  {
-    "name": "lightspeed-agentic-alerts-adapter",
-    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-agentic-alerts-adapter-rhel9@sha256:10af58d31ab3add2e6ec1058ba5d10a87e2d5a4d77258b3f47a0ffc84eff3770",
-    "revision": "39bfcdcd8bc7963fe0caa0a6b99c1ad9c919a13d",
-    "operator_arg": "alerts-adapter-image",
-    "snapshot_component": "lightspeed-agentic-alerts-adapter",
-    "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-alerts-adapter",
-    "stable_prefix": "registry.redhat.io/openshift-lightspeed/lightspeed-agentic-alerts-adapter-rhel9"
-  },
-  {
     "name": "lightspeed-otel-collector",
     "image": "registry.redhat.io/openshift-lightspeed/otelcol-lightspeed-rhel9@sha256:fb86a2c82c959e8ec72e707ce6cc0c4005f806da38ec50da5606557346549cd3",
     "revision": "8bc5f3bbc050e5912c113e485453e342ecea2d8c",


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Updated operator image arguments and bundle related image metadata to shift from agentic console/alerts-adapter images to OTEL Collector and RHOKP.
  * Adjusted default image resolution to pull directly from bundle-related defaults.
* **New Features**
  * Agentic console UI and alerts adapter reconciliation is now gated by whether their image values are provided (and alerts adapter config reference is enabled).
* **Bug Fixes**
  * Readiness/status now consistently reports disabled components with clear reasons when images/config are missing.
* **Tests**
  * Updated expectations for generated deployment images and added coverage for disabled-when-image-empty gating behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->