### PR TITLE
OLS-3491: spec changes for configurable step instructions

### DIFF
--- a/.ai/spec/what/agentic-sandbox-profile.md
+++ b/.ai/spec/what/agentic-sandbox-profile.md
@@ -32,6 +32,12 @@ See also: `templog.md` (collector), `ocpmcp.md` (MCP Service/CA), `crd-api.md` (
    - `mcp-endpoint` — OpenShift MCP HTTPS Service URL
    - `mcp-ca-secret` — name of the MCP client CA Secret (`lightspeed-agentic-mcp-ca`)
 11. When introspection is disabled, MCP keys are omitted. Appserver deletes the MCP client CA Secret when present.
+11a. [PLANNED: OLS-3491] When `spec.agenticOLS.instructions` is set, also publish optional per-step instruction keys (omit a key when that step string is empty/unset):
+   - `instructions-analysis` — cluster default analysis system instructions
+   - `instructions-execution` — cluster default execution system instructions
+   - `instructions-verification` — cluster default verification system instructions
+   - `instructions-escalation` — cluster default escalation system instructions
+   Agentic-operator consumes these for create-time materialization (analysis/execution/verification) and for call-time escalation resolution. See agentic-operator `what/sandbox-execution.md` and `what/crd-api.md`.
 
 ### Thin sandbox PodSpec
 12. PodSpec contains one container (`lightspeed-agentic-sandbox`) with image from `GetAgenticSandboxImage()`, optional resource/toleration/nodeSelector overrides, and writable emptyDirs:
@@ -79,6 +85,7 @@ See also: `templog.md` (collector), `ocpmcp.md` (MCP Service/CA), `crd-api.md` (
 |---|---|
 | `spec.agenticOLS.sandboxMode` | `bare-pod` (default) or `sandbox-claim` |
 | `spec.agenticOLS.agenticSandboxConfig` | Resources / tolerations / nodeSelector for thin PodSpec |
+| `spec.agenticOLS.instructions.*` | [PLANNED: OLS-3491] Optional cluster per-step system instructions → ConfigMap `instructions-*` keys |
 | `spec.ols.introspectionEnabled` | Gates MCP keys and MCP client CA Secret |
 | `--agentic-sandbox-image` | Sandbox container image in thin PodSpec |
 

--- a/.ai/spec/what/crd-api.md
+++ b/.ai/spec/what/crd-api.md
@@ -60,6 +60,16 @@ Field path (relative to `spec.agenticOLS`) | JSON key | Go type | Required | Def
 ---|---|---|---|---|---|---
 `sandboxMode` | `sandboxMode` | `SandboxMode` | No | `bare-pod` | Enum: `bare-pod`, `sandbox-claim` | How the agentic operator provisions sandbox pods
 `agenticSandboxConfig` | `agenticSandboxConfig` | `Config` | No | — | — | Resources, tolerations, nodeSelector for the thin sandbox PodSpec. Replicas ignored.
+`instructions` | `instructions` | `*AgenticStepInstructions` | No | — | — | [PLANNED: OLS-3491] Optional cluster-wide per-step system instructions (analysis / execution / verification / escalation). When set for a step, replaces the product built-in for that step for **new** AgenticRuns (and for escalation, when the escalation step runs). See agentic-operator `sandbox-execution.md`.
+
+#### AgenticStepInstructions Fields [PLANNED: OLS-3491]
+
+Field path (relative to `spec.agenticOLS.instructions`) | JSON key | Go type | Required | Default | Validation | Description
+---|---|---|---|---|---|---
+`analysis` | `analysis` | `string` | No | — | MaxLength=32768 | Cluster default system instructions for the analysis step
+`execution` | `execution` | `string` | No | — | MaxLength=32768 | Cluster default system instructions for the execution step
+`verification` | `verification` | `string` | No | — | MaxLength=32768 | Cluster default system instructions for the verification step
+`escalation` | `escalation` | `string` | No | — | MaxLength=32768 | Cluster default system instructions for the escalation step
 
 #### AgenticOLS Behavioral Rules
 
@@ -68,6 +78,10 @@ Field path (relative to `spec.agenticOLS`) | JSON key | Go type | Required | Def
 60. OpenAPI enum validation rejects values other than `bare-pod` and `sandbox-claim`.
 61. `agenticSandboxConfig` overrides default sandbox PodSpec scheduling/resources (requests-only defaults: 500m CPU / 128Mi memory). Replicas are ignored.
 62. Classic operator publishes handoff via appserver-owned client CA Secrets plus `agenticintegration` ConfigMap (`lightspeed-agentic-configuration`). See `agentic-sandbox-profile.md`.
+63. [PLANNED: OLS-3491] `spec.agenticOLS.instructions` is optional. Each step key is independently optional. Omitted keys mean “use product built-in for that step” (unless an AgenticRun step override applies — agentic-operator).
+64. [PLANNED: OLS-3491] When a step instruction string is set, it is a **full replacement** of the built-in system instructions for that step (not an append). Task/request input remains separate (`AgenticRun.spec.request` and step query payloads).
+65. [PLANNED: OLS-3491] Classic operator MUST publish non-empty `instructions.*` values into the handoff ConfigMap so agentic-operator can consume them without importing `ols.openshift.io` types. See `agentic-sandbox-profile.md`.
+66. [PLANNED: OLS-3491] `instructions` on `AgenticOLSSpec` MUST NOT be used for chat/classic OLS query prompts (`spec.ols.querySystemPrompt` remains the classic override).
 
 ### LLM Provider Configuration (spec.llm)
 


### PR DESCRIPTION
## Summary

Spec-only change for [OLS-3491](https://redhat.atlassian.net/browse/OLS-3491) (configurable agentic step instructions), pre-push reviewed.

Design decisions locked in refinement:

- Split **system instructions** vs step **query** input (`request` / option JSON / etc.)
- Per-step overrides on `AgenticRunStep.instructions` (analysis / execution / verification)
- Cluster defaults on `OLSConfig.spec.agenticOLS.instructions.*` via handoff ConfigMap
- Priority: run > cluster > built-in; full replace; create-time materialize into run spec
- Escalation: cluster/built-in at call time only; follow-up RFE for full `spec.escalation` step
- Revision feedback out of scope
- `Agent` CR stays compute-tier only

## Test plan

- [ ] Spec review for internal consistency across the four related PRs
- [ ] Confirm no implementation code in this PR

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added planned configuration for optional per-step instructions covering analysis, execution, verification, and escalation in agentic runs.
  * Each instruction can override its corresponding built-in guidance and supports up to 32,768 characters.
  * Instructions are published through the handoff configuration and apply only to agentic runs, without changing the classic query system prompt.

* **Documentation**
  * Documented the new configuration surface and supported instruction fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->