### PR TITLE
Bundle Update from Snapshot crt-nshift-lightspeed-tenant/ols-20260729-165308-000

### DIFF
--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     console.openshift.io/operator-monitoring-default: "true"
-    createdAt: "2026-07-29T11:48:55Z"
+    createdAt: "2026-07-29T23:07:46Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -1012,7 +1012,7 @@ spec:
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.annotations['olm.targetNamespaces']
-                    image: registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:74a5c2911a2bad23a33ec1cb4ada78d6b4483ca7d32e534930ac64298e7fa3da
+                    image: registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:18ba78e3610cfd80cfd69ae2e300d726a0e5a00010aec1bd2fd1ab4e1118136b
                     imagePullPolicy: Always
                     livenessProbe:
                       httpGet:
@@ -1137,7 +1137,7 @@ spec:
     - name: lightspeed-console-plugin
       image: registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:abc8816ab7681a045dba349688fb26755a772045770327cfe41dae11475dabec
     - name: lightspeed-operator
-      image: registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:74a5c2911a2bad23a33ec1cb4ada78d6b4483ca7d32e534930ac64298e7fa3da
+      image: registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:18ba78e3610cfd80cfd69ae2e300d726a0e5a00010aec1bd2fd1ab4e1118136b
     - name: openshift-mcp-server
       image: registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9@sha256:e7626fae901d8855922cf77ab71ea6ce22f3ce15d32184632ac5985d359afd68
     - name: rhokp

--- a/related_images.json
+++ b/related_images.json
@@ -31,8 +31,8 @@
   },
   {
     "name": "lightspeed-operator",
-    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:74a5c2911a2bad23a33ec1cb4ada78d6b4483ca7d32e534930ac64298e7fa3da",
-    "revision": "b2274a8e08233d6a09923d1256e4a5533d44ad18",
+    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:18ba78e3610cfd80cfd69ae2e300d726a0e5a00010aec1bd2fd1ab4e1118136b",
+    "revision": "86a5ebdfcec96d400c0cecb0ab03f4e17b3ca8eb",
     "operator_target": "image",
     "snapshot_component": "lightspeed-operator",
     "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator",


### PR DESCRIPTION
This PR is triggered by the release crt-nshift-lightspeed-tenant/ols-20260729-165308-000-610ead1-dmdc4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Lightspeed Operator release metadata timestamp.
  * Refreshed the Lightspeed Operator manager container image digest and its related image reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->