### PR TITLE
OLS-3727: Add ServiceMonitor for RHOKP Solr metrics

### DIFF
--- a/internal/controller/appserver/assets.go
+++ b/internal/controller/appserver/assets.go
@@ -780,7 +780,7 @@ func GenerateService(r reconciler.Reconciler, cr *olsv1alpha1.OLSConfig) (*corev
 	return &service, nil
 }
 
-func GenerateServiceMonitor(r reconciler.Reconciler, cr *olsv1alpha1.OLSConfig) (*monv1.ServiceMonitor, error) {
+func generateServiceMonitor(r reconciler.Reconciler, cr *olsv1alpha1.OLSConfig) (*monv1.ServiceMonitor, error) {
 	metaLabels := utils.GenerateAppServerSelectorLabels()
 	metaLabels["monitoring.openshift.io/collection-profile"] = "full"
 	metaLabels["app.kubernetes.io/component"] = "metrics"

--- a/internal/controller/appserver/assets_test.go
+++ b/internal/controller/appserver/assets_test.go
@@ -1607,7 +1607,7 @@ var _ = Describe("App server assets", func() {
 		})
 
 		It("should generate the OLS service monitor", func() {
-			serviceMonitor, err := GenerateServiceMonitor(testReconcilerInstance, cr)
+			serviceMonitor, err := generateServiceMonitor(testReconcilerInstance, cr)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(serviceMonitor.Name).To(Equal(utils.AppServerServiceMonitorName))
 			Expect(serviceMonitor.Namespace).To(Equal(utils.OLSNamespaceDefault))

--- a/internal/controller/appserver/reconciler.go
+++ b/internal/controller/appserver/reconciler.go
@@ -410,7 +410,7 @@ func reconcileMetricsReaderSecret(r reconciler.Reconciler, ctx context.Context, 
 }
 
 func reconcileServiceMonitor(r reconciler.Reconciler, ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
-	sm, err := GenerateServiceMonitor(r, cr)
+	sm, err := generateServiceMonitor(r, cr)
 	if err != nil {
 		return fmt.Errorf("%s: %w", utils.ErrGenerateServiceMonitor, err)
 	}

--- a/internal/controller/ocpmcp/assets.go
+++ b/internal/controller/ocpmcp/assets.go
@@ -188,9 +188,9 @@ func GetConfigPath() string {
 	return path.Join(utils.OpenShiftMCPServerConfigMountPath, utils.OpenShiftMCPServerConfigFilename)
 }
 
-// GenerateServiceMonitor generates a ServiceMonitor for HTTPS scraping of
+// generateServiceMonitor generates a ServiceMonitor for HTTPS scraping of
 // MCP server metrics on :8443, path /metrics. Server TLS only (service-ca).
-func GenerateServiceMonitor(r reconciler.Reconciler, cr *olsv1alpha1.OLSConfig) (*monv1.ServiceMonitor, error) {
+func generateServiceMonitor(r reconciler.Reconciler, cr *olsv1alpha1.OLSConfig) (*monv1.ServiceMonitor, error) {
 	metaLabels := selectorLabels()
 	metaLabels["monitoring.openshift.io/collection-profile"] = "full"
 	metaLabels["app.kubernetes.io/component"] = "metrics"

--- a/internal/controller/ocpmcp/assets_test.go
+++ b/internal/controller/ocpmcp/assets_test.go
@@ -97,7 +97,7 @@ var _ = Describe("OpenShift MCP Server assets", func() {
 	})
 
 	It("should generate the ServiceMonitor with HTTPS scrape config", func() {
-		sm, err := GenerateServiceMonitor(testReconcilerInstance, testCR)
+		sm, err := generateServiceMonitor(testReconcilerInstance, testCR)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(sm.Name).To(Equal(utils.OpenShiftMCPServerServiceMonitorName))
 		Expect(sm.Namespace).To(Equal(utils.OLSNamespaceDefault))

--- a/internal/controller/ocpmcp/reconciler.go
+++ b/internal/controller/ocpmcp/reconciler.go
@@ -177,7 +177,7 @@ func reconcileDeployment(r reconciler.Reconciler, ctx context.Context, cr *olsv1
 }
 
 func reconcileServiceMonitor(r reconciler.Reconciler, ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
-	sm, err := GenerateServiceMonitor(r, cr)
+	sm, err := generateServiceMonitor(r, cr)
 	if err != nil {
 		return fmt.Errorf("%s: %w", utils.ErrGenerateOpenShiftMCPServerServiceMonitor, err)
 	}

--- a/internal/controller/otelcollector/assets.go
+++ b/internal/controller/otelcollector/assets.go
@@ -216,9 +216,9 @@ func GenerateOtelCollectorNetworkPolicy(r reconciler.Reconciler, cr *olsv1alpha1
 	return &np, nil
 }
 
-// GenerateOtelCollectorServiceMonitor generates a ServiceMonitor for HTTPS scraping of
+// generateOtelCollectorServiceMonitor generates a ServiceMonitor for HTTPS scraping of
 // collector metrics on :8888. Server TLS only (service-ca); no client mTLS or Bearer.
-func GenerateOtelCollectorServiceMonitor(r reconciler.Reconciler, cr *olsv1alpha1.OLSConfig) (*monv1.ServiceMonitor, error) {
+func generateOtelCollectorServiceMonitor(r reconciler.Reconciler, cr *olsv1alpha1.OLSConfig) (*monv1.ServiceMonitor, error) {
 	metaLabels := utils.GenerateOtelCollectorSelectorLabels()
 	metaLabels["monitoring.openshift.io/collection-profile"] = "full"
 	metaLabels["app.kubernetes.io/component"] = "metrics"

--- a/internal/controller/otelcollector/assets_test.go
+++ b/internal/controller/otelcollector/assets_test.go
@@ -148,7 +148,7 @@ var _ = Describe("OTEL Collector assets", func() {
 	})
 
 	It("should generate the collector ServiceMonitor for HTTPS metrics scraping", func() {
-		sm, err := GenerateOtelCollectorServiceMonitor(testReconcilerInstance, testCR)
+		sm, err := generateOtelCollectorServiceMonitor(testReconcilerInstance, testCR)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(sm.Name).To(Equal(utils.OtelCollectorServiceMonitorName))
 		Expect(sm.Namespace).To(Equal(utils.OLSNamespaceDefault))

--- a/internal/controller/otelcollector/reconciler.go
+++ b/internal/controller/otelcollector/reconciler.go
@@ -197,7 +197,7 @@ func reconcileOtelCollectorDeployment(r reconciler.Reconciler, ctx context.Conte
 }
 
 func reconcileOtelCollectorServiceMonitor(r reconciler.Reconciler, ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
-	sm, err := GenerateOtelCollectorServiceMonitor(r, cr)
+	sm, err := generateOtelCollectorServiceMonitor(r, cr)
 	if err != nil {
 		return fmt.Errorf("%s: %w", utils.ErrGenerateOtelCollectorServiceMonitor, err)
 	}

--- a/internal/controller/rhokp/assets.go
+++ b/internal/controller/rhokp/assets.go
@@ -2,7 +2,9 @@ package rhokp
 
 import (
 	"fmt"
+	"strings"
 
+	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -94,4 +96,57 @@ func GenerateNetworkPolicy(r reconciler.Reconciler, cr *olsv1alpha1.OLSConfig) (
 		return nil, fmt.Errorf("%s: %w", utils.ErrSetRHOKPNetworkPolicyOwnerReference, err)
 	}
 	return &np, nil
+}
+
+// generateServiceMonitor generates a ServiceMonitor for HTTPS scraping of
+// RHOKP Solr metrics on :8443, path /solr/admin/metrics. Server TLS only (service-ca).
+func generateServiceMonitor(r reconciler.Reconciler, cr *olsv1alpha1.OLSConfig) (*monv1.ServiceMonitor, error) {
+	metaLabels := selectorLabels()
+	metaLabels["monitoring.openshift.io/collection-profile"] = "full"
+	metaLabels["app.kubernetes.io/component"] = "metrics"
+	metaLabels["openshift.io/user-monitoring"] = "false"
+
+	valFalse := false
+	serverName := strings.Join([]string{utils.RHOKPServiceName, r.GetNamespace(), "svc"}, ".")
+	var schemeHTTPS monv1.Scheme = "https"
+
+	serviceMonitor := monv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      utils.RHOKPServiceMonitorName,
+			Namespace: r.GetNamespace(),
+			Labels:    metaLabels,
+		},
+		Spec: monv1.ServiceMonitorSpec{
+			Endpoints: []monv1.Endpoint{
+				{
+					Port:     "https",
+					Path:     utils.RHOKPMetricsPath,
+					Interval: "30s",
+					Scheme:   &schemeHTTPS,
+					HTTPConfigWithProxyAndTLSFiles: monv1.HTTPConfigWithProxyAndTLSFiles{
+						HTTPConfigWithTLSFiles: monv1.HTTPConfigWithTLSFiles{
+							TLSConfig: &monv1.TLSConfig{
+								TLSFilesConfig: monv1.TLSFilesConfig{
+									CAFile: "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt",
+								},
+								SafeTLSConfig: monv1.SafeTLSConfig{
+									InsecureSkipVerify: &valFalse,
+									ServerName:         &serverName,
+								},
+							},
+						},
+					},
+				},
+			},
+			JobLabel: "app.kubernetes.io/name",
+			Selector: metav1.LabelSelector{
+				MatchLabels: selectorLabels(),
+			},
+		},
+	}
+
+	if err := controllerutil.SetControllerReference(cr, &serviceMonitor, r.GetScheme()); err != nil {
+		return nil, fmt.Errorf("%s: %w", utils.ErrSetRHOKPServiceMonitorOwnerReference, err)
+	}
+	return &serviceMonitor, nil
 }

--- a/internal/controller/rhokp/reconciler.go
+++ b/internal/controller/rhokp/reconciler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 
+	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -29,6 +30,7 @@ func ReconcileDeployment(r reconciler.Reconciler, ctx context.Context, olsconfig
 		{Name: "reconcile RHOKP Service", Task: reconcileService},
 		{Name: "reconcile RHOKP TLS Certs", Task: reconcileTLSSecret},
 		{Name: "reconcile RHOKP Deployment", Task: reconcileDeployment},
+		{Name: "reconcile RHOKP ServiceMonitor", Task: reconcileServiceMonitor},
 	}, false)
 }
 
@@ -39,6 +41,7 @@ func Remove(r reconciler.Reconciler, ctx context.Context) error {
 		{Name: "delete RHOKP service", Task: deleteService},
 		{Name: "delete RHOKP network policy", Task: deleteNetworkPolicy},
 		{Name: "delete RHOKP TLS secret", Task: deleteTLSSecret},
+		{Name: "delete RHOKP ServiceMonitor", Task: deleteServiceMonitor},
 	})
 }
 
@@ -126,6 +129,18 @@ func deleteNetworkPolicy(r reconciler.Reconciler, ctx context.Context) error {
 
 func deleteTLSSecret(r reconciler.Reconciler, ctx context.Context) error {
 	return deleteNamespacedObject(r, ctx, &corev1.Secret{}, utils.RHOKPCertsSecretName)
+}
+
+func reconcileServiceMonitor(r reconciler.Reconciler, ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
+	sm, err := generateServiceMonitor(r, cr)
+	if err != nil {
+		return fmt.Errorf("%s: %w", utils.ErrGenerateRHOKPServiceMonitor, err)
+	}
+	return utils.ReconcileServiceMonitor(r, ctx, sm)
+}
+
+func deleteServiceMonitor(r reconciler.Reconciler, ctx context.Context) error {
+	return deleteNamespacedObject(r, ctx, &monv1.ServiceMonitor{}, utils.RHOKPServiceMonitorName)
 }
 
 func deleteNamespacedObject(r reconciler.Reconciler, ctx context.Context, obj client.Object, name string) error {

--- a/internal/controller/rhokp/reconciler_test.go
+++ b/internal/controller/rhokp/reconciler_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/gomega"
 	olsv1alpha1 "github.com/openshift/lightspeed-operator/api/v1alpha1"
 	"github.com/openshift/lightspeed-operator/internal/controller/utils"
+	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -104,6 +105,26 @@ var _ = Describe("RHOKP reconciler", Ordered, func() {
 			expectOwnedByOLSConfig(dep)
 			Expect(dep.Spec.Template.Spec.Containers[0].Image).To(Equal(utils.RHOOKPImageDefault))
 			Expect(dep.Annotations).To(HaveKey(utils.RHOKPTLSSecretResourceVersionAnnotation))
+		})
+
+		It("should create the RHOKP ServiceMonitor", func() {
+			sm := &monv1.ServiceMonitor{}
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      utils.RHOKPServiceMonitorName,
+				Namespace: utils.OLSNamespaceDefault,
+			}, sm)
+			Expect(err).NotTo(HaveOccurred())
+			expectOwnedByOLSConfig(sm)
+			Expect(sm.Spec.Endpoints).To(HaveLen(1))
+			ep := sm.Spec.Endpoints[0]
+			Expect(ep.Port).To(Equal("https"))
+			Expect(ep.Path).To(Equal(utils.RHOKPMetricsPath))
+			Expect(string(*ep.Scheme)).To(Equal("https"))
+			Expect(ep.TLSConfig).NotTo(BeNil())
+			Expect(*ep.TLSConfig.InsecureSkipVerify).To(BeFalse())
+			Expect(ep.TLSConfig.CAFile).To(Equal("/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt"))
+			expectedServerName := utils.RHOKPServiceName + "." + utils.OLSNamespaceDefault + ".svc"
+			Expect(*ep.TLSConfig.ServerName).To(Equal(expectedServerName))
 		})
 
 		It("should mount TLS as localhost.crt/localhost.key for Apache httpd", func() {
@@ -235,6 +256,13 @@ var _ = Describe("RHOKP reconciler", Ordered, func() {
 				Namespace: utils.OLSNamespaceDefault,
 			}, tlsSecret)
 			Expect(apierrors.IsNotFound(err)).To(BeTrue(), "TLS secret should be deleted")
+
+			sm := &monv1.ServiceMonitor{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      utils.RHOKPServiceMonitorName,
+				Namespace: utils.OLSNamespaceDefault,
+			}, sm)
+			Expect(apierrors.IsNotFound(err)).To(BeTrue(), "ServiceMonitor should be deleted")
 		})
 	})
 })

--- a/internal/controller/rhokp/suite_test.go
+++ b/internal/controller/rhokp/suite_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	configv1 "github.com/openshift/api/config/v1"
+	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -78,6 +79,8 @@ var _ = BeforeSuite(func() {
 	err = olsv1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 	err = configv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = monv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})

--- a/internal/controller/utils/constants.go
+++ b/internal/controller/utils/constants.go
@@ -661,6 +661,10 @@ ssl_ca_file = '/etc/certs/cm-olspostgresca/service-ca.crt'
 	RHOKPProbeFailureThreshold = 6
 	// RHOKPReadinessProbeFailureThreshold is the readiness probe failure threshold for the standalone RHOKP.
 	RHOKPReadinessProbeFailureThreshold = 3
+	// RHOKPServiceMonitorName is the ServiceMonitor for scraping RHOKP Solr metrics.
+	RHOKPServiceMonitorName = "lightspeed-rhokp-monitor"
+	// RHOKPMetricsPath is the Prometheus metrics endpoint path on the RHOKP Solr server.
+	RHOKPMetricsPath = "/solr/admin/metrics"
 
 	/*** Environment Variable Suffixes ***/
 	// EnvVarSuffixAPIKey is the environment variable suffix for API key credentials

--- a/internal/controller/utils/errors.go
+++ b/internal/controller/utils/errors.go
@@ -232,19 +232,21 @@ const (
 	ErrGetOpenShiftMCPServerTLSSecret                    = "failed to get openshift-mcp-server TLS secret" // #nosec G101
 
 	/*** RHOKP Standalone Errors ***/
-	ErrGenerateRHOKPService                = "failed to generate RHOKP service"
-	ErrGenerateRHOKPNetworkPolicy          = "failed to generate RHOKP network policy"
-	ErrGenerateRHOKPDeployment             = "failed to generate RHOKP deployment"
-	ErrSetRHOKPServiceOwnerReference       = "failed to set RHOKP service owner reference"
-	ErrSetRHOKPNetworkPolicyOwnerReference = "failed to set RHOKP network policy owner reference"
-	ErrSetRHOKPDeploymentOwnerReference    = "failed to set RHOKP deployment owner reference"
-	ErrCreateRHOKPNetworkPolicy            = "failed to create RHOKP network policy"
-	ErrGetRHOKPNetworkPolicy               = "failed to get RHOKP network policy"
-	ErrUpdateRHOKPNetworkPolicy            = "failed to update RHOKP network policy"
-	ErrCreateRHOKPDeployment               = "failed to create RHOKP deployment"
-	ErrGetRHOKPDeployment                  = "failed to get RHOKP deployment"
-	ErrUpdateRHOKPDeployment               = "failed to update RHOKP deployment"
-	ErrGetRHOKPTLSSecret                   = "failed to get RHOKP TLS secret" // #nosec G101
+	ErrGenerateRHOKPService                 = "failed to generate RHOKP service"
+	ErrGenerateRHOKPNetworkPolicy           = "failed to generate RHOKP network policy"
+	ErrGenerateRHOKPDeployment              = "failed to generate RHOKP deployment"
+	ErrSetRHOKPServiceOwnerReference        = "failed to set RHOKP service owner reference"
+	ErrSetRHOKPNetworkPolicyOwnerReference  = "failed to set RHOKP network policy owner reference"
+	ErrSetRHOKPDeploymentOwnerReference     = "failed to set RHOKP deployment owner reference"
+	ErrCreateRHOKPNetworkPolicy             = "failed to create RHOKP network policy"
+	ErrGetRHOKPNetworkPolicy                = "failed to get RHOKP network policy"
+	ErrUpdateRHOKPNetworkPolicy             = "failed to update RHOKP network policy"
+	ErrCreateRHOKPDeployment                = "failed to create RHOKP deployment"
+	ErrGetRHOKPDeployment                   = "failed to get RHOKP deployment"
+	ErrUpdateRHOKPDeployment                = "failed to update RHOKP deployment"
+	ErrGetRHOKPTLSSecret                    = "failed to get RHOKP TLS secret" // #nosec G101
+	ErrGenerateRHOKPServiceMonitor          = "failed to generate RHOKP ServiceMonitor"
+	ErrSetRHOKPServiceMonitorOwnerReference = "failed to set RHOKP ServiceMonitor owner reference"
 
 	// Cleanup error constants for conditional operand removal.
 	ErrRemoveOpenShiftMCPServerResources = "failed to remove openshift-mcp-server resources"


### PR DESCRIPTION
## Description

**Summary**
Add a Prometheus ServiceMonitor for the RHOKP Solr server to enable metrics scraping.

**Changes**
- Add `GenerateServiceMonitor()` in `rhokp/assets.go` — creates a ServiceMonitor targeting port `https` on `:8443/solr/admin/metrics` with service-ca TLS verification
- Wire `reconcileServiceMonitor` / `deleteServiceMonitor` into `rhokp/reconciler.go` (Phase 2 and Remove flows)
- Add constants: `RHOKPServiceMonitorName`, `RHOKPMetricsPath`
- Add error constants for generation and owner reference failures
- Register `monv1` scheme in `rhokp/suite_test.go`
- Unit tests for ServiceMonitor generation, reconciliation, and cleanup


## Type of change

- [ ] Refactor
- [ x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
https://redhat.atlassian.net/browse/OLS-3727
- Closes #
https://redhat.atlassian.net/browse/OLS-3727

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus monitoring for RHOKP Solr metrics.
  * Metrics are collected securely over HTTPS every 30 seconds using service-ca certificates.
  * Monitoring resources are automatically created, maintained, and removed with the RHOKP deployment.

* **Bug Fixes**
  * Improved monitoring resource ownership and cleanup to prevent stale configuration.

* **Tests**
  * Added coverage for monitoring resource creation, HTTPS settings, metrics endpoints, ownership, and deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->