### PR TITLE
OLS-3089 Disable SA token automount for non-API pods

### DIFF
--- a/internal/controller/otelcollector/deployment.go
+++ b/internal/controller/otelcollector/deployment.go
@@ -162,7 +162,8 @@ func GenerateOtelCollectorDeployment(r reconciler.Reconciler, ctx context.Contex
 					Labels: utils.GenerateOtelCollectorSelectorLabels(),
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: utils.OtelCollectorServiceAccountName,
+					AutomountServiceAccountToken: utils.BoolPtr(false),
+					ServiceAccountName:           utils.OtelCollectorServiceAccountName,
 					// No explicit UID/GID — OpenShift assigns from the namespace range via restricted SCC.
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsNonRoot: &runAsNonRoot,

--- a/internal/controller/postgres/deployment.go
+++ b/internal/controller/postgres/deployment.go
@@ -194,6 +194,7 @@ func GeneratePostgresDeployment(r reconciler.Reconciler, ctx context.Context, cr
 					Labels: utils.GeneratePostgresSelectorLabels(),
 				},
 				Spec: corev1.PodSpec{
+					AutomountServiceAccountToken: utils.BoolPtr(false),
 					Containers: []corev1.Container{
 						{
 							Name:            utils.PostgresDeploymentName,

--- a/internal/controller/utils/utils.go
+++ b/internal/controller/utils/utils.go
@@ -1092,6 +1092,7 @@ func GenerateConsolePluginDeployment(
 					Labels: opts.Labels,
 				},
 				Spec: corev1.PodSpec{
+					AutomountServiceAccountToken: BoolPtr(false),
 					Containers: []corev1.Container{
 						{
 							Name:            opts.ContainerName,


### PR DESCRIPTION
## Summary

- **[OLS-3089](https://redhat.atlassian.net/browse/OLS-3089)**: Set `automountServiceAccountToken=false` on PostgreSQL, console, agentic-console, and OTEL collector PodSpecs. These pods serve static files or run databases and do not make Kubernetes API calls, so they should not mount service account tokens.

## Test plan

- [ ] Verify PostgreSQL deployment starts without SA token mounted
- [ ] Verify console and agentic-console deployments serve UI correctly
- [ ] Verify OTEL collector starts and collects telemetry without SA token

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Disabled automatic service account token mounting for OTEL Collector, Postgres, and console plugin workloads.
  - Existing service account assignments remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->