### PR TITLE
OLS-3859: Enable read-only Tekton tools

### DIFF
--- a/internal/controller/ocpmcp/assets.go
+++ b/internal/controller/ocpmcp/assets.go
@@ -21,15 +21,15 @@ import (
 // configTOML is the openshift-mcp-server runtime config.
 // Denied resources keep Secret (and RBAC) data out of the LLM path; toolsets are pinned
 // so upstream default changes do not affect OLS. Metrics uses in-cluster Thanos/Alertmanager.
-// read_only = false is required: openshift-mcp-server-rhel9 sets ReadOnly=true in build-time defaults;
-// omitting this leaves only readOnlyHint tools (no resources_create_or_update, etc.).
 const configTOML = `# Denied resources prevent the MCP server from accessing these Kubernetes resource types.
 # This ensures secret data never reaches the LLM through the shipped MCP server.
 # User-brought MCP servers (spec.mcpServers) are the user's responsibility to secure.
 # Toolsets are pinned explicitly so upstream default changes do not affect OLS.
 
-read_only = false
-toolsets = ["core", "config", "helm", "metrics"]
+read_only = true
+disable_destructive = true
+experimental_enable_target_compatibility_tool_filters = true
+toolsets = ["core", "config", "helm", "metrics", "tekton"]
 
 [[denied_resources]]
 group = ""

--- a/internal/controller/ocpmcp/assets_test.go
+++ b/internal/controller/ocpmcp/assets_test.go
@@ -32,8 +32,11 @@ var _ = Describe("OpenShift MCP Server assets", func() {
 		Expect(cm.Labels).To(Equal(labels))
 
 		toml := cm.Data[utils.OpenShiftMCPServerConfigFilename]
-		Expect(toml).To(ContainSubstring("read_only = false"))
-		Expect(toml).To(ContainSubstring(`toolsets = ["core", "config", "helm", "metrics"]`))
+		Expect(toml).To(ContainSubstring("read_only = true"))
+		Expect(toml).NotTo(ContainSubstring("read_only = false"))
+		Expect(toml).To(ContainSubstring("disable_destructive = true"))
+		Expect(toml).To(ContainSubstring("experimental_enable_target_compatibility_tool_filters = true"))
+		Expect(toml).To(ContainSubstring(`toolsets = ["core", "config", "helm", "metrics", "tekton"]`))
 		Expect(toml).To(ContainSubstring(`kind = "Secret"`))
 		Expect(toml).To(ContainSubstring(`group = ""`))
 		Expect(toml).To(ContainSubstring(`group = "rbac.authorization.k8s.io"`))


### PR DESCRIPTION
## Description

Enable the Tekton toolset in the operator-managed OpenShift MCP server while enforcing a read-only, non-destructive configuration. Target compatibility filtering hides Tekton tools when the cluster does not serve `tekton.dev/v1` PipelineRuns.

The downstream MCP image can sync additional Tekton tools, including PipelineRun diagnosis, independently after their upstream changes merge.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue # [OLS-3859](https://redhat.atlassian.net/browse/OLS-3859)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

- `make test`
- Verified the generated MCP TOML pins the Tekton toolset and sets `read_only`, `disable_destructive`, and target compatibility filtering to `true`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Tekton tools.
  * Enabled target-compatible tool filtering.

* **Security**
  * Configured the MCP server for read-only operation.
  * Disabled destructive operations to help prevent unintended changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->