### PR TITLE
OLS-3765 Add restricted securityContext to sandbox PodSpec in ConfigMap

### DIFF
--- a/internal/controller/agenticintegration/assets.go
+++ b/internal/controller/agenticintegration/assets.go
@@ -62,11 +62,27 @@ func GenerateSandboxPodSpec(r reconciler.Reconciler, cr *olsv1alpha1.OLSConfig) 
 	resources := utils.GetResourcesOrDefault(cfg.Resources, defaultSandboxResources())
 
 	spec := &corev1.PodSpec{
+		SecurityContext: &corev1.PodSecurityContext{
+			RunAsNonRoot: utils.BoolPtr(true),
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			},
+		},
 		Containers: []corev1.Container{
 			{
 				Name:      utils.AgenticSandboxContainerName,
 				Image:     r.GetAgenticSandboxImage(),
 				Resources: *resources,
+				SecurityContext: &corev1.SecurityContext{
+					AllowPrivilegeEscalation: utils.BoolPtr(false),
+					RunAsNonRoot:             utils.BoolPtr(true),
+					Capabilities: &corev1.Capabilities{
+						Drop: []corev1.Capability{"ALL"},
+					},
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeRuntimeDefault,
+					},
+				},
 				VolumeMounts: []corev1.VolumeMount{
 					{Name: sandboxHomeVolumeName, MountPath: sandboxHomeMountPath},
 					{Name: sandboxSkillsWorkdirVolumeName, MountPath: sandboxSkillsWorkdirMountPath},

--- a/internal/controller/agenticintegration/assets_test.go
+++ b/internal/controller/agenticintegration/assets_test.go
@@ -43,6 +43,18 @@ var _ = Describe("Agentic integration assets", func() {
 		Expect(spec.Volumes).To(HaveLen(2))
 		Expect(spec.Volumes[0].EmptyDir).NotTo(BeNil())
 		Expect(spec.Volumes[1].EmptyDir).NotTo(BeNil())
+
+		By("setting PSA restricted-compliant pod-level securityContext")
+		Expect(spec.SecurityContext).NotTo(BeNil())
+		Expect(*spec.SecurityContext.RunAsNonRoot).To(BeTrue())
+		Expect(spec.SecurityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+
+		By("setting PSA restricted-compliant container-level securityContext")
+		Expect(c.SecurityContext).NotTo(BeNil())
+		Expect(*c.SecurityContext.AllowPrivilegeEscalation).To(BeFalse())
+		Expect(*c.SecurityContext.RunAsNonRoot).To(BeTrue())
+		Expect(c.SecurityContext.Capabilities.Drop).To(ConsistOf(corev1.Capability("ALL")))
+		Expect(c.SecurityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
 	})
 
 	It("should apply AgenticSandboxConfig resources, tolerations, and nodeSelector", func() {


### PR DESCRIPTION
## Summary
- `GenerateSandboxPodSpec()` produces the base PodSpec stored in `lightspeed-agentic-configuration` ConfigMap
- It lacked `securityContext`, causing PSA `restricted:latest` violations when the agentic operator creates sandbox pods from this base spec
- Adds pod-level and container-level securityContext matching the agentic operator's `bootstrap.go` pattern
- `ReadOnlyRootFilesystem` intentionally omitted — sandbox containers need writable root

## Test plan
- [x] `make test` passes (includes securityContext assertions in `assets_test.go`)
- [ ] Deploy classic operator, verify ConfigMap's `sandbox-pod-spec` includes securityContext
- [ ] Submit AgenticRun on restricted namespace, verify no PSA warning

Jira: https://redhat.atlassian.net/browse/OLS-3765
Related: https://github.com/openshift/lightspeed-agentic-operator/pull/407 (quickstart script fix)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Sandbox workloads now run as non-root with restricted security settings.
  * Privilege escalation is disabled, runtime-default seccomp profiles are enabled, and Linux capabilities are dropped.
  * Improved compliance with Kubernetes Pod Security Admission restricted standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->