### PR TITLE
OLS-3593 enable init container comparison for app server deployment

### DIFF
--- a/internal/controller/appserver/deployment.go
+++ b/internal/controller/appserver/deployment.go
@@ -2,6 +2,7 @@ package appserver
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"path"
@@ -466,6 +467,7 @@ func GenerateOLSDeployment(r reconciler.Reconciler, cr *olsv1alpha1.OLSConfig) (
 
 	annotations := map[string]string{
 		utils.OLSConfigMapResourceVersionAnnotation: configMapResourceVersion,
+		utils.RAGSpecHashAnnotation:                 ragSpecHash(cr),
 		utils.ProxyCACertHashAnnotation:             proxyCACMResourceVersion,
 	}
 
@@ -616,6 +618,13 @@ func updateOLSDeployment(r reconciler.Reconciler, ctx context.Context, cr *olsv1
 		}
 	}
 
+	// Step 4: Check if RAG spec has changed
+	currentRAGHash := ragSpecHash(cr)
+	if existingDeployment.Annotations[utils.RAGSpecHashAnnotation] != currentRAGHash {
+		r.GetLogger().Info("RAG spec changed, updating deployment")
+		changed = true
+	}
+
 	// If nothing changed, skip update
 	if !changed {
 		return nil
@@ -630,6 +639,7 @@ func updateOLSDeployment(r reconciler.Reconciler, ctx context.Context, cr *olsv1
 	}
 
 	existingDeployment.Annotations[utils.OLSConfigMapResourceVersionAnnotation] = desiredDeployment.Annotations[utils.OLSConfigMapResourceVersionAnnotation]
+	existingDeployment.Annotations[utils.RAGSpecHashAnnotation] = currentRAGHash
 	existingDeployment.Annotations[utils.ProxyCACertHashAnnotation] = currentProxyCACMHash
 
 	r.GetLogger().Info("updating OLS deployment", "name", existingDeployment.Name)
@@ -732,4 +742,12 @@ func RestartAppServer(r reconciler.Reconciler, ctx context.Context, deployment .
 	}
 
 	return nil
+}
+
+func ragSpecHash(cr *olsv1alpha1.OLSConfig) string {
+	if len(cr.Spec.OLSConfig.RAG) == 0 {
+		return ""
+	}
+	data, _ := json.Marshal(cr.Spec.OLSConfig.RAG)
+	return fmt.Sprintf("%x", sha256.Sum256(data))
 }

--- a/internal/controller/utils/constants.go
+++ b/internal/controller/utils/constants.go
@@ -629,6 +629,8 @@ ssl_ca_file = '/etc/certs/cm-olspostgresca/service-ca.crt'
 	OpenShiftMCPServerConfigMapResourceVersionAnnotation = "ols.openshift.io/mcp-server-configmap-version"
 	// OpenShiftMCPServerTLSSecretResourceVersionAnnotation tracks the MCP TLS Secret ResourceVersion on the MCP Deployment.
 	OpenShiftMCPServerTLSSecretResourceVersionAnnotation = "ols.openshift.io/mcp-server-tls-secret-version" // #nosec G101
+	// RAGSpecHashAnnotation tracks the hash of .spec.ols.rag on the app-server Deployment.
+	RAGSpecHashAnnotation = "ols.openshift.io/rag-spec-hash"
 
 	/*** Standalone RHOKP Constants ***/
 	// RHOKPDeploymentName is the Deployment name for the standalone RHOKP operand.


### PR DESCRIPTION
## Summary
- Fix: detect changes to `.spec.ols.rag` (RAG image references) so they trigger a deployment rollout
- Root cause: `DeploymentSpecEqual` was called with `compareInitContainers=false`, and no other change detector tracked RAG images — so RAG image changes were silently ignored

## Why not just enable init container comparison?

The obvious fix — flipping `compareInitContainers` from `false` to `true` — causes an **infinite reconciliation loop** when RAG is configured.

When RAG images are present, the operator sets an `image.openshift.io/triggers` annotation on the deployment (`rag.go:62-79`). This tells OpenShift's image trigger controller to resolve ImageStreamTags and replace the init container image field with the resolved `@sha256:...` digest. With `compareInitContainers=true`, this creates a fight between two controllers:

1. **Operator reconciles** → generates desired deployment with the user-specified image tag (e.g., `my-image:latest`)
2. **OpenShift trigger controller** → resolves the tag and writes the SHA digest into the deployment (e.g., `my-image@sha256:abc...`)
3. **Operator reconciles again** → `ContainerSpecEqual` compares `a.Image == b.Image`, sees tag != digest, detects a "change"
4. **Operator updates** the deployment back to the tag → goto step 2

This was confirmed in e2e testing where the deployment generation reached 5663 vs observed generation 2303 (~5-6 updates/second).

## Solution

Track a SHA-256 hash of the CR's `.spec.ols.rag` in a deployment annotation (`ols.openshift.io/rag-spec-hash`). When the user changes RAG image references, the hash changes and triggers a deployment rollout — without comparing init container images directly and without conflicting with OpenShift's image trigger mechanism.

## Test plan
- [x] `make test` passes — all unit tests green
- [x] `bundle-e2e-4-21` CI passed (including BYOK/RAG tests)
- [ ] Deploy OLS with a RAG image configured, change the image tag, and verify the operator rolls out a new deployment

Fixes: [OLS-3593](https://redhat.atlassian.net/browse/OLS-3593)

🤖 Generated with [Claude Code](https://claude.com/claude-code)