### PR TITLE
Bundle Update from Snapshot crt-nshift-lightspeed-tenant/ols-20260730-010226-000

### DIFF
--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     console.openshift.io/operator-monitoring-default: "true"
-    createdAt: "2026-07-29T23:07:46Z"
+    createdAt: "2026-07-30T13:10:11Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -1001,8 +1001,8 @@ spec:
                       - --cert-dir=/etc/tls/private
                       - --dataverse-exporter-image=registry.redhat.io/lightspeed-core/dataverse-exporter-rhel9@sha256:1c7ffaead23adfb1dc6bd3adfe75c80f284d6d31f13ca427d754703c78514cb2
                       - --postgres-image=registry.redhat.io/rhel9/postgresql-16@sha256:42f385ac3c9b8913426da7c57e70bc6617cd237aaf697c667f6385a8c0b0118b
-                      - --service-image=registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9@sha256:55d2becda14642064be4ffde695744243cf4a5a7c0c545695782cf95c9d6ca9e
-                      - --console-image=registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:abc8816ab7681a045dba349688fb26755a772045770327cfe41dae11475dabec
+                      - --service-image=registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9@sha256:802897cc0906ae5dbfa1ac6976027ed690cedbc903878e64262c57270a2c0cab
+                      - --console-image=registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:4fe49967001efe4e277c887a0b218e9d7ff7c051f2d7e8928afaab2d1705cfb0
                       - --openshift-mcp-server-image=registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9@sha256:e7626fae901d8855922cf77ab71ea6ce22f3ce15d32184632ac5985d359afd68
                       - --rhokp-image=registry.redhat.io/offline-knowledge-portal/rhokp-rhel9:latest
                     command:
@@ -1012,7 +1012,7 @@ spec:
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.annotations['olm.targetNamespaces']
-                    image: registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:18ba78e3610cfd80cfd69ae2e300d726a0e5a00010aec1bd2fd1ab4e1118136b
+                    image: registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:33754d9f419c2d6713b693aadcd8be37c5f293f4f9d07e28bae75a7768a18317
                     imagePullPolicy: Always
                     livenessProbe:
                       httpGet:
@@ -1133,11 +1133,11 @@ spec:
     - name: lightspeed-postgresql
       image: registry.redhat.io/rhel9/postgresql-16@sha256:42f385ac3c9b8913426da7c57e70bc6617cd237aaf697c667f6385a8c0b0118b
     - name: lightspeed-service-api
-      image: registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9@sha256:55d2becda14642064be4ffde695744243cf4a5a7c0c545695782cf95c9d6ca9e
+      image: registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9@sha256:802897cc0906ae5dbfa1ac6976027ed690cedbc903878e64262c57270a2c0cab
     - name: lightspeed-console-plugin
-      image: registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:abc8816ab7681a045dba349688fb26755a772045770327cfe41dae11475dabec
+      image: registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:4fe49967001efe4e277c887a0b218e9d7ff7c051f2d7e8928afaab2d1705cfb0
     - name: lightspeed-operator
-      image: registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:18ba78e3610cfd80cfd69ae2e300d726a0e5a00010aec1bd2fd1ab4e1118136b
+      image: registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:33754d9f419c2d6713b693aadcd8be37c5f293f4f9d07e28bae75a7768a18317
     - name: openshift-mcp-server
       image: registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9@sha256:e7626fae901d8855922cf77ab71ea6ce22f3ce15d32184632ac5985d359afd68
     - name: rhokp

--- a/related_images.json
+++ b/related_images.json
@@ -13,8 +13,8 @@
   },
   {
     "name": "lightspeed-service-api",
-    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9@sha256:55d2becda14642064be4ffde695744243cf4a5a7c0c545695782cf95c9d6ca9e",
-    "revision": "1430287650a771663f09802447d32e591f3884cd",
+    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9@sha256:802897cc0906ae5dbfa1ac6976027ed690cedbc903878e64262c57270a2c0cab",
+    "revision": "38771432b12e704bc1adcb1009673504c891417c",
     "operator_arg": "service-image",
     "snapshot_component": "lightspeed-service",
     "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service",
@@ -22,8 +22,8 @@
   },
   {
     "name": "lightspeed-console-plugin",
-    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:abc8816ab7681a045dba349688fb26755a772045770327cfe41dae11475dabec",
-    "revision": "a7700da4c3fc5fde06354282c07de52a662f09b2",
+    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:4fe49967001efe4e277c887a0b218e9d7ff7c051f2d7e8928afaab2d1705cfb0",
+    "revision": "62ae57ae860791976aeba3e9a70f872233d868e3",
     "operator_arg": "console-image",
     "snapshot_component": "lightspeed-console",
     "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console",
@@ -31,8 +31,8 @@
   },
   {
     "name": "lightspeed-operator",
-    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:18ba78e3610cfd80cfd69ae2e300d726a0e5a00010aec1bd2fd1ab4e1118136b",
-    "revision": "86a5ebdfcec96d400c0cecb0ab03f4e17b3ca8eb",
+    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:33754d9f419c2d6713b693aadcd8be37c5f293f4f9d07e28bae75a7768a18317",
+    "revision": "7132654399ec1289f5e1d3376bec3e4636b174af",
     "operator_target": "image",
     "snapshot_component": "lightspeed-operator",
     "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator",


### PR DESCRIPTION
This PR is triggered by the release crt-nshift-lightspeed-tenant/ols-20260730-010226-000-2c12dbe-qrpxl.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the Lightspeed Operator release metadata timestamp.
  - Refreshed the Lightspeed console plugin image reference to the latest digest (including the manager argument and related images).
  - Refreshed the Lightspeed Operator manager image digest and synchronized related image references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->