### PR TITLE
OLS-3737 Stop injecting otel-collector config into olsconfig.yaml

### DIFF
--- a/.ai/spec/what/audit-logging.md
+++ b/.ai/spec/what/audit-logging.md
@@ -6,14 +6,14 @@ Collector / Postgres storage and OTEL hub behavior: see `what/templog.md`.
 
 ## Architecture
 
-Audit configuration is split between **service** (stdout JSON events, trace export to in-cluster collector) and **collector** (Postgres storage, optional external trace forwarding). The operator generates `olsconfig.yaml` for lightspeed-service from service fields only; `spec.audit` is collector-only.
+Audit configuration is split between **service** (stdout JSON events) and **collector** (Postgres storage, optional external trace forwarding). The operator generates `olsconfig.yaml` for lightspeed-service from service fields only; `spec.audit` is collector-only. Service trace export to the in-cluster collector is currently **disabled** (OLS-3737).
 
-```
+```yaml
 spec.ols.auditEventsEnabled  →  olsconfig.yaml audit.logging (Enabled|Disabled)
                                →  stdout compliance JSON
 
-always                         →  olsconfig.yaml audit.otel.endpoint
-                               →  lightspeed-otel-collector.<ns>.svc:4317 (TLS)
+(disabled — OLS-3737)          →  olsconfig.yaml audit.otel.endpoint
+                               →  NOT injected until e2e coverage exists
 
 spec.audit.logging             →  collector Postgres pipeline (OLS-3510+)
 spec.audit.tracingEndpoint     →  collector external trace export (OLS-3510+)
@@ -47,17 +47,15 @@ spec:
 | olsconfig.yaml key | Source | Default |
 |---|---|---|
 | `audit.logging` | `spec.ols.auditEventsEnabled` | `Enabled` |
-| `audit.otel.endpoint` | operator constant | `lightspeed-otel-collector.<namespace>.svc:4317` |
-| `audit.otel.tls_mode` | operator constant | `Secure` |
 
-7. Trace export to the in-cluster collector is **always** configured (gRPC OTLP). External backends are reached via the collector (`spec.audit.tracingEndpoint`), not by setting a service endpoint on the CR.
+7. **OLS-3737**: OTEL endpoint injection (`audit.otel.endpoint`, `audit.otel.tls_mode`) is **disabled** until e2e tests prove the collector pipeline works end-to-end. The service falls back to a no-op tracer when the otel section is absent. Re-enablement is tracked in OLS-3737 Phase 3.
 8. `spec.audit` MUST NOT affect generated `olsconfig.yaml` audit settings.
 9. Changes to `spec.ols.auditEventsEnabled` MUST trigger reconciliation that regenerates `olsconfig.yaml` and rolls the app-server deployment.
-10. The operator mounts the OpenShift service-ca bundle (`openshift-service-ca.crt`) at `/etc/certs/otel-collector-ca/service-ca.crt` in the app-server, adds it to `extra_ca`, and sets `OTEL_EXPORTER_OTLP_CERTIFICATE` to that path for OTLP/gRPC trust. See `tls.md`.
+10. The operator mounts the OpenShift service-ca bundle (`openshift-service-ca.crt`) at `/etc/certs/otel-collector-ca/service-ca.crt` in the app-server, adds it to `extra_ca`, and sets `OTEL_EXPORTER_OTLP_CERTIFICATE` to that path. These mounts are **retained** even while OTEL export is disabled (OLS-3737) to simplify Phase 3 re-enablement. See `tls.md`.
 
 ### Reconciliation
 
-11. The operator does not emit its own audit events. Its responsibilities are CRD schema, `olsconfig.yaml` generation for stdout audit and in-cluster trace export, and OTEL Collector operand reconciliation (`OtelCollectorReady`). See `reconciliation.md` and `templog.md`.
+11. The operator does not emit its own audit events. Its responsibilities are CRD schema and `olsconfig.yaml` generation for stdout audit config. OTEL Collector operand reconciliation (`OtelCollectorReady`) and in-cluster trace export are currently **disabled** (OLS-3737); see `reconciliation.md` and `templog.md`.
 
 ## Migration (breaking change)
 
@@ -66,8 +64,8 @@ The previous `spec.audit.logging` (`Enabled`/`Disabled`) and `spec.audit.otel` b
 | Previous | New |
 |---|---|
 | `spec.audit.logging: Enabled/Disabled` | `spec.ols.auditEventsEnabled: true/false` |
-| `spec.audit.otel.endpoint` | removed — service always exports to in-cluster collector |
-| `spec.audit.otel.tlsMode: Insecure` | removed — service always uses `Secure` to collector |
+| `spec.audit.otel.endpoint` | removed — operator-injected endpoint (currently disabled, OLS-3737) |
+| `spec.audit.otel.tlsMode: Insecure` | removed — TLS mode `Secure` when re-enabled (OLS-3737 Phase 3) |
 | (none) | `spec.audit.tracingEndpoint` — external trace export via collector |
 
 Existing CRs with the old `spec.audit` shape must be rewritten manually before upgrade. There is no conversion webhook.

--- a/.ai/spec/what/templog.md
+++ b/.ai/spec/what/templog.md
@@ -4,14 +4,14 @@ Implementation details for the lightspeed-operator's role in the templog / OTEL 
 
 ## Architecture
 
-The OTEL Collector is the in-cluster telemetry hub. It is **always deployed** when Lightspeed is installed. Configuration is split between **service behavior** (stdout audit events, trace export to collector) and **collector behavior** (Postgres storage, trace forwarding).
+The OTEL Collector is the in-cluster telemetry hub. Its reconciliation is currently **disabled** (OLS-3737) until e2e tests prove the pipeline works; it will not be deployed on new installs. Configuration is split between **service behavior** (stdout audit events) and **collector behavior** (Postgres storage, trace forwarding).
 
 ```text
 lightspeed-service
   ├─ stdout JSON audit events     ← spec.ols.auditEventsEnabled
-  └─ OTLP traces (gRPC :4317)   ← always → lightspeed-otel-collector Service
+  └─ OTLP traces (gRPC :4317)   ← disabled (OLS-3737); no-op tracer fallback
 
-OTEL Collector (always deployed)
+OTEL Collector (disabled — OLS-3737; re-enable in Phase 3)
   ├─ logs pipeline → Postgres     ← spec.audit.logging (*bool, default true)
   │     (only service.name=lightspeed-agentic-sandbox)
   ├─ postgres_admin HTTPS :8080   ← always (templog cleanup / GET for agentic-operator)
@@ -64,12 +64,10 @@ The operator generates service audit config independently of `spec.audit`:
 | olsconfig.yaml | Source |
 |----------------|--------|
 | `audit.logging` | `spec.ols.auditEventsEnabled` (default Enabled) |
-| `audit.otel.endpoint` | Always `lightspeed-otel-collector.<ns>.svc:4317` |
-| `audit.otel.tls_mode` | Always `Secure` (OTLP/gRPC with TLS) |
 
-The operator mounts the OpenShift service-ca bundle into the app-server at `/etc/certs/otel-collector-ca/service-ca.crt`, adds it to `extra_ca` in `olsconfig.yaml`, and sets `OTEL_EXPORTER_OTLP_CERTIFICATE` to that path (required for OTLP/gRPC; `extra_ca` alone is not used by the exporter). See `tls.md`.
+**OLS-3737**: OTEL endpoint injection (`audit.otel.endpoint`, `audit.otel.tls_mode`) is **disabled** until e2e tests prove the collector pipeline works. The service falls back to a no-op tracer when the otel section is absent. Re-enablement tracked in OLS-3737 Phase 3.
 
-Service continues to use the existing gRPC OTLP trace exporter (`opentelemetry.exporter.otlp.proto.grpc`).
+The operator still mounts the OpenShift service-ca bundle into the app-server at `/etc/certs/otel-collector-ca/service-ca.crt`, adds it to `extra_ca` in `olsconfig.yaml`, and sets `OTEL_EXPORTER_OTLP_CERTIFICATE` to that path. These mounts are retained for Phase 3 re-enablement. See `tls.md`.
 
 ## Operator image flag ([OLS-3509](https://redhat.atlassian.net/browse/OLS-3509))
 
@@ -82,13 +80,15 @@ Service continues to use the existing gRPC OTLP trace exporter (`opentelemetry.e
 
 The Postgres bootstrap script creates only `quota` and `conversation_cache` schemas. It does **not** create the `templogs` schema or tables.
 
-The OTEL Collector always creates and manages the `templogs` schema, `logs` table, and indexes via the `postgres_admin` extension at collector startup (`postgres_admin` is always enabled for clients). `spec.audit.logging` only controls whether new OTLP logs are exported into that schema. The operator never drops this schema. The `logs` table uses `agentic_run_id` (AgenticRun UID, normalized to 32-char hex) and `phase` (audit phase name) as the primary query dimensions, with a composite index on `(agentic_run_id, phase)`.
+When the collector is enabled, it creates and manages the `templogs` schema, `logs` table, and indexes via the `postgres_admin` extension at collector startup (`postgres_admin` is always enabled for clients). `spec.audit.logging` only controls whether new OTLP logs are exported into that schema. The operator never drops this schema. The `logs` table uses `agentic_run_id` (AgenticRun UID, normalized to 32-char hex) and `phase` (audit phase name) as the primary query dimensions, with a composite index on `(agentic_run_id, phase)`.
 
 See `postgres.md` for Postgres bootstrap scope and `templog.md` (lightspeed-service repo) for table DDL semantics.
 
 ## Collector Operand ([OLS-3510](https://redhat.atlassian.net/browse/OLS-3510), [OLS-3513](https://redhat.atlassian.net/browse/OLS-3513), [OLS-3656](https://redhat.atlassian.net/browse/OLS-3656))
 
-1. **Always** deploy a single-replica Collector Deployment. Service exposes OTLP gRPC `:4317`, OTLP HTTP `:4318`, `postgres_admin` HTTPS `:8080`, and HTTPS Prometheus metrics `:8888`. Health check listens on `:13133` (pod-local; not on the Service).
+> **OLS-3737**: Collector reconciliation is **disabled** — the rules below describe the target architecture when re-enabled in Phase 3. The collector code is commented out, not deleted.
+
+1. Deploy a single-replica Collector Deployment. Service exposes OTLP gRPC `:4317`, OTLP HTTP `:4318`, `postgres_admin` HTTPS `:8080`, and HTTPS Prometheus metrics `:8888`. Health check listens on `:13133` (pod-local; not on the Service).
 2. Image from `GetOtelCollectorImage()`; pod scheduling from `spec.ols.deployment.otelCollector`.
 3. ConfigMap pipelines driven by `spec.audit`:
    - `logging` true/absent → logs pipeline with `routing/logs` connector and `postgresexporter`; only OTLP logs where `service.name == "lightspeed-agentic-sandbox"` are stored in Postgres; unmatched logs go to `logs/unmatched` → `nop`
@@ -116,7 +116,7 @@ Agentic-operator reads OTLP/admin endpoints from `lightspeed-agentic-configurati
 
 ## Constraints
 
-1. Collector is always a single replica.
+1. Collector is a single replica (when enabled).
 2. Collector container image is operator-managed via `--otel-collector-image` (not user-supplied in CR).
 3. `templogs` schema is created by the OTEL Collector, not Postgres bootstrap; the operator never drops it.
 4. Only sandbox audit logs (`service.name=lightspeed-agentic-sandbox`) are routed to Postgres.

--- a/config/default/deployment-patch.yaml
+++ b/config/default/deployment-patch.yaml
@@ -18,13 +18,7 @@
   value: --openshift-mcp-server-image=__REPLACE_OPENSHIFT_MCP_SERVER__
 - op: add
   path: /spec/template/spec/containers/0/args/-
-  value: --otel-collector-image=__REPLACE_LIGHTSPEED_OTEL_COLLECTOR__
-- op: add
-  path: /spec/template/spec/containers/0/args/-
   value: --rhokp-image=__REPLACE_RHOKP__
-- op: add
-  path: /spec/template/spec/containers/0/args/-
-  value: --agentic-sandbox-image=__REPLACE_LIGHTSPEED_AGENTIC_SANDBOX__
 - op: replace
   path: /spec/template/spec/containers/0/image
   value: __REPLACE_LIGHTSPEED_OPERATOR__

--- a/internal/controller/agenticintegration/assets.go
+++ b/internal/controller/agenticintegration/assets.go
@@ -98,14 +98,17 @@ func GenerateAgenticConfigurationConfigMap(r reconciler.Reconciler, cr *olsv1alp
 	}
 
 	ns := r.GetNamespace()
-	otelHost := fmt.Sprintf("%s.%s.svc", utils.OtelCollectorServiceName, ns)
+	// OLS-3737: OTEL endpoint data disabled until e2e tests prove the
+	// collector pipeline works. Re-enable in OLS-3737 Phase 3.
+	// otelHost := fmt.Sprintf("%s.%s.svc", utils.OtelCollectorServiceName, ns)
 
 	data := map[string]string{
-		utils.AgenticConfigurationSandboxModeKey:           string(SandboxModeFromCR(cr)),
-		utils.AgenticConfigurationSandboxPodSpecKey:        string(podSpecJSON),
-		utils.AgenticConfigurationOtelCollectorEndpointKey: fmt.Sprintf("%s:%d", otelHost, utils.OtelCollectorGRPCPort),
-		utils.AgenticConfigurationOtelAdminEndpointKey:     fmt.Sprintf("https://%s:%d", otelHost, utils.OtelCollectorAdminPort),
-		utils.AgenticConfigurationOtelCASecretKey:          utils.AgenticOtelCASecretName,
+		utils.AgenticConfigurationSandboxModeKey:    string(SandboxModeFromCR(cr)),
+		utils.AgenticConfigurationSandboxPodSpecKey: string(podSpecJSON),
+		// OLS-3737: OTEL keys disabled until collector pipeline is proven.
+		// utils.AgenticConfigurationOtelCollectorEndpointKey: fmt.Sprintf("%s:%d", otelHost, utils.OtelCollectorGRPCPort),
+		// utils.AgenticConfigurationOtelAdminEndpointKey:     fmt.Sprintf("https://%s:%d", otelHost, utils.OtelCollectorAdminPort),
+		// utils.AgenticConfigurationOtelCASecretKey:          utils.AgenticOtelCASecretName,
 	}
 	if utils.BoolDeref(cr.Spec.OLSConfig.IntrospectionEnabled, true) {
 		data[utils.AgenticConfigurationMCPEndpointKey] = utils.OpenShiftMCPServerServiceURL(ns)

--- a/internal/controller/agenticintegration/assets_test.go
+++ b/internal/controller/agenticintegration/assets_test.go
@@ -2,7 +2,6 @@ package agenticintegration
 
 import (
 	"encoding/json"
-	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -76,21 +75,17 @@ var _ = Describe("Agentic integration assets", func() {
 		Expect(cm.Name).To(Equal(utils.AgenticConfigurationConfigMapName))
 		Expect(cm.Labels).To(Equal(labels))
 		Expect(cm.Data[utils.AgenticConfigurationSandboxModeKey]).To(Equal(string(olsv1alpha1.SandboxModeBarePod)))
-		Expect(cm.Data[utils.AgenticConfigurationOtelCASecretKey]).To(Equal(utils.AgenticOtelCASecretName))
+		// OLS-3737: OTEL key assertions disabled until collector pipeline is proven.
+		// Expect(cm.Data[utils.AgenticConfigurationOtelCASecretKey]).To(Equal(utils.AgenticOtelCASecretName))
 		Expect(cm.Data).NotTo(HaveKey(utils.AgenticConfigurationMCPEndpointKey))
 		Expect(cm.Data).NotTo(HaveKey(utils.AgenticConfigurationMCPCASecretKey))
+		Expect(cm.Data).NotTo(HaveKey(utils.AgenticConfigurationOtelCollectorEndpointKey))
+		Expect(cm.Data).NotTo(HaveKey(utils.AgenticConfigurationOtelAdminEndpointKey))
+		Expect(cm.Data).NotTo(HaveKey(utils.AgenticConfigurationOtelCASecretKey))
 
 		var podSpec corev1.PodSpec
 		Expect(json.Unmarshal([]byte(cm.Data[utils.AgenticConfigurationSandboxPodSpecKey]), &podSpec)).To(Succeed())
 		Expect(podSpec.Containers[0].Image).To(Equal(utils.AgenticSandboxImageDefault))
-
-		host := fmt.Sprintf("%s.%s.svc", utils.OtelCollectorServiceName, utils.OLSNamespaceDefault)
-		Expect(cm.Data[utils.AgenticConfigurationOtelCollectorEndpointKey]).To(Equal(
-			fmt.Sprintf("%s:%d", host, utils.OtelCollectorGRPCPort),
-		))
-		Expect(cm.Data[utils.AgenticConfigurationOtelAdminEndpointKey]).To(Equal(
-			fmt.Sprintf("https://%s:%d", host, utils.OtelCollectorAdminPort),
-		))
 	})
 
 	It("should include MCP keys when introspection is enabled", func() {

--- a/internal/controller/agenticintegration/reconciler.go
+++ b/internal/controller/agenticintegration/reconciler.go
@@ -85,14 +85,17 @@ func reconcileConfigurationConfigMap(r reconciler.Reconciler, ctx context.Contex
 func handoffCreatePrerequisites(r reconciler.Reconciler, ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
 	ns := r.GetNamespace()
 
-	svc := &corev1.Service{}
-	if err := r.Get(ctx, client.ObjectKey{Name: utils.OtelCollectorServiceName, Namespace: ns}, svc); err != nil {
-		return fmt.Errorf("OTEL Collector Service %s: %w", utils.OtelCollectorServiceName, err)
-	}
-	if err := requireSecretKey(r, ctx, ns, utils.AgenticOtelCASecretName, utils.AgenticOtelCASecretDataKey); err != nil {
-		return err
-	}
+	// OLS-3737: OTEL Collector prerequisite checks disabled until e2e tests
+	// prove the collector pipeline works. Re-enable in OLS-3737 Phase 3.
+	// svc := &corev1.Service{}
+	// if err := r.Get(ctx, client.ObjectKey{Name: utils.OtelCollectorServiceName, Namespace: ns}, svc); err != nil {
+	// 	return fmt.Errorf("OTEL Collector Service %s: %w", utils.OtelCollectorServiceName, err)
+	// }
+	// if err := requireSecretKey(r, ctx, ns, utils.AgenticOtelCASecretName, utils.AgenticOtelCASecretDataKey); err != nil {
+	// 	return err
+	// }
 
+	svc := &corev1.Service{}
 	if !utils.BoolDeref(cr.Spec.OLSConfig.IntrospectionEnabled, true) {
 		return nil
 	}

--- a/internal/controller/agenticintegration/reconciler_test.go
+++ b/internal/controller/agenticintegration/reconciler_test.go
@@ -20,8 +20,10 @@ var _ = Describe("Agentic integration reconciler", Ordered, func() {
 		testCR.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(false)
 	})
 
+	// OLS-3737: OTEL prerequisite gating is disabled. The handoff ConfigMap
+	// should be created even without the OTEL Collector Service.
 	Context("create gating", func() {
-		It("should not create the handoff ConfigMap when OTEL Service is missing", func() {
+		It("should create the handoff ConfigMap even when OTEL Service is missing", func() {
 			cm := &corev1.ConfigMap{}
 			err := k8sClient.Get(ctx, types.NamespacedName{
 				Name:      utils.AgenticConfigurationConfigMapName,
@@ -33,7 +35,7 @@ var _ = Describe("Agentic integration reconciler", Ordered, func() {
 				Expect(apierrors.IsNotFound(err)).To(BeTrue())
 			}
 
-			// Other specs may have created prerequisites; remove OTEL Service for this gate.
+			// Remove OTEL Service to verify the handoff no longer gates on it.
 			otelSvc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
 				Name: utils.OtelCollectorServiceName, Namespace: utils.OLSNamespaceDefault,
 			}}
@@ -43,14 +45,13 @@ var _ = Describe("Agentic integration reconciler", Ordered, func() {
 			gated := testCR.DeepCopy()
 			gated.Spec.OLSConfig.IntrospectionEnabled = utils.BoolPtr(false)
 			err = ReconcileAgenticIntegrationResources(testReconcilerInstance, ctx, gated)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(utils.ErrAgenticConfigurationPrerequisitesNotReady))
+			Expect(err).NotTo(HaveOccurred())
 
 			err = k8sClient.Get(ctx, types.NamespacedName{
 				Name:      utils.AgenticConfigurationConfigMapName,
 				Namespace: utils.OLSNamespaceDefault,
 			}, cm)
-			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 
@@ -71,7 +72,8 @@ var _ = Describe("Agentic integration reconciler", Ordered, func() {
 			expectOwnedByOLSConfig(cm)
 			Expect(cm.Data[utils.AgenticConfigurationSandboxModeKey]).To(Equal(string(olsv1alpha1.SandboxModeBarePod)))
 			Expect(cm.Data).To(HaveKey(utils.AgenticConfigurationSandboxPodSpecKey))
-			Expect(cm.Data[utils.AgenticConfigurationOtelCASecretKey]).To(Equal(utils.AgenticOtelCASecretName))
+			// OLS-3737: OTEL keys no longer present in handoff ConfigMap.
+			Expect(cm.Data).NotTo(HaveKey(utils.AgenticConfigurationOtelCASecretKey))
 			Expect(cm.Data).NotTo(HaveKey(utils.AgenticConfigurationMCPEndpointKey))
 		})
 

--- a/internal/controller/appserver/assets.go
+++ b/internal/controller/appserver/assets.go
@@ -354,20 +354,22 @@ func buildOLSConfig(r reconciler.Reconciler, ctx context.Context, cr *olsv1alpha
 
 // buildServiceAuditConfig maps OLS service audit settings into olsconfig.yaml.
 // spec.audit on the CR is collector-only; stdout audit uses spec.ols.auditEventsEnabled.
-// Traces are always exported to the in-cluster OTEL Collector.
 func buildServiceAuditConfig(cr *olsv1alpha1.OLSConfig, namespace string) *utils.AuditYAMLConfig {
 	logging := "Enabled"
 	if !utils.BoolDeref(cr.Spec.OLSConfig.AuditEventsEnabled, true) {
 		logging = "Disabled"
 	}
-	endpoint := fmt.Sprintf("%s.%s.svc:%d",
-		utils.OtelCollectorServiceName, namespace, utils.OtelCollectorGRPCPort)
+	// OLS-3737: OTEL endpoint injection is disabled until e2e tests prove the
+	// collector pipeline works end-to-end. The service falls back to a no-op
+	// tracer when the otel section is absent. Re-enable in OLS-3737 Phase 3.
+	// endpoint := fmt.Sprintf("%s.%s.svc:%d",
+	// 	utils.OtelCollectorServiceName, namespace, utils.OtelCollectorGRPCPort)
 	return &utils.AuditYAMLConfig{
 		Logging: logging,
-		OTEL: &utils.OTELYAMLConfig{
-			Endpoint: endpoint,
-			TLSMode:  "Secure",
-		},
+		// OTEL: &utils.OTELYAMLConfig{
+		// 	Endpoint: endpoint,
+		// 	TLSMode:  "Secure",
+		// },
 	}
 }
 

--- a/internal/controller/appserver/assets_test.go
+++ b/internal/controller/appserver/assets_test.go
@@ -2445,14 +2445,16 @@ var _ = Describe("Helper function unit tests", func() {
 })
 
 func serviceAuditYAMLMatcher(logging string) OmegaMatcher {
-	endpoint := fmt.Sprintf("%s.%s.svc:%d",
-		utils.OtelCollectorServiceName, utils.OLSNamespaceDefault, utils.OtelCollectorGRPCPort)
+	// OLS-3737: OTEL endpoint assertion disabled until e2e tests prove the
+	// collector pipeline works. Re-enable in OLS-3737 Phase 3.
+	// endpoint := fmt.Sprintf("%s.%s.svc:%d",
+	// 	utils.OtelCollectorServiceName, utils.OLSNamespaceDefault, utils.OtelCollectorGRPCPort)
 	return MatchAllKeys(Keys{
 		"logging": Equal(logging),
-		"otel": MatchAllKeys(Keys{
-			"endpoint": Equal(endpoint),
-			"tls_mode": Equal("Secure"),
-		}),
+		// "otel": MatchAllKeys(Keys{
+		// 	"endpoint": Equal(endpoint),
+		// 	"tls_mode": Equal("Secure"),
+		// }),
 	})
 }
 

--- a/internal/controller/olsconfig_controller.go
+++ b/internal/controller/olsconfig_controller.go
@@ -83,7 +83,8 @@ import (
 	"github.com/openshift/lightspeed-operator/internal/controller/appserver"
 	"github.com/openshift/lightspeed-operator/internal/controller/console"
 	"github.com/openshift/lightspeed-operator/internal/controller/ocpmcp"
-	"github.com/openshift/lightspeed-operator/internal/controller/otelcollector"
+	// OLS-3737: OTEL Collector reconciliation disabled until e2e coverage exists.
+	// "github.com/openshift/lightspeed-operator/internal/controller/otelcollector"
 	"github.com/openshift/lightspeed-operator/internal/controller/postgres"
 	"github.com/openshift/lightspeed-operator/internal/controller/utils"
 	"github.com/openshift/lightspeed-operator/internal/controller/watchers"
@@ -310,9 +311,10 @@ func (r *OLSConfigReconciler) reconcileIndependentResources(ctx context.Context,
 		{Name: "postgres resources", Fn: func(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
 			return postgres.ReconcilePostgresResources(r, ctx, cr)
 		}},
-		{Name: "OTEL Collector resources", Fn: func(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
-			return otelcollector.ReconcileOtelCollectorResources(r, ctx, cr)
-		}},
+		// OLS-3737: OTEL Collector reconciliation disabled until e2e coverage exists.
+		// {Name: "OTEL Collector resources", Fn: func(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
+		// 	return otelcollector.ReconcileOtelCollectorResources(r, ctx, cr)
+		// }},
 		{Name: "openshift-mcp-server resources", Fn: func(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
 			return ocpmcp.ReconcileResources(r, ctx, cr)
 		}},
@@ -415,9 +417,10 @@ func (r *OLSConfigReconciler) reconcileDeploymentsAndStatus(ctx context.Context,
 		{Name: "postgres deployment", Fn: func(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
 			return postgres.ReconcilePostgresDeployment(r, ctx, cr)
 		}, ConditionType: utils.TypeCacheReady, Deployment: utils.PostgresDeploymentName},
-		{Name: "OTEL Collector deployment", Fn: func(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
-			return otelcollector.ReconcileOtelCollectorDeployment(r, ctx, cr)
-		}, ConditionType: utils.TypeOtelCollectorReady, Deployment: utils.OtelCollectorDeploymentName},
+		// OLS-3737: OTEL Collector reconciliation disabled until e2e coverage exists.
+		// {Name: "OTEL Collector deployment", Fn: func(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
+		// 	return otelcollector.ReconcileOtelCollectorDeployment(r, ctx, cr)
+		// }, ConditionType: utils.TypeOtelCollectorReady, Deployment: utils.OtelCollectorDeploymentName},
 	}
 
 	if utils.BoolDeref(olsconfig.Spec.OLSConfig.IntrospectionEnabled, true) {


### PR DESCRIPTION
## Summary
- Comment out OTEL endpoint injection in `buildServiceAuditConfig` — the service falls back to a no-op tracer when the otel section is absent
- Comment out otel-collector reconciliation (Phase 1 resources + Phase 2 deployment) since the collector image was removed from the release bundle (PR #1884)
- Update operator specs (`audit-logging.md`, `templog.md`) to reflect the change
- Regenerate `deployment-patch.yaml` (removes stale otel-collector and agentic-sandbox image args)

## Context
PR #1884 removed the `lightspeed-otel-collector` image from `related_images.json` and the CSV. The collector operand can no longer run, yet the operator still unconditionally injects `audit.otel.endpoint` into `olsconfig.yaml`, causing the service to silently fail sending traces to a non-existent collector.

All code is commented out (not deleted) for easy re-enablement in [OLS-3737](https://redhat.atlassian.net/browse/OLS-3737) Phase 3 once e2e tests prove the pipeline works.

## Test plan
- [x] `make test` passes — all controller packages green
- [ ] Deploy on cluster, verify olsconfig.yaml has no `audit.otel` block
- [ ] Verify service starts with no-op tracer, no otel-related errors in logs
- [ ] Verify otel-collector resources are not created

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Temporarily disabled OpenTelemetry collector reconciliation and automatic in-cluster trace export.
  * Audit configuration no longer injects OpenTelemetry endpoint/TLS settings; services fall back to a no-op tracer when telemetry config is absent.
  * Agentic handoff configuration no longer includes OpenTelemetry collector/admin endpoint and CA secret entries.
  * Updated operator startup args by removing placeholder OpenTelemetry and agentic sandbox image arguments (RH OpenShift Knowledge Prompt image remains).
* **Documentation**
  * Refreshed audit-logging and templog specs to describe the disabled behavior and the planned re-enablement path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->