### PR TITLE
Removing agentic images fallback and passing empty string.

### DIFF
--- a/internal/controller/olsconfig_controller.go
+++ b/internal/controller/olsconfig_controller.go
@@ -83,9 +83,7 @@ import (
 	"github.com/openshift/lightspeed-operator/internal/controller/appserver"
 	"github.com/openshift/lightspeed-operator/internal/controller/console"
 	"github.com/openshift/lightspeed-operator/internal/controller/ocpmcp"
-
-	// OLS-3737: OTEL Collector reconciliation disabled until e2e coverage exists.
-	// "github.com/openshift/lightspeed-operator/internal/controller/otelcollector"
+	"github.com/openshift/lightspeed-operator/internal/controller/otelcollector"
 	"github.com/openshift/lightspeed-operator/internal/controller/postgres"
 	"github.com/openshift/lightspeed-operator/internal/controller/rhokp"
 	"github.com/openshift/lightspeed-operator/internal/controller/utils"
@@ -315,10 +313,6 @@ func (r *OLSConfigReconciler) reconcileIndependentResources(ctx context.Context,
 		{Name: "postgres resources", Fn: func(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
 			return postgres.ReconcilePostgresResources(r, ctx, cr)
 		}},
-		// OLS-3737: OTEL Collector reconciliation disabled until e2e coverage exists.
-		// {Name: "OTEL Collector resources", Fn: func(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
-		// 	return otelcollector.ReconcileOtelCollectorResources(r, ctx, cr)
-		// }},
 	}
 
 	// Optional operands — gated by CR fields or image flags.
@@ -375,6 +369,15 @@ func (r *OLSConfigReconciler) reconcileIndependentResources(ctx context.Context,
 		if err := alertsadapter.RemoveAlertsAdapter(r, ctx); err != nil {
 			resourceFailures["alerts adapter cleanup"] = fmt.Errorf("%s: %w", utils.ErrRemoveAlertsAdapterResources, err)
 		}
+	}
+
+	if r.Options.OtelCollectorImage != "" {
+		resourceSteps = append(resourceSteps, utils.ReconcileSteps{
+			Name: "OTEL Collector resources",
+			Fn: func(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
+				return otelcollector.ReconcileOtelCollectorResources(r, ctx, cr)
+			},
+		})
 	}
 
 	resourceSteps = append(resourceSteps, utils.ReconcileSteps{
@@ -448,10 +451,6 @@ func (r *OLSConfigReconciler) reconcileDeploymentsAndStatus(ctx context.Context,
 		{Name: "postgres deployment", Fn: func(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
 			return postgres.ReconcilePostgresDeployment(r, ctx, cr)
 		}, ConditionType: utils.TypeCacheReady, Deployment: utils.PostgresDeploymentName},
-		// OLS-3737: OTEL Collector reconciliation disabled until e2e coverage exists.
-		// {Name: "OTEL Collector deployment", Fn: func(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
-		// 	return otelcollector.ReconcileOtelCollectorDeployment(r, ctx, cr)
-		// }, ConditionType: utils.TypeOtelCollectorReady, Deployment: utils.OtelCollectorDeploymentName},
 	}
 
 	// Optional operands — gated by CR fields or image flags.
@@ -516,6 +515,26 @@ func (r *OLSConfigReconciler) reconcileDeploymentsAndStatus(ctx context.Context,
 			ObservedGeneration: olsconfig.Generation,
 			Reason:             "Disabled",
 			Message:            "RHOKP is disabled; spec.ols.byokRAGOnly is true",
+			LastTransitionTime: metav1.Now(),
+		})
+	}
+
+	if r.Options.OtelCollectorImage != "" {
+		deploymentSteps = append(deploymentSteps, utils.ReconcileSteps{
+			Name: "OTEL Collector deployment",
+			Fn: func(ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
+				return otelcollector.ReconcileOtelCollectorDeployment(r, ctx, cr)
+			},
+			ConditionType: utils.TypeOtelCollectorReady,
+			Deployment:    utils.OtelCollectorDeploymentName,
+		})
+	} else {
+		newStatus.Conditions = append(newStatus.Conditions, metav1.Condition{
+			Type:               utils.TypeOtelCollectorReady,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: olsconfig.Generation,
+			Reason:             "Disabled",
+			Message:            "OTEL Collector is disabled; image not provided",
 			LastTransitionTime: metav1.Now(),
 		})
 	}

--- a/internal/controller/otelcollector/deployment_test.go
+++ b/internal/controller/otelcollector/deployment_test.go
@@ -31,7 +31,7 @@ var _ = Describe("OTEL Collector deployment", func() {
 
 		container := spec.Containers[0]
 		Expect(container.Name).To(Equal(utils.OtelCollectorContainerName))
-		Expect(container.Image).To(Equal(utils.OtelCollectorImageDefault))
+		Expect(container.Image).To(Equal(testOtelCollectorImage))
 		Expect(container.Args).To(ConsistOf("--config=/etc/otelcol/config.yaml"))
 
 		postgresEnv, ok := containerEnvNamed(container, utils.OtelCollectorPostgresConnectionStringEnvVar)

--- a/internal/controller/otelcollector/reconciler_test.go
+++ b/internal/controller/otelcollector/reconciler_test.go
@@ -232,7 +232,7 @@ var _ = Describe("OTEL Collector reconciler", Ordered, func() {
 			}, dep)
 			Expect(err).NotTo(HaveOccurred())
 			expectOwnedByOLSConfig(dep)
-			Expect(dep.Spec.Template.Spec.Containers[0].Image).To(Equal(utils.OtelCollectorImageDefault))
+			Expect(dep.Spec.Template.Spec.Containers[0].Image).To(Equal(testOtelCollectorImage))
 			Expect(dep.Annotations).To(HaveKey(utils.OtelCollectorConfigMapResourceVersionAnnotation))
 		})
 

--- a/internal/controller/otelcollector/suite_test.go
+++ b/internal/controller/otelcollector/suite_test.go
@@ -42,6 +42,8 @@ import (
 	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
 
+const testOtelCollectorImage = "quay.io/test/lightspeed-otel-collector:test"
+
 var (
 	ctx                    context.Context
 	cfg                    *rest.Config
@@ -92,12 +94,14 @@ var _ = BeforeSuite(func() {
 	err = k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: utils.OLSNamespaceDefault}})
 	Expect(err).NotTo(HaveOccurred())
 
-	testReconcilerInstance = utils.NewTestReconciler(
+	tr := utils.NewTestReconciler(
 		k8sClient,
 		logf.Log.WithName("controller").WithName("OLSConfig"),
 		scheme.Scheme,
 		utils.OLSNamespaceDefault,
 	)
+	tr.OtelCollectorImage = testOtelCollectorImage
+	testReconcilerInstance = tr
 
 	cr = &olsv1alpha1.OLSConfig{}
 	crNamespacedName = types.NamespacedName{Name: utils.OLSConfigName}

--- a/internal/controller/utils/constants.go
+++ b/internal/controller/utils/constants.go
@@ -695,10 +695,10 @@ var (
 
 const (
 	// Fallbacks when related_images.json is unavailable (e.g. local run outside repo root).
-	agenticConsoleUIImageFallback = "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-console:main"
-	alertsAdapterImageFallback    = "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-alerts-adapter:main"
-	agenticSandboxImageFallback   = "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-agentic-sandbox:main"
-	otelCollectorImageFallback    = "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/lightspeed-otel-collector:main"
+	agenticConsoleUIImageFallback = ""
+	alertsAdapterImageFallback    = ""
+	agenticSandboxImageFallback   = ""
+	otelCollectorImageFallback    = ""
 	rhokpImageFallback            = "registry.redhat.io/offline-knowledge-portal/rhokp-rhel9@sha256:f46082f2dc2972582f3b85ed2a563b554d0aba3255ba2f00835e65f4929ae9a9"
 )
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled deployment and readiness tracking for the OpenTelemetry Collector when an image is configured.
  * The OpenTelemetry Collector is now reported as disabled when no image is provided.

* **Bug Fixes**
  * Improved default image resolution for the agentic console, alerts adapter, agentic sandbox, and OpenTelemetry Collector.
  * Prevented unintended fallback to hardcoded registry images when no explicit image is configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->