### PR TITLE
Switch service e2e pipelines to openshift-ci hypershift hosted clusters.

### DIFF
--- a/.tekton/integration-tests/pipelines/lightspeed-service-integration-test-pipeline-4.16.yaml
+++ b/.tekton/integration-tests/pipelines/lightspeed-service-integration-test-pipeline-4.16.yaml
@@ -7,7 +7,7 @@ metadata:
   name: ols-integration-tests-pipeline
 spec:
   description: |
-    Runs OpenShift Lightspeed service integration tests on a Konflux ephemeral OpenShift cluster (EaaS):
+    Runs OpenShift Lightspeed service integration tests on a HyperShift hosted cluster (openshift-ci):
     provision cluster, install the operator via ols-install (OLM bundle or direct per install-mode),
     then clone operator + service at related_images
     revisions and run tests/scripts/test-e2e-cluster.sh, push artifacts.
@@ -31,7 +31,7 @@ spec:
       default: 'openshift-lightspeed'
       type: string
     - name: openshift-version-prefix
-      description: 'Minor line prefix for eaas-get-latest-openshift-version-by-prefix (include trailing dot, e.g. 4.19.)'
+      description: 'OpenShift minor version prefix (include trailing dot, e.g. 4.16.) passed to test scripts.'
       default: '4.16.'
       type: string
     - name: artifact-oci-tag-prefix
@@ -43,71 +43,33 @@ spec:
       type: string
       default: 'bundle'
   tasks:
-    - name: eaas-provision-space
+    - name: provision-ephemeral-cluster
       taskRef:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/build-definitions.git
+            value: https://github.com/openshift/konflux-tasks
           - name: revision
             value: main
           - name: pathInRepo
-            value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
+            value: tasks/provision-ephemeral-cluster/0.1/provision-ephemeral-cluster.yaml
       params:
-        - name: ownerKind
-          value: PipelineRun
         - name: ownerName
           value: $(context.pipelineRun.name)
         - name: ownerUid
           value: $(context.pipelineRun.uid)
-    - name: provision-cluster
-      runAfter:
-        - eaas-provision-space
-      params:
-        - name: openshift-version-prefix
-          value: $(params.openshift-version-prefix)
-      taskSpec:
-        params:
-          - name: openshift-version-prefix
-            type: string
-        results:
-          - name: clusterName
-            value: "$(steps.create-cluster.results.clusterName)"
-        steps:
-          - name: pick-version
-            ref:
-              resolver: git
-              params:
-                - name: url
-                  value: https://github.com/konflux-ci/build-definitions.git
-                - name: revision
-                  value: main
-                - name: pathInRepo
-                  value: stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
-            params:
-              - name: prefix
-                value: "$(params.openshift-version-prefix)"
-          - name: create-cluster
-            ref:
-              resolver: git
-              params:
-                - name: url
-                  value: https://github.com/konflux-ci/build-definitions.git
-                - name: revision
-                  value: main
-                - name: pathInRepo
-                  value: stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
-            params:
-              - name: eaasSpaceSecretRef
-                value: $(tasks.eaas-provision-space.results.secretRef)
-              - name: version
-                value: "$(steps.pick-version.results.version)"
-              - name: instanceType
-                value: "m5.2xlarge"
+        - name: workflow
+          value: hypershift-hostedcluster-workflow
+        - name: clusterProfile
+          value: aws-konflux-prod
+        - name: env
+          value: '{"COMPUTE_NODE_TYPE": "m5.2xlarge", "HYPERSHIFT_NODE_COUNT": "3", "HOSTED_MANAGEMENT_CLUSTER": "hosted-mgmt2"}'
+        - name: releases
+          value: '{"latest":{"release":{"channel":"stable","version":"4.16","architecture":"multi"}}}'
     - name: ols-install
       description: Install operator (OLM bundle or direct); record SNAPSHOT image ref and commit for service tests.
       runAfter:
-        - provision-cluster
+        - provision-ephemeral-cluster
       params:
         - name: SNAPSHOT
           value: $(params.SNAPSHOT)
@@ -115,6 +77,8 @@ spec:
           value: "$(params.namespace)"
         - name: install-mode
           value: $(params.install-mode)
+        - name: clusterCredentialsSecretRef
+          value: $(tasks.provision-ephemeral-cluster.results.secretRef)
       taskSpec:
         results:
           - name: bundle-image
@@ -128,27 +92,13 @@ spec:
           - name: install-mode
             type: string
             default: "bundle"
+          - name: clusterCredentialsSecretRef
+            type: string
         volumes:
-          - name: credentials
-            emptyDir: {}
+          - name: cluster-credentials
+            secret:
+              secretName: $(params.clusterCredentialsSecretRef)
         steps:
-          - name: get-kubeconfig
-            ref:
-              resolver: git
-              params:
-                - name: url
-                  value: https://github.com/konflux-ci/build-definitions.git
-                - name: revision
-                  value: main
-                - name: pathInRepo
-                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
-            params:
-              - name: eaasSpaceSecretRef
-                value: $(tasks.eaas-provision-space.results.secretRef)
-              - name: clusterName
-                value: "$(tasks.provision-cluster.results.clusterName)"
-              - name: credentials
-                value: credentials
           - name: install-operator
             env:
               - name: SNAPSHOT
@@ -158,11 +108,11 @@ spec:
                   fieldRef:
                     fieldPath: metadata.labels['appstudio.openshift.io/component']
               - name: KUBECONFIG
-                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+                value: "/credentials/kubeconfig"
               - name: OLS_NAMESPACE
                 value: "$(params.namespace)"
             volumeMounts:
-              - name: credentials
+              - name: cluster-credentials
                 mountPath: /credentials
             image: registry.redhat.io/openshift4/ose-cli:latest
             script: |
@@ -213,6 +163,8 @@ spec:
           value: $(params.openshift-version-prefix)
         - name: artifact-oci-tag-prefix
           value: $(params.artifact-oci-tag-prefix)
+        - name: clusterCredentialsSecretRef
+          value: $(tasks.provision-ephemeral-cluster.results.secretRef)
       runAfter:
         - ols-install
       taskSpec:
@@ -226,6 +178,8 @@ spec:
           - name: openshift-version-prefix
             type: string
           - name: artifact-oci-tag-prefix
+            type: string
+          - name: clusterCredentialsSecretRef
             type: string
         volumes:
           - name: azure-openai-token
@@ -252,26 +206,10 @@ spec:
           - name: vertex-token
             secret:
               secretName: vertex-apitoken
-          - name: credentials
-            emptyDir: {}
+          - name: cluster-credentials
+            secret:
+              secretName: $(params.clusterCredentialsSecretRef)
         steps:
-          - name: get-kubeconfig
-            ref:
-              resolver: git
-              params:
-                - name: url
-                  value: https://github.com/konflux-ci/build-definitions.git
-                - name: revision
-                  value: main
-                - name: pathInRepo
-                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
-            params:
-              - name: eaasSpaceSecretRef
-                value: $(tasks.eaas-provision-space.results.secretRef)
-              - name: clusterName
-                value: "$(tasks.provision-cluster.results.clusterName)"
-              - name: credentials
-                value: credentials
           - name: run-e2e-tests
             onError: continue
             resources:
@@ -295,7 +233,7 @@ spec:
                 mountPath: /var/run/vertex
               - name: insights-stage-upload-offline-token
                 mountPath: /var/run/insights-stage-upload-offline-token
-              - name: credentials
+              - name: cluster-credentials
                 mountPath: /credentials
             env:
               - name: BAM_PROVIDER_KEY_PATH
@@ -309,7 +247,7 @@ spec:
               - name: VERTEX_PROVIDER_KEY_PATH
                 value: "/var/run/vertex/token"
               - name: KUBECONFIG
-                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+                value: "/credentials/kubeconfig"
               - name: ARTIFACT_DIR
                 value: "/workspace/artifacts"
               - name: SUITE_ID
@@ -347,9 +285,9 @@ spec:
                   value: .tekton/integration-tests/stepactions/gather-cluster-resources/0.1/gather-cluster-resources.yaml
             params:
               - name: credentials
-                value: "credentials"
+                value: "cluster-credentials"
               - name: kubeconfig
-                value: "$(steps.get-kubeconfig.results.kubeconfig)"
+                value: "kubeconfig"
               - name: artifact-dir
                 value: "/workspace/konflux-artifacts"
               - name: gather-script-url
@@ -391,6 +329,21 @@ spec:
                 - name: pathInRepo
                   value: stepactions/fail-if-any-step-failed/0.1/fail-if-any-step-failed.yaml
   finally:
+    - name: deprovision-ephemeral-cluster
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/openshift/konflux-tasks
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/deprovision-ephemeral-cluster/0.1/deprovision-ephemeral-cluster.yaml
+      params:
+        - name: testPlatformClusterClaimName
+          value: $(tasks.provision-ephemeral-cluster.results.testPlatformClusterClaimName)
+        - name: testPlatformClusterClaimNamespace
+          value: $(tasks.provision-ephemeral-cluster.results.testPlatformClusterClaimNamespace)
     - name: export-logs-for-retention
       taskRef:
         resolver: git

--- a/.tekton/integration-tests/pipelines/lightspeed-service-integration-test-pipeline-4.17.yaml
+++ b/.tekton/integration-tests/pipelines/lightspeed-service-integration-test-pipeline-4.17.yaml
@@ -7,7 +7,7 @@ metadata:
   name: ols-integration-tests-pipeline
 spec:
   description: |
-    Runs OpenShift Lightspeed service integration tests on a Konflux ephemeral OpenShift cluster (EaaS):
+    Runs OpenShift Lightspeed service integration tests on a HyperShift hosted cluster (openshift-ci):
     provision cluster, install the operator via ols-install (OLM bundle or direct per install-mode),
     then clone operator + service at related_images
     revisions and run tests/scripts/test-e2e-cluster.sh, push artifacts.
@@ -24,15 +24,15 @@ spec:
       type: string
     - name: test-name
       description: 'The name of the test corresponding to a defined Konflux integration test.'
-      default: 'ols-e2e-tests-4.19'
+      default: 'ols-e2e-tests-4.17'
       type: string
     - name: namespace
       description: 'Namespace to run tests in'
       default: 'openshift-lightspeed'
       type: string
     - name: openshift-version-prefix
-      description: 'Minor line prefix for eaas-get-latest-openshift-version-by-prefix (include trailing dot, e.g. 4.19.)'
-      default: '4.19.'
+      description: 'OpenShift minor version prefix (include trailing dot, e.g. 4.17.) passed to test scripts.'
+      default: '4.17.'
       type: string
     - name: artifact-oci-tag-prefix
       description: 'Prepended to commit SHA in ols-service-artifacts Quay tag. Use "416" for OCP 4.16; empty for other minors.'
@@ -43,71 +43,33 @@ spec:
       type: string
       default: 'bundle'
   tasks:
-    - name: eaas-provision-space
+    - name: provision-ephemeral-cluster
       taskRef:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/build-definitions.git
+            value: https://github.com/openshift/konflux-tasks
           - name: revision
             value: main
           - name: pathInRepo
-            value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
+            value: tasks/provision-ephemeral-cluster/0.1/provision-ephemeral-cluster.yaml
       params:
-        - name: ownerKind
-          value: PipelineRun
         - name: ownerName
           value: $(context.pipelineRun.name)
         - name: ownerUid
           value: $(context.pipelineRun.uid)
-    - name: provision-cluster
-      runAfter:
-        - eaas-provision-space
-      params:
-        - name: openshift-version-prefix
-          value: $(params.openshift-version-prefix)
-      taskSpec:
-        params:
-          - name: openshift-version-prefix
-            type: string
-        results:
-          - name: clusterName
-            value: "$(steps.create-cluster.results.clusterName)"
-        steps:
-          - name: pick-version
-            ref:
-              resolver: git
-              params:
-                - name: url
-                  value: https://github.com/konflux-ci/build-definitions.git
-                - name: revision
-                  value: main
-                - name: pathInRepo
-                  value: stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
-            params:
-              - name: prefix
-                value: "$(params.openshift-version-prefix)"
-          - name: create-cluster
-            ref:
-              resolver: git
-              params:
-                - name: url
-                  value: https://github.com/konflux-ci/build-definitions.git
-                - name: revision
-                  value: main
-                - name: pathInRepo
-                  value: stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
-            params:
-              - name: eaasSpaceSecretRef
-                value: $(tasks.eaas-provision-space.results.secretRef)
-              - name: version
-                value: "$(steps.pick-version.results.version)"
-              - name: instanceType
-                value: "m5.2xlarge"
+        - name: workflow
+          value: hypershift-hostedcluster-workflow
+        - name: clusterProfile
+          value: aws-konflux-prod
+        - name: env
+          value: '{"COMPUTE_NODE_TYPE": "m5.2xlarge", "HYPERSHIFT_NODE_COUNT": "3", "HOSTED_MANAGEMENT_CLUSTER": "hosted-mgmt2"}'
+        - name: releases
+          value: '{"latest":{"release":{"channel":"stable","version":"4.17","architecture":"multi"}}}'
     - name: ols-install
       description: Install operator (OLM bundle or direct); record SNAPSHOT image ref and commit for service tests.
       runAfter:
-        - provision-cluster
+        - provision-ephemeral-cluster
       params:
         - name: SNAPSHOT
           value: $(params.SNAPSHOT)
@@ -115,6 +77,8 @@ spec:
           value: "$(params.namespace)"
         - name: install-mode
           value: $(params.install-mode)
+        - name: clusterCredentialsSecretRef
+          value: $(tasks.provision-ephemeral-cluster.results.secretRef)
       taskSpec:
         results:
           - name: bundle-image
@@ -128,27 +92,13 @@ spec:
           - name: install-mode
             type: string
             default: "bundle"
+          - name: clusterCredentialsSecretRef
+            type: string
         volumes:
-          - name: credentials
-            emptyDir: {}
+          - name: cluster-credentials
+            secret:
+              secretName: $(params.clusterCredentialsSecretRef)
         steps:
-          - name: get-kubeconfig
-            ref:
-              resolver: git
-              params:
-                - name: url
-                  value: https://github.com/konflux-ci/build-definitions.git
-                - name: revision
-                  value: main
-                - name: pathInRepo
-                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
-            params:
-              - name: eaasSpaceSecretRef
-                value: $(tasks.eaas-provision-space.results.secretRef)
-              - name: clusterName
-                value: "$(tasks.provision-cluster.results.clusterName)"
-              - name: credentials
-                value: credentials
           - name: install-operator
             env:
               - name: SNAPSHOT
@@ -158,11 +108,11 @@ spec:
                   fieldRef:
                     fieldPath: metadata.labels['appstudio.openshift.io/component']
               - name: KUBECONFIG
-                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+                value: "/credentials/kubeconfig"
               - name: OLS_NAMESPACE
                 value: "$(params.namespace)"
             volumeMounts:
-              - name: credentials
+              - name: cluster-credentials
                 mountPath: /credentials
             image: registry.redhat.io/openshift4/ose-cli:latest
             script: |
@@ -213,6 +163,8 @@ spec:
           value: $(params.openshift-version-prefix)
         - name: artifact-oci-tag-prefix
           value: $(params.artifact-oci-tag-prefix)
+        - name: clusterCredentialsSecretRef
+          value: $(tasks.provision-ephemeral-cluster.results.secretRef)
       runAfter:
         - ols-install
       taskSpec:
@@ -226,6 +178,8 @@ spec:
           - name: openshift-version-prefix
             type: string
           - name: artifact-oci-tag-prefix
+            type: string
+          - name: clusterCredentialsSecretRef
             type: string
         volumes:
           - name: azure-openai-token
@@ -252,26 +206,10 @@ spec:
           - name: vertex-token
             secret:
               secretName: vertex-apitoken
-          - name: credentials
-            emptyDir: {}
+          - name: cluster-credentials
+            secret:
+              secretName: $(params.clusterCredentialsSecretRef)
         steps:
-          - name: get-kubeconfig
-            ref:
-              resolver: git
-              params:
-                - name: url
-                  value: https://github.com/konflux-ci/build-definitions.git
-                - name: revision
-                  value: main
-                - name: pathInRepo
-                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
-            params:
-              - name: eaasSpaceSecretRef
-                value: $(tasks.eaas-provision-space.results.secretRef)
-              - name: clusterName
-                value: "$(tasks.provision-cluster.results.clusterName)"
-              - name: credentials
-                value: credentials
           - name: run-e2e-tests
             onError: continue
             resources:
@@ -295,7 +233,7 @@ spec:
                 mountPath: /var/run/vertex
               - name: insights-stage-upload-offline-token
                 mountPath: /var/run/insights-stage-upload-offline-token
-              - name: credentials
+              - name: cluster-credentials
                 mountPath: /credentials
             env:
               - name: BAM_PROVIDER_KEY_PATH
@@ -309,7 +247,7 @@ spec:
               - name: VERTEX_PROVIDER_KEY_PATH
                 value: "/var/run/vertex/token"
               - name: KUBECONFIG
-                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+                value: "/credentials/kubeconfig"
               - name: ARTIFACT_DIR
                 value: "/workspace/artifacts"
               - name: SUITE_ID
@@ -347,9 +285,9 @@ spec:
                   value: .tekton/integration-tests/stepactions/gather-cluster-resources/0.1/gather-cluster-resources.yaml
             params:
               - name: credentials
-                value: "credentials"
+                value: "cluster-credentials"
               - name: kubeconfig
-                value: "$(steps.get-kubeconfig.results.kubeconfig)"
+                value: "kubeconfig"
               - name: artifact-dir
                 value: "/workspace/konflux-artifacts"
               - name: gather-script-url
@@ -391,6 +329,21 @@ spec:
                 - name: pathInRepo
                   value: stepactions/fail-if-any-step-failed/0.1/fail-if-any-step-failed.yaml
   finally:
+    - name: deprovision-ephemeral-cluster
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/openshift/konflux-tasks
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/deprovision-ephemeral-cluster/0.1/deprovision-ephemeral-cluster.yaml
+      params:
+        - name: testPlatformClusterClaimName
+          value: $(tasks.provision-ephemeral-cluster.results.testPlatformClusterClaimName)
+        - name: testPlatformClusterClaimNamespace
+          value: $(tasks.provision-ephemeral-cluster.results.testPlatformClusterClaimNamespace)
     - name: export-logs-for-retention
       taskRef:
         resolver: git

--- a/.tekton/integration-tests/pipelines/lightspeed-service-integration-test-pipeline-4.18.yaml
+++ b/.tekton/integration-tests/pipelines/lightspeed-service-integration-test-pipeline-4.18.yaml
@@ -7,7 +7,7 @@ metadata:
   name: ols-integration-tests-pipeline
 spec:
   description: |
-    Runs OpenShift Lightspeed service integration tests on a Konflux ephemeral OpenShift cluster (EaaS):
+    Runs OpenShift Lightspeed service integration tests on a HyperShift hosted cluster (openshift-ci):
     provision cluster, install the operator via ols-install (OLM bundle or direct per install-mode),
     then clone operator + service at related_images
     revisions and run tests/scripts/test-e2e-cluster.sh, push artifacts.
@@ -24,15 +24,15 @@ spec:
       type: string
     - name: test-name
       description: 'The name of the test corresponding to a defined Konflux integration test.'
-      default: 'ols-e2e-tests-4.19'
+      default: 'ols-e2e-tests-4.18'
       type: string
     - name: namespace
       description: 'Namespace to run tests in'
       default: 'openshift-lightspeed'
       type: string
     - name: openshift-version-prefix
-      description: 'Minor line prefix for eaas-get-latest-openshift-version-by-prefix (include trailing dot, e.g. 4.19.)'
-      default: '4.19.'
+      description: 'OpenShift minor version prefix (include trailing dot, e.g. 4.18.) passed to test scripts.'
+      default: '4.18.'
       type: string
     - name: artifact-oci-tag-prefix
       description: 'Prepended to commit SHA in ols-service-artifacts Quay tag. Use "416" for OCP 4.16; empty for other minors.'
@@ -43,71 +43,33 @@ spec:
       type: string
       default: 'bundle'
   tasks:
-    - name: eaas-provision-space
+    - name: provision-ephemeral-cluster
       taskRef:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/build-definitions.git
+            value: https://github.com/openshift/konflux-tasks
           - name: revision
             value: main
           - name: pathInRepo
-            value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
+            value: tasks/provision-ephemeral-cluster/0.1/provision-ephemeral-cluster.yaml
       params:
-        - name: ownerKind
-          value: PipelineRun
         - name: ownerName
           value: $(context.pipelineRun.name)
         - name: ownerUid
           value: $(context.pipelineRun.uid)
-    - name: provision-cluster
-      runAfter:
-        - eaas-provision-space
-      params:
-        - name: openshift-version-prefix
-          value: $(params.openshift-version-prefix)
-      taskSpec:
-        params:
-          - name: openshift-version-prefix
-            type: string
-        results:
-          - name: clusterName
-            value: "$(steps.create-cluster.results.clusterName)"
-        steps:
-          - name: pick-version
-            ref:
-              resolver: git
-              params:
-                - name: url
-                  value: https://github.com/konflux-ci/build-definitions.git
-                - name: revision
-                  value: main
-                - name: pathInRepo
-                  value: stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
-            params:
-              - name: prefix
-                value: "$(params.openshift-version-prefix)"
-          - name: create-cluster
-            ref:
-              resolver: git
-              params:
-                - name: url
-                  value: https://github.com/konflux-ci/build-definitions.git
-                - name: revision
-                  value: main
-                - name: pathInRepo
-                  value: stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
-            params:
-              - name: eaasSpaceSecretRef
-                value: $(tasks.eaas-provision-space.results.secretRef)
-              - name: version
-                value: "$(steps.pick-version.results.version)"
-              - name: instanceType
-                value: "m5.2xlarge"
+        - name: workflow
+          value: hypershift-hostedcluster-workflow
+        - name: clusterProfile
+          value: aws-konflux-prod
+        - name: env
+          value: '{"COMPUTE_NODE_TYPE": "m5.2xlarge", "HYPERSHIFT_NODE_COUNT": "3", "HOSTED_MANAGEMENT_CLUSTER": "hosted-mgmt2"}'
+        - name: releases
+          value: '{"latest":{"release":{"channel":"stable","version":"4.18","architecture":"multi"}}}'
     - name: ols-install
       description: Install operator (OLM bundle or direct); record SNAPSHOT image ref and commit for service tests.
       runAfter:
-        - provision-cluster
+        - provision-ephemeral-cluster
       params:
         - name: SNAPSHOT
           value: $(params.SNAPSHOT)
@@ -115,6 +77,8 @@ spec:
           value: "$(params.namespace)"
         - name: install-mode
           value: $(params.install-mode)
+        - name: clusterCredentialsSecretRef
+          value: $(tasks.provision-ephemeral-cluster.results.secretRef)
       taskSpec:
         results:
           - name: bundle-image
@@ -128,27 +92,13 @@ spec:
           - name: install-mode
             type: string
             default: "bundle"
+          - name: clusterCredentialsSecretRef
+            type: string
         volumes:
-          - name: credentials
-            emptyDir: {}
+          - name: cluster-credentials
+            secret:
+              secretName: $(params.clusterCredentialsSecretRef)
         steps:
-          - name: get-kubeconfig
-            ref:
-              resolver: git
-              params:
-                - name: url
-                  value: https://github.com/konflux-ci/build-definitions.git
-                - name: revision
-                  value: main
-                - name: pathInRepo
-                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
-            params:
-              - name: eaasSpaceSecretRef
-                value: $(tasks.eaas-provision-space.results.secretRef)
-              - name: clusterName
-                value: "$(tasks.provision-cluster.results.clusterName)"
-              - name: credentials
-                value: credentials
           - name: install-operator
             env:
               - name: SNAPSHOT
@@ -158,11 +108,11 @@ spec:
                   fieldRef:
                     fieldPath: metadata.labels['appstudio.openshift.io/component']
               - name: KUBECONFIG
-                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+                value: "/credentials/kubeconfig"
               - name: OLS_NAMESPACE
                 value: "$(params.namespace)"
             volumeMounts:
-              - name: credentials
+              - name: cluster-credentials
                 mountPath: /credentials
             image: registry.redhat.io/openshift4/ose-cli:latest
             script: |
@@ -213,6 +163,8 @@ spec:
           value: $(params.openshift-version-prefix)
         - name: artifact-oci-tag-prefix
           value: $(params.artifact-oci-tag-prefix)
+        - name: clusterCredentialsSecretRef
+          value: $(tasks.provision-ephemeral-cluster.results.secretRef)
       runAfter:
         - ols-install
       taskSpec:
@@ -226,6 +178,8 @@ spec:
           - name: openshift-version-prefix
             type: string
           - name: artifact-oci-tag-prefix
+            type: string
+          - name: clusterCredentialsSecretRef
             type: string
         volumes:
           - name: azure-openai-token
@@ -252,26 +206,10 @@ spec:
           - name: vertex-token
             secret:
               secretName: vertex-apitoken
-          - name: credentials
-            emptyDir: {}
+          - name: cluster-credentials
+            secret:
+              secretName: $(params.clusterCredentialsSecretRef)
         steps:
-          - name: get-kubeconfig
-            ref:
-              resolver: git
-              params:
-                - name: url
-                  value: https://github.com/konflux-ci/build-definitions.git
-                - name: revision
-                  value: main
-                - name: pathInRepo
-                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
-            params:
-              - name: eaasSpaceSecretRef
-                value: $(tasks.eaas-provision-space.results.secretRef)
-              - name: clusterName
-                value: "$(tasks.provision-cluster.results.clusterName)"
-              - name: credentials
-                value: credentials
           - name: run-e2e-tests
             onError: continue
             resources:
@@ -295,7 +233,7 @@ spec:
                 mountPath: /var/run/vertex
               - name: insights-stage-upload-offline-token
                 mountPath: /var/run/insights-stage-upload-offline-token
-              - name: credentials
+              - name: cluster-credentials
                 mountPath: /credentials
             env:
               - name: BAM_PROVIDER_KEY_PATH
@@ -309,7 +247,7 @@ spec:
               - name: VERTEX_PROVIDER_KEY_PATH
                 value: "/var/run/vertex/token"
               - name: KUBECONFIG
-                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+                value: "/credentials/kubeconfig"
               - name: ARTIFACT_DIR
                 value: "/workspace/artifacts"
               - name: SUITE_ID
@@ -347,9 +285,9 @@ spec:
                   value: .tekton/integration-tests/stepactions/gather-cluster-resources/0.1/gather-cluster-resources.yaml
             params:
               - name: credentials
-                value: "credentials"
+                value: "cluster-credentials"
               - name: kubeconfig
-                value: "$(steps.get-kubeconfig.results.kubeconfig)"
+                value: "kubeconfig"
               - name: artifact-dir
                 value: "/workspace/konflux-artifacts"
               - name: gather-script-url
@@ -391,6 +329,21 @@ spec:
                 - name: pathInRepo
                   value: stepactions/fail-if-any-step-failed/0.1/fail-if-any-step-failed.yaml
   finally:
+    - name: deprovision-ephemeral-cluster
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/openshift/konflux-tasks
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/deprovision-ephemeral-cluster/0.1/deprovision-ephemeral-cluster.yaml
+      params:
+        - name: testPlatformClusterClaimName
+          value: $(tasks.provision-ephemeral-cluster.results.testPlatformClusterClaimName)
+        - name: testPlatformClusterClaimNamespace
+          value: $(tasks.provision-ephemeral-cluster.results.testPlatformClusterClaimNamespace)
     - name: export-logs-for-retention
       taskRef:
         resolver: git

--- a/.tekton/integration-tests/pipelines/lightspeed-service-integration-test-pipeline-4.19.yaml
+++ b/.tekton/integration-tests/pipelines/lightspeed-service-integration-test-pipeline-4.19.yaml
@@ -7,7 +7,7 @@ metadata:
   name: ols-integration-tests-pipeline
 spec:
   description: |
-    Runs OpenShift Lightspeed service integration tests on a Konflux ephemeral OpenShift cluster (EaaS):
+    Runs OpenShift Lightspeed service integration tests on a HyperShift hosted cluster (openshift-ci):
     provision cluster, install the operator via ols-install (OLM bundle or direct per install-mode),
     then clone operator + service at related_images
     revisions and run tests/scripts/test-e2e-cluster.sh, push artifacts.
@@ -31,7 +31,7 @@ spec:
       default: 'openshift-lightspeed'
       type: string
     - name: openshift-version-prefix
-      description: 'Minor line prefix for eaas-get-latest-openshift-version-by-prefix (include trailing dot, e.g. 4.19.)'
+      description: 'OpenShift minor version prefix (include trailing dot, e.g. 4.19.) passed to test scripts.'
       default: '4.19.'
       type: string
     - name: artifact-oci-tag-prefix
@@ -43,71 +43,33 @@ spec:
       type: string
       default: 'bundle'
   tasks:
-    - name: eaas-provision-space
+    - name: provision-ephemeral-cluster
       taskRef:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/build-definitions.git
+            value: https://github.com/openshift/konflux-tasks
           - name: revision
             value: main
           - name: pathInRepo
-            value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
+            value: tasks/provision-ephemeral-cluster/0.1/provision-ephemeral-cluster.yaml
       params:
-        - name: ownerKind
-          value: PipelineRun
         - name: ownerName
           value: $(context.pipelineRun.name)
         - name: ownerUid
           value: $(context.pipelineRun.uid)
-    - name: provision-cluster
-      runAfter:
-        - eaas-provision-space
-      params:
-        - name: openshift-version-prefix
-          value: $(params.openshift-version-prefix)
-      taskSpec:
-        params:
-          - name: openshift-version-prefix
-            type: string
-        results:
-          - name: clusterName
-            value: "$(steps.create-cluster.results.clusterName)"
-        steps:
-          - name: pick-version
-            ref:
-              resolver: git
-              params:
-                - name: url
-                  value: https://github.com/konflux-ci/build-definitions.git
-                - name: revision
-                  value: main
-                - name: pathInRepo
-                  value: stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
-            params:
-              - name: prefix
-                value: "$(params.openshift-version-prefix)"
-          - name: create-cluster
-            ref:
-              resolver: git
-              params:
-                - name: url
-                  value: https://github.com/konflux-ci/build-definitions.git
-                - name: revision
-                  value: main
-                - name: pathInRepo
-                  value: stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
-            params:
-              - name: eaasSpaceSecretRef
-                value: $(tasks.eaas-provision-space.results.secretRef)
-              - name: version
-                value: "$(steps.pick-version.results.version)"
-              - name: instanceType
-                value: "m5.2xlarge"
+        - name: workflow
+          value: hypershift-hostedcluster-workflow
+        - name: clusterProfile
+          value: aws-konflux-prod
+        - name: env
+          value: '{"COMPUTE_NODE_TYPE": "m5.2xlarge", "HYPERSHIFT_NODE_COUNT": "3", "HOSTED_MANAGEMENT_CLUSTER": "hosted-mgmt2"}'
+        - name: releases
+          value: '{"latest":{"release":{"channel":"stable","version":"4.19","architecture":"multi"}}}'
     - name: ols-install
       description: Install operator (OLM bundle or direct); record SNAPSHOT image ref and commit for service tests.
       runAfter:
-        - provision-cluster
+        - provision-ephemeral-cluster
       params:
         - name: SNAPSHOT
           value: $(params.SNAPSHOT)
@@ -115,6 +77,8 @@ spec:
           value: "$(params.namespace)"
         - name: install-mode
           value: $(params.install-mode)
+        - name: clusterCredentialsSecretRef
+          value: $(tasks.provision-ephemeral-cluster.results.secretRef)
       taskSpec:
         results:
           - name: bundle-image
@@ -128,27 +92,13 @@ spec:
           - name: install-mode
             type: string
             default: "bundle"
+          - name: clusterCredentialsSecretRef
+            type: string
         volumes:
-          - name: credentials
-            emptyDir: {}
+          - name: cluster-credentials
+            secret:
+              secretName: $(params.clusterCredentialsSecretRef)
         steps:
-          - name: get-kubeconfig
-            ref:
-              resolver: git
-              params:
-                - name: url
-                  value: https://github.com/konflux-ci/build-definitions.git
-                - name: revision
-                  value: main
-                - name: pathInRepo
-                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
-            params:
-              - name: eaasSpaceSecretRef
-                value: $(tasks.eaas-provision-space.results.secretRef)
-              - name: clusterName
-                value: "$(tasks.provision-cluster.results.clusterName)"
-              - name: credentials
-                value: credentials
           - name: install-operator
             env:
               - name: SNAPSHOT
@@ -158,11 +108,11 @@ spec:
                   fieldRef:
                     fieldPath: metadata.labels['appstudio.openshift.io/component']
               - name: KUBECONFIG
-                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+                value: "/credentials/kubeconfig"
               - name: OLS_NAMESPACE
                 value: "$(params.namespace)"
             volumeMounts:
-              - name: credentials
+              - name: cluster-credentials
                 mountPath: /credentials
             image: registry.redhat.io/openshift4/ose-cli:latest
             script: |
@@ -213,6 +163,8 @@ spec:
           value: $(params.openshift-version-prefix)
         - name: artifact-oci-tag-prefix
           value: $(params.artifact-oci-tag-prefix)
+        - name: clusterCredentialsSecretRef
+          value: $(tasks.provision-ephemeral-cluster.results.secretRef)
       runAfter:
         - ols-install
       taskSpec:
@@ -226,6 +178,8 @@ spec:
           - name: openshift-version-prefix
             type: string
           - name: artifact-oci-tag-prefix
+            type: string
+          - name: clusterCredentialsSecretRef
             type: string
         volumes:
           - name: azure-openai-token
@@ -243,9 +197,6 @@ spec:
           - name: watsonx-token
             secret:
               secretName: watsonx-apitoken
-          - name: vertex-token
-            secret:
-              secretName: vertex-apitoken
           - name: insights-stage-upload-offline-token
             secret:
               secretName: insights-stage-upload-offline-token
@@ -255,26 +206,10 @@ spec:
           - name: vertex-token
             secret:
               secretName: vertex-apitoken
-          - name: credentials
-            emptyDir: {}
+          - name: cluster-credentials
+            secret:
+              secretName: $(params.clusterCredentialsSecretRef)
         steps:
-          - name: get-kubeconfig
-            ref:
-              resolver: git
-              params:
-                - name: url
-                  value: https://github.com/konflux-ci/build-definitions.git
-                - name: revision
-                  value: main
-                - name: pathInRepo
-                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
-            params:
-              - name: eaasSpaceSecretRef
-                value: $(tasks.eaas-provision-space.results.secretRef)
-              - name: clusterName
-                value: "$(tasks.provision-cluster.results.clusterName)"
-              - name: credentials
-                value: credentials
           - name: run-e2e-tests
             onError: continue
             resources:
@@ -298,7 +233,7 @@ spec:
                 mountPath: /var/run/vertex
               - name: insights-stage-upload-offline-token
                 mountPath: /var/run/insights-stage-upload-offline-token
-              - name: credentials
+              - name: cluster-credentials
                 mountPath: /credentials
             env:
               - name: BAM_PROVIDER_KEY_PATH
@@ -312,7 +247,7 @@ spec:
               - name: VERTEX_PROVIDER_KEY_PATH
                 value: "/var/run/vertex/token"
               - name: KUBECONFIG
-                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+                value: "/credentials/kubeconfig"
               - name: ARTIFACT_DIR
                 value: "/workspace/artifacts"
               - name: SUITE_ID
@@ -350,9 +285,9 @@ spec:
                   value: .tekton/integration-tests/stepactions/gather-cluster-resources/0.1/gather-cluster-resources.yaml
             params:
               - name: credentials
-                value: "credentials"
+                value: "cluster-credentials"
               - name: kubeconfig
-                value: "$(steps.get-kubeconfig.results.kubeconfig)"
+                value: "kubeconfig"
               - name: artifact-dir
                 value: "/workspace/konflux-artifacts"
               - name: gather-script-url
@@ -394,6 +329,21 @@ spec:
                 - name: pathInRepo
                   value: stepactions/fail-if-any-step-failed/0.1/fail-if-any-step-failed.yaml
   finally:
+    - name: deprovision-ephemeral-cluster
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/openshift/konflux-tasks
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/deprovision-ephemeral-cluster/0.1/deprovision-ephemeral-cluster.yaml
+      params:
+        - name: testPlatformClusterClaimName
+          value: $(tasks.provision-ephemeral-cluster.results.testPlatformClusterClaimName)
+        - name: testPlatformClusterClaimNamespace
+          value: $(tasks.provision-ephemeral-cluster.results.testPlatformClusterClaimNamespace)
     - name: export-logs-for-retention
       taskRef:
         resolver: git


### PR DESCRIPTION
Replace EaaS ephemeral cluster provisioning (eaas-provision-space + eaas-create-ephemeral-cluster-hypershift-aws) with provision-ephemeral-cluster from openshift/konflux-tasks using hypershift-hostedcluster-workflow and the shared aws-konflux-prod cluster profile.

Kubeconfig is now served via a secret volume (cluster-credentials) at /credentials/kubeconfig instead of fetched via eaas-get-ephemeral-cluster-credentials. deprovision-ephemeral-cluster added to finally block.

## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integration tests now run on HyperShift hosted OpenShift clusters across supported versions 4.16–4.19.
  * Cluster credentials are provided automatically for installation, service testing, and resource collection.
  * Test clusters are automatically deprovisioned after each run.

* **Improvements**
  * Updated pipeline descriptions and version parameter guidance to reflect the hosted-cluster workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->