### PR TITLE
Bundle Update from Snapshot crt-nshift-lightspeed-tenant/ols-20260813-022329-000

### DIFF
--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     console.openshift.io/operator-monitoring-default: "true"
-    createdAt: "2026-08-12T15:24:56Z"
+    createdAt: "2026-08-20T16:46:46Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -799,19 +799,6 @@ spec:
                 - watch
             - apiGroups:
                 - ""
-              resources:
-                - secrets
-              verbs:
-                - create
-                - delete
-                - deletecollection
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - ""
               resourceNames:
                 - pull-secret
               resources:
@@ -909,18 +896,6 @@ spec:
                 - update
                 - watch
             - apiGroups:
-                - networking.k8s.io
-              resources:
-                - networkpolicies
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
                 - ols.openshift.io
               resources:
                 - olsconfigs
@@ -957,16 +932,48 @@ spec:
                 - watch
             - apiGroups:
                 - rbac.authorization.k8s.io
+              resourceNames:
+                - lightspeed-agentic-alerts-adapter-agenticruns
+                - lightspeed-app-server-sar-role-binding
+              resources:
+                - clusterrolebindings
+              verbs:
+                - delete
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
               resources:
                 - clusterrolebindings
                 - clusterroles
                 - rolebindings
               verbs:
                 - create
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resourceNames:
+                - lightspeed-agentic-alerts-adapter-agenticruns
+                - lightspeed-app-server-sar-role
+              resources:
+                - clusterroles
+              verbs:
                 - delete
                 - get
                 - list
-                - patch
+                - update
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resourceNames:
+                - lightspeed-agentic-alerts-adapter-alertmanager
+              resources:
+                - rolebindings
+              verbs:
+                - delete
+                - get
+                - list
                 - update
                 - watch
             - apiGroups:
@@ -1010,9 +1017,9 @@ spec:
                       - --cert-dir=/etc/tls/private
                       - --dataverse-exporter-image=registry.redhat.io/lightspeed-core/dataverse-exporter-rhel9@sha256:1c7ffaead23adfb1dc6bd3adfe75c80f284d6d31f13ca427d754703c78514cb2
                       - --postgres-image=registry.redhat.io/rhel9/postgresql-16@sha256:42f385ac3c9b8913426da7c57e70bc6617cd237aaf697c667f6385a8c0b0118b
-                      - --service-image=registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9@sha256:958693ae1cdd0c1549d8ad9d618643da6cfb73196742723c3d78f7f023a70502
-                      - --console-image=registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:b935868e60f03e5d16849caaf1789feaf2da2ab1358d32d702cfe0708124e53d
-                      - --openshift-mcp-server-image=registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9@sha256:588577fec9f42aff4e3e4b3c7fdf1d1c6e2ead441978e25c0b7775b106d5baaf
+                      - --service-image=registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9@sha256:7cefa901793ca8d0ecc39e29e30abda16d0d8f9823caff5f1bf1c80efda1633d
+                      - --console-image=registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:321743fbda2f9346feef8049b38b49358873b1f62749dd66c7e553c82c50710f
+                      - --openshift-mcp-server-image=registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9@sha256:8a8321cc2e00c3f13bf8e433da0fb3c990def939d5c7dec5f3978e9e323fc98b
                       - --rhokp-image=registry.redhat.io/offline-knowledge-portal/rhokp-rhel9@sha256:f46082f2dc2972582f3b85ed2a563b554d0aba3255ba2f00835e65f4929ae9a9
                     command:
                       - /manager
@@ -1021,7 +1028,7 @@ spec:
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.annotations['olm.targetNamespaces']
-                    image: registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:71abcf4b043e20096a670badf767f4d99e30a34fc21326750621392d3f10004e
+                    image: registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:ad4559ce40870ba2a68398b539d8ba89ecccde68099f1a63fd969d98fd741470
                     imagePullPolicy: Always
                     livenessProbe:
                       httpGet:
@@ -1099,6 +1106,31 @@ spec:
                 - create
                 - patch
             - apiGroups:
+                - ""
+              resources:
+                - secrets
+              verbs:
+                - create
+                - delete
+                - deletecollection
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
                 - rbac.authorization.k8s.io
               resources:
                 - rolebindings
@@ -1142,12 +1174,12 @@ spec:
     - name: lightspeed-postgresql
       image: registry.redhat.io/rhel9/postgresql-16@sha256:42f385ac3c9b8913426da7c57e70bc6617cd237aaf697c667f6385a8c0b0118b
     - name: lightspeed-service-api
-      image: registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9@sha256:958693ae1cdd0c1549d8ad9d618643da6cfb73196742723c3d78f7f023a70502
+      image: registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9@sha256:7cefa901793ca8d0ecc39e29e30abda16d0d8f9823caff5f1bf1c80efda1633d
     - name: lightspeed-console-plugin
-      image: registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:b935868e60f03e5d16849caaf1789feaf2da2ab1358d32d702cfe0708124e53d
+      image: registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:321743fbda2f9346feef8049b38b49358873b1f62749dd66c7e553c82c50710f
     - name: lightspeed-operator
-      image: registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:71abcf4b043e20096a670badf767f4d99e30a34fc21326750621392d3f10004e
+      image: registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:ad4559ce40870ba2a68398b539d8ba89ecccde68099f1a63fd969d98fd741470
     - name: openshift-mcp-server
-      image: registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9@sha256:588577fec9f42aff4e3e4b3c7fdf1d1c6e2ead441978e25c0b7775b106d5baaf
+      image: registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9@sha256:8a8321cc2e00c3f13bf8e433da0fb3c990def939d5c7dec5f3978e9e323fc98b
     - name: rhokp
       image: registry.redhat.io/offline-knowledge-portal/rhokp-rhel9@sha256:f46082f2dc2972582f3b85ed2a563b554d0aba3255ba2f00835e65f4929ae9a9

--- a/bundle/manifests/ols.openshift.io_olsconfigs.yaml
+++ b/bundle/manifests/ols.openshift.io_olsconfigs.yaml
@@ -320,8 +320,11 @@ spec:
                             custom:
                               description: |-
                                 custom is a user-defined TLS security profile. Be extremely careful using a custom
-                                profile as invalid configurations can be catastrophic. An example custom profile
-                                looks like this:
+                                profile as invalid configurations can be catastrophic.
+
+                                The supported groups list for this profile is empty by default.
+
+                                An example custom profile looks like this:
 
                                   minTLSVersion: VersionTLS11
                                   ciphers:
@@ -346,6 +349,46 @@ spec:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
+                                groups:
+                                  description: |-
+                                    groups is an optional, ordered field used to specify the supported groups (formerly known as
+                                    elliptic curves) that are used during the TLS handshake.  The order of the groups represents
+                                    a suggested preference, with the most preferred group first. Note that not all platform
+                                    components honor the ordering: Go-based components use Go's internal preference order and
+                                    treat this list as a filter of allowed groups rather than an ordered preference.
+                                    Operators may remove entries their operands do not support.
+
+                                    When omitted, this means no opinion and the platform is left to choose reasonable defaults which are
+                                    subject to change over time and may be different per platform component depending on the underlying TLS
+                                    libraries they use. If specified, the list must contain at least one and at most 7 groups,
+                                    and each group must be unique.
+
+                                    For example, to use X25519 and secp256r1 (yaml):
+
+                                      groups:
+                                        - X25519
+                                        - secp256r1
+                                  items:
+                                    description: |-
+                                      TLSGroup is a supported group identifier that can be used in TLSProfile.Groups.
+                                      There is a one-to-one mapping between these names and the group IDs defined
+                                      in Go's crypto/tls package based on IANA's "TLS Supported Groups" registry:
+                                      https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8
+                                      Note that X25519MLKEM768 is a post-quantum hybrid group that is not
+                                      FIPS-approved and should be ignored by components running in FIPS mode.
+                                    enum:
+                                    - X25519
+                                    - secp256r1
+                                    - secp384r1
+                                    - secp521r1
+                                    - X25519MLKEM768
+                                    - SecP256r1MLKEM768
+                                    - SecP384r1MLKEM1024
+                                    type: string
+                                  maxItems: 7
+                                  minItems: 1
+                                  type: array
+                                  x-kubernetes-list-type: set
                                 minTLSVersion:
                                   description: |-
                                     minTLSVersion is used to specify the minimal version of the TLS protocol
@@ -366,6 +409,10 @@ spec:
                                 legacy clients and want to remain highly secure while being compatible with
                                 most clients currently in use.
 
+                                The supported groups list includes by default the following groups
+                                in suggested preference order (ordering may not be honored by all implementations):
+                                X25519MLKEM768, X25519, secp256r1, secp384r1.
+
                                 This profile is equivalent to a Custom profile specified as:
                                   minTLSVersion: VersionTLS12
                                   ciphers:
@@ -384,7 +431,9 @@ spec:
                               description: |-
                                 modern is a TLS security profile for use with clients that support TLS 1.3 and
                                 do not need backward compatibility for older clients.
-
+                                The supported groups list includes by default the following groups
+                                in suggested preference order (ordering may not be honored by all implementations):
+                                X25519MLKEM768, X25519, secp256r1, secp384r1.
                                 This profile is equivalent to a Custom profile specified as:
                                   minTLSVersion: VersionTLS13
                                   ciphers:
@@ -397,6 +446,10 @@ spec:
                               description: |-
                                 old is a TLS profile for use when services need to be accessed by very old
                                 clients or libraries and should be used only as a last resort.
+
+                                The supported groups list includes by default the following groups
+                                in suggested preference order (ordering may not be honored by all implementations):
+                                X25519MLKEM768, X25519, secp256r1, secp384r1.
 
                                 This profile is equivalent to a Custom profile specified as:
                                   minTLSVersion: VersionTLS10
@@ -414,11 +467,14 @@ spec:
                                     - ECDHE-RSA-AES128-SHA256
                                     - ECDHE-ECDSA-AES128-SHA
                                     - ECDHE-RSA-AES128-SHA
+                                    - ECDHE-ECDSA-AES256-SHA384
+                                    - ECDHE-RSA-AES256-SHA384
                                     - ECDHE-ECDSA-AES256-SHA
                                     - ECDHE-RSA-AES256-SHA
                                     - AES128-GCM-SHA256
                                     - AES256-GCM-SHA384
                                     - AES128-SHA256
+                                    - AES256-SHA256
                                     - AES128-SHA
                                     - AES256-SHA
                                     - DES-CBC3-SHA
@@ -429,10 +485,16 @@ spec:
                                 type is one of Old, Intermediate, Modern or Custom. Custom provides the
                                 ability to specify individual TLS security profile parameters.
 
-                                The profiles are based on version 5.7 of the Mozilla Server Side TLS
-                                configuration guidelines. The cipher lists consist of the configuration's
-                                "ciphersuites" followed by the Go-specific "ciphers" from the guidelines.
-                                See: https://ssl-config.mozilla.org/guidelines/5.7.json
+                                The cipher and groups lists in these profiles are based on version 5.8 of the
+                                Mozilla Server Side TLS configuration guidelines.
+                                See: https://ssl-config.mozilla.org/guidelines/5.8.json
+
+                                The groups are listed in suggested preference order, with the most preferred group first.
+                                Note that not all platform components honor the ordering: Go-based components use Go's
+                                internal preference order and treat this list as a filter of allowed groups rather than
+                                an ordered preference.
+                                Note that X25519MLKEM768 is a post-quantum hybrid group that is not
+                                FIPS-approved and should be ignored by components running in FIPS mode.
 
                                 The profiles are intent based, so they may change over time as new ciphers are
                                 developed and existing ciphers are found to be insecure. Depending on
@@ -1948,8 +2010,11 @@ spec:
                       custom:
                         description: |-
                           custom is a user-defined TLS security profile. Be extremely careful using a custom
-                          profile as invalid configurations can be catastrophic. An example custom profile
-                          looks like this:
+                          profile as invalid configurations can be catastrophic.
+
+                          The supported groups list for this profile is empty by default.
+
+                          An example custom profile looks like this:
 
                             minTLSVersion: VersionTLS11
                             ciphers:
@@ -1974,6 +2039,46 @@ spec:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
+                          groups:
+                            description: |-
+                              groups is an optional, ordered field used to specify the supported groups (formerly known as
+                              elliptic curves) that are used during the TLS handshake.  The order of the groups represents
+                              a suggested preference, with the most preferred group first. Note that not all platform
+                              components honor the ordering: Go-based components use Go's internal preference order and
+                              treat this list as a filter of allowed groups rather than an ordered preference.
+                              Operators may remove entries their operands do not support.
+
+                              When omitted, this means no opinion and the platform is left to choose reasonable defaults which are
+                              subject to change over time and may be different per platform component depending on the underlying TLS
+                              libraries they use. If specified, the list must contain at least one and at most 7 groups,
+                              and each group must be unique.
+
+                              For example, to use X25519 and secp256r1 (yaml):
+
+                                groups:
+                                  - X25519
+                                  - secp256r1
+                            items:
+                              description: |-
+                                TLSGroup is a supported group identifier that can be used in TLSProfile.Groups.
+                                There is a one-to-one mapping between these names and the group IDs defined
+                                in Go's crypto/tls package based on IANA's "TLS Supported Groups" registry:
+                                https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8
+                                Note that X25519MLKEM768 is a post-quantum hybrid group that is not
+                                FIPS-approved and should be ignored by components running in FIPS mode.
+                              enum:
+                              - X25519
+                              - secp256r1
+                              - secp384r1
+                              - secp521r1
+                              - X25519MLKEM768
+                              - SecP256r1MLKEM768
+                              - SecP384r1MLKEM1024
+                              type: string
+                            maxItems: 7
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: set
                           minTLSVersion:
                             description: |-
                               minTLSVersion is used to specify the minimal version of the TLS protocol
@@ -1994,6 +2099,10 @@ spec:
                           legacy clients and want to remain highly secure while being compatible with
                           most clients currently in use.
 
+                          The supported groups list includes by default the following groups
+                          in suggested preference order (ordering may not be honored by all implementations):
+                          X25519MLKEM768, X25519, secp256r1, secp384r1.
+
                           This profile is equivalent to a Custom profile specified as:
                             minTLSVersion: VersionTLS12
                             ciphers:
@@ -2012,7 +2121,9 @@ spec:
                         description: |-
                           modern is a TLS security profile for use with clients that support TLS 1.3 and
                           do not need backward compatibility for older clients.
-
+                          The supported groups list includes by default the following groups
+                          in suggested preference order (ordering may not be honored by all implementations):
+                          X25519MLKEM768, X25519, secp256r1, secp384r1.
                           This profile is equivalent to a Custom profile specified as:
                             minTLSVersion: VersionTLS13
                             ciphers:
@@ -2025,6 +2136,10 @@ spec:
                         description: |-
                           old is a TLS profile for use when services need to be accessed by very old
                           clients or libraries and should be used only as a last resort.
+
+                          The supported groups list includes by default the following groups
+                          in suggested preference order (ordering may not be honored by all implementations):
+                          X25519MLKEM768, X25519, secp256r1, secp384r1.
 
                           This profile is equivalent to a Custom profile specified as:
                             minTLSVersion: VersionTLS10
@@ -2042,11 +2157,14 @@ spec:
                               - ECDHE-RSA-AES128-SHA256
                               - ECDHE-ECDSA-AES128-SHA
                               - ECDHE-RSA-AES128-SHA
+                              - ECDHE-ECDSA-AES256-SHA384
+                              - ECDHE-RSA-AES256-SHA384
                               - ECDHE-ECDSA-AES256-SHA
                               - ECDHE-RSA-AES256-SHA
                               - AES128-GCM-SHA256
                               - AES256-GCM-SHA384
                               - AES128-SHA256
+                              - AES256-SHA256
                               - AES128-SHA
                               - AES256-SHA
                               - DES-CBC3-SHA
@@ -2057,10 +2175,16 @@ spec:
                           type is one of Old, Intermediate, Modern or Custom. Custom provides the
                           ability to specify individual TLS security profile parameters.
 
-                          The profiles are based on version 5.7 of the Mozilla Server Side TLS
-                          configuration guidelines. The cipher lists consist of the configuration's
-                          "ciphersuites" followed by the Go-specific "ciphers" from the guidelines.
-                          See: https://ssl-config.mozilla.org/guidelines/5.7.json
+                          The cipher and groups lists in these profiles are based on version 5.8 of the
+                          Mozilla Server Side TLS configuration guidelines.
+                          See: https://ssl-config.mozilla.org/guidelines/5.8.json
+
+                          The groups are listed in suggested preference order, with the most preferred group first.
+                          Note that not all platform components honor the ordering: Go-based components use Go's
+                          internal preference order and treat this list as a filter of allowed groups rather than
+                          an ordered preference.
+                          Note that X25519MLKEM768 is a post-quantum hybrid group that is not
+                          FIPS-approved and should be ignored by components running in FIPS mode.
 
                           The profiles are intent based, so they may change over time as new ciphers are
                           developed and existing ciphers are found to be insecure. Depending on

--- a/related_images.json
+++ b/related_images.json
@@ -13,8 +13,8 @@
   },
   {
     "name": "lightspeed-service-api",
-    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9@sha256:958693ae1cdd0c1549d8ad9d618643da6cfb73196742723c3d78f7f023a70502",
-    "revision": "a6514dc1f8763477cfb4452eff052f50ee1f6c67",
+    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9@sha256:7cefa901793ca8d0ecc39e29e30abda16d0d8f9823caff5f1bf1c80efda1633d",
+    "revision": "681505eee4d5972448dd164f5330afc45383fc29",
     "operator_arg": "service-image",
     "snapshot_component": "lightspeed-service",
     "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service",
@@ -22,8 +22,8 @@
   },
   {
     "name": "lightspeed-console-plugin",
-    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:b935868e60f03e5d16849caaf1789feaf2da2ab1358d32d702cfe0708124e53d",
-    "revision": "1b74e852848a2eb5021bb7291ca6610e7f524e09",
+    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:321743fbda2f9346feef8049b38b49358873b1f62749dd66c7e553c82c50710f",
+    "revision": "16f8e3ca4a06e6e15a675fc5e145d8d06dbab6c0",
     "operator_arg": "console-image",
     "snapshot_component": "lightspeed-console",
     "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-console",
@@ -31,8 +31,8 @@
   },
   {
     "name": "lightspeed-operator",
-    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:71abcf4b043e20096a670badf767f4d99e30a34fc21326750621392d3f10004e",
-    "revision": "8110b0eef5136bb501a6e5abbadfee2ef94108b7",
+    "image": "registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:ad4559ce40870ba2a68398b539d8ba89ecccde68099f1a63fd969d98fd741470",
+    "revision": "2094895b277d36194f529e6910c15fabda4a7d41",
     "operator_target": "image",
     "snapshot_component": "lightspeed-operator",
     "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-operator",
@@ -40,8 +40,8 @@
   },
   {
     "name": "openshift-mcp-server",
-    "image": "registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9@sha256:588577fec9f42aff4e3e4b3c7fdf1d1c6e2ead441978e25c0b7775b106d5baaf",
-    "revision": "62a7a596becd258f375ca7d66dfce638cdc11970",
+    "image": "registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9@sha256:8a8321cc2e00c3f13bf8e433da0fb3c990def939d5c7dec5f3978e9e323fc98b",
+    "revision": "2641eb9bfb35492be42a12fca2da2ade19d33bde",
     "operator_arg": "openshift-mcp-server-image",
     "snapshot_component": "openshift-mcp-server",
     "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/openshift-mcp-server",


### PR DESCRIPTION
This PR is triggered by the release crt-nshift-lightspeed-tenant/ols-20260813-022329-000-9c474d6-2fmw7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated operator metadata with the latest release information.
  * Refreshed service API, console plugin, operator, and OpenShift MCP server image references.

* **Security**
  * Tightened operator permissions by limiting access to named resources.
  * Scoped secrets and network policy access to the operator’s namespace where appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->