### PR TITLE
OLS-3491: apply CodeRabbit follow-ups for agentic instructions spec

### DIFF
--- a/.ai/spec/what/agentic-sandbox-profile.md
+++ b/.ai/spec/what/agentic-sandbox-profile.md
@@ -32,12 +32,12 @@ See also: `templog.md` (collector), `ocpmcp.md` (MCP Service/CA), `crd-api.md` (
    - `mcp-endpoint` — OpenShift MCP HTTPS Service URL
    - `mcp-ca-secret` — name of the MCP client CA Secret (`lightspeed-agentic-mcp-ca`)
 11. When introspection is disabled, MCP keys are omitted. Appserver deletes the MCP client CA Secret when present.
-11a. [PLANNED: OLS-3491] When `spec.agenticOLS.instructions` is set, also publish optional per-step instruction keys (omit a key when that step string is empty/unset):
+11a. [PLANNED: OLS-3491] Optional per-step instruction keys derived from `spec.agenticOLS.instructions`:
    - `instructions-analysis` — cluster default analysis system instructions
    - `instructions-execution` — cluster default execution system instructions
    - `instructions-verification` — cluster default verification system instructions
    - `instructions-escalation` — cluster default escalation system instructions
-   Agentic-operator consumes these for create-time materialization (analysis/execution/verification) and for call-time escalation resolution. See agentic-operator `what/sandbox-execution.md` and `what/crd-api.md`.
+   On each reconcile, the classic operator MUST replace the complete `instructions-*` key subset: publish a key only when its source string is non-empty; **delete** any existing `instructions-*` key whose source is empty or unset. Stale keys MUST NOT remain after a non-empty→empty/unset transition. Agentic-operator consumes these for create-time materialization (analysis/execution/verification) and for call-time escalation resolution. See agentic-operator `what/sandbox-execution.md` and `what/crd-api.md`.
 
 ### Thin sandbox PodSpec
 12. PodSpec contains one container (`lightspeed-agentic-sandbox`) with image from `GetAgenticSandboxImage()`, optional resource/toleration/nodeSelector overrides, and writable emptyDirs:

--- a/.ai/spec/what/crd-api.md
+++ b/.ai/spec/what/crd-api.md
@@ -78,10 +78,11 @@ Field path (relative to `spec.agenticOLS.instructions`) | JSON key | Go type | R
 60. OpenAPI enum validation rejects values other than `bare-pod` and `sandbox-claim`.
 61. `agenticSandboxConfig` overrides default sandbox PodSpec scheduling/resources (requests-only defaults: 500m CPU / 128Mi memory). Replicas are ignored.
 62. Classic operator publishes handoff via appserver-owned client CA Secrets plus `agenticintegration` ConfigMap (`lightspeed-agentic-configuration`). See `agentic-sandbox-profile.md`.
-63. [PLANNED: OLS-3491] `spec.agenticOLS.instructions` is optional. Each step key is independently optional. Omitted keys mean “use product built-in for that step” (unless an AgenticRun step override applies — agentic-operator).
-64. [PLANNED: OLS-3491] When a step instruction string is set, it is a **full replacement** of the built-in system instructions for that step (not an append). Task/request input remains separate (`AgenticRun.spec.request` and step query payloads).
-65. [PLANNED: OLS-3491] Classic operator MUST publish non-empty `instructions.*` values into the handoff ConfigMap so agentic-operator can consume them without importing `ols.openshift.io` types. See `agentic-sandbox-profile.md`.
+63. [PLANNED: OLS-3491] `spec.agenticOLS.instructions` is optional. Each step key is independently optional. Omitted or empty keys mean “no cluster default for that step” (agentic-operator falls through to product built-in unless an AgenticRun step override applies).
+64. [PLANNED: OLS-3491] When a step instruction string is set (non-empty), it is a **full replacement** of the built-in system instructions for that step (not an append). Task/request input remains separate (`AgenticRun.spec.request` and step query payloads).
+65. [PLANNED: OLS-3491] Classic operator MUST publish non-empty `instructions.*` values into the handoff ConfigMap (`lightspeed-agentic-configuration`) and delete cleared keys (see `agentic-sandbox-profile.md` rule 11a) so agentic-operator can consume them without importing `ols.openshift.io` types.
 66. [PLANNED: OLS-3491] `instructions` on `AgenticOLSSpec` MUST NOT be used for chat/classic OLS query prompts (`spec.ols.querySystemPrompt` remains the classic override).
+67. [PLANNED: OLS-3491] **Precedence (cross-component):** effective step system instructions resolve as `AgenticRun.spec.<step>.instructions` (creator-supplied or materialized) > `OLSConfig.spec.agenticOLS.instructions.<step>` (via handoff ConfigMap) > product built-in. For analysis / execution / verification, the selected value is **materialized into the AgenticRun spec at create time**; later cluster ConfigMap changes MUST NOT alter an existing run. Escalation has no run field and resolves at **call time** (cluster ConfigMap or built-in). Authoritative materialization rules: agentic-operator `what/crd-api.md` rules 10a–10c.
 
 ### LLM Provider Configuration (spec.llm)
 


### PR DESCRIPTION
## Summary
- Follow-up to #1948, which merged before the CodeRabbit fixes were pushed
- Spec clarifications: delete cleared `instructions-*` handoff keys; explicit precedence + create-time vs call-time materialization

## Test plan
- [ ] Spec review only (no code)

Closes the gaps called out on #1948 review threads.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how optional instruction settings are applied during reconciliation.
  * Defined empty or unset values as absent and documented removal of previously published settings.
  * Documented precedence and materialization rules across run-level configuration, cluster configuration, and built-in instructions.
  * Clarified that instruction settings are replaced as a complete subset to prevent stale values from persisting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->