### PR TITLE
OLS-0000 Fix read-only kubeconfig in service e2e tests

### DIFF
--- a/.tekton/integration-tests/scripts/run-service-integration-tests.sh
+++ b/.tekton/integration-tests/scripts/run-service-integration-tests.sh
@@ -29,6 +29,10 @@ echo "---------------------------------------------"
 
 bash .tekton/integration-tests/scripts/install-oc-if-missing.sh "${ocp_channel}"
 
+# Secret volumes are read-only; oc project writes context back to kubeconfig.
+cp "${KUBECONFIG}" /tmp/kubeconfig
+export KUBECONFIG=/tmp/kubeconfig
+
 ols_ns="${OLS_NAMESPACE:-openshift-lightspeed}"
 echo "Setting default namespace for oc (e2e harness uses commands without -n)"
 oc project "${ols_ns}"


### PR DESCRIPTION
The switch to HyperShift hosted clusters (26ebaa21) mounts the kubeconfig from a Secret volume, which Kubernetes makes read-only. `oc project` writes context changes back to the kubeconfig file, causing "open /credentials/kubeconfig: read-only file system".

Copy the kubeconfig to /tmp before use so oc can update the context.

## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integration test setup by ensuring the Kubernetes configuration can be safely updated when switching OpenShift projects.
  * Prevented failures caused by attempting to modify a read-only configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->