### PR TITLE
OLS-3633: Implement endpoint configuration and context store

### DIFF
--- a/.ai/spec/how/cli.md
+++ b/.ai/spec/how/cli.md
@@ -24,7 +24,7 @@ Audience: AI agents. This document describes **code layout, client wiring, and I
 | `attachments.go` | — | `ReadAttachments(paths)` — reads files, builds attachment array |
 | `render.go` | — | `RenderMarkdown(text)` — terminal markdown rendering via glamour |
 
-*Implemented: `root.go`, `version.go`, `kubeconfig.go` (OLS-3632). Remaining files are planned.*
+*Implemented: `root.go`, `version.go`, `kubeconfig.go` (OLS-3632); `config/endpoint.go`, `config/persistence.go`, `config/kubeconfig.go` (OLS-3633). Remaining files are planned.*
 
 ---
 
@@ -32,8 +32,9 @@ Audience: AI agents. This document describes **code layout, client wiring, and I
 
 | File | Types | Key functions |
 |------|-------|---------------|
-| `endpoint.go` | `SetEndpointOptions` | `NewSetEndpointCmd`, `Run` — persists URL keyed by kubeconfig context |
-| `persistence.go` | `ContextStore` | `LoadConversationID`, `SaveConversationID`, `LoadEndpoint`, `SaveEndpoint` — local file storage per kubeconfig context |
+| `endpoint.go` | — | `NewSetEndpointCmd`, `NewConfigCmd` — validates URL (HTTPS required, `--insecure-allow-http` for dev), persists URL keyed by kubeconfig context |
+| `persistence.go` | `ContextStore` | `LoadEndpoint`, `SaveEndpoint` — per-context local file storage under `<UserConfigDir>/oc-ols/contexts/<sanitized-context-name>/` |
+| `kubeconfig.go` | — | `loadRawKubeConfig` — minimal kubeconfig loading for context name resolution |
 
 ---
 
@@ -139,7 +140,7 @@ LLM responses contain markdown formatting (headings, code blocks, lists, bold/it
 
 ## Conversation persistence
 
-- **Storage location:** `~/.config/oc-ols/contexts/<storage-key>/` directory, where `<storage-key>` is derived from a SHA-256 hash of the canonical kubeconfig path + context name (e.g., `sha256(abs_kubeconfig_path + ":" + context_name)[:16]`). This ensures context names from different `--kubeconfig` files do not collide, and prevents path traversal from malicious context names. A `manifest.json` at `~/.config/oc-ols/contexts/` maps storage keys back to human-readable `{kubeconfig, context}` pairs for debugging.
+- **Storage location:** `<UserConfigDir>/oc-ols/contexts/<sanitized-context-name>/` directory, where `<sanitized-context-name>` is the kubeconfig context name with characters outside `[a-zA-Z0-9._-]` replaced by `_`. When sanitization modifies the name, a short SHA-256 hash suffix of the original name is appended to prevent collisions (e.g., `admin:cluster` → `admin_cluster_a3f8b2c1`, `admin_cluster` → `admin_cluster`). Empty, `.`, and `..` names are rejected.
   - `conversation.json` stores `{"conversation_id": "<uuid>", "updated_at": "<timestamp>"}`.
   - `endpoint` file stores the configured URL as plain text.
 - **Behavior:** After each successful query, the returned `conversation_id` is persisted for the current kubeconfig context. On subsequent queries, the persisted `conversation_id` is included in the request automatically.

--- a/.ai/spec/how/cli.md
+++ b/.ai/spec/how/cli.md
@@ -140,6 +140,8 @@ LLM responses contain markdown formatting (headings, code blocks, lists, bold/it
 
 ## Conversation persistence
 
+*Implemented: storage layout and endpoint persistence (OLS-3633). Conversation ID persistence planned for OLS-3636.*
+
 - **Storage location:** `<UserConfigDir>/oc-ols/contexts/<sanitized-context-name>/` directory, where `<sanitized-context-name>` is the kubeconfig context name with characters outside `[a-zA-Z0-9._-]` replaced by `_`. When sanitization modifies the name, a short SHA-256 hash suffix of the original name is appended to prevent collisions (e.g., `admin:cluster` → `admin_cluster_a3f8b2c1`, `admin_cluster` → `admin_cluster`). Empty, `.`, and `..` names are rejected.
   - `conversation.json` stores `{"conversation_id": "<uuid>", "updated_at": "<timestamp>"}`.
   - `endpoint` file stores the configured URL as plain text.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,8 @@ make test-e2e   # E2E tests (requires cluster)
 
 ### CLI Plugin
 - `cmd/oc-ols/main.go` - CLI binary entry point (IOStreams, root command)
-- `cli/` - CLI command implementations (root, version, kubeconfig integration)
+- `cli/` - CLI command implementations (root, version, kubeconfig integration, endpoint resolution)
+- `cli/config/` - Per-context configuration storage (endpoint persistence, set-endpoint subcommand)
 
 ### Controllers
 - `internal/controller/olsconfig_controller.go` - Main reconciler with finalizer logic

--- a/cli/config/endpoint.go
+++ b/cli/config/endpoint.go
@@ -1,0 +1,126 @@
+package config
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+const (
+	ErrInvalidURL     = "invalid endpoint URL"
+	ErrHTTPNotAllowed = "cleartext HTTP endpoints are not allowed (bearer token would be sent unencrypted). " +
+		"Use https:// or pass --insecure-allow-http for development"
+	ErrResolveContext = "failed to resolve kubeconfig context"
+	ErrWriteOutput    = "failed to write output"
+)
+
+// ValidateEndpointURL checks that a URL is valid, has a host, and uses HTTPS
+// (or HTTP if allowHTTP is true).
+func ValidateEndpointURL(endpoint string, allowHTTP bool) error {
+	parsedURL, err := url.ParseRequestURI(endpoint)
+	if err != nil {
+		return fmt.Errorf("%s %q: %w", ErrInvalidURL, endpoint, err)
+	}
+
+	if parsedURL.Host == "" {
+		return fmt.Errorf("%s %q: missing host", ErrInvalidURL, endpoint)
+	}
+
+	if parsedURL.Scheme == "http" && !allowHTTP {
+		return fmt.Errorf("%s", ErrHTTPNotAllowed)
+	}
+
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return fmt.Errorf("%s %q: scheme must be http or https", ErrInvalidURL, endpoint)
+	}
+
+	return nil
+}
+
+// NewSetEndpointCmd creates the "config set-endpoint" subcommand.
+func NewSetEndpointCmd(streams genericclioptions.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "set-endpoint URL",
+		Short: "Set the OLS service endpoint for the current kubeconfig context",
+		Long: "Set the OLS service endpoint URL for the current kubeconfig context. " +
+			"HTTPS is required by default since the bearer token is sent in the Authorization header.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			endpoint := strings.TrimSpace(args[0])
+
+			insecureAllowHTTP, err := cmd.Flags().GetBool("insecure-allow-http")
+			if err != nil {
+				return err
+			}
+
+			if err := ValidateEndpointURL(endpoint, insecureAllowHTTP); err != nil {
+				return err
+			}
+
+			contextName, err := cmd.Flags().GetString("context")
+			if err != nil {
+				return err
+			}
+			if contextName == "" {
+				contextName, err = resolveCurrentContext(cmd)
+				if err != nil {
+					return err
+				}
+			}
+
+			store, err := NewContextStore()
+			if err != nil {
+				return err
+			}
+
+			if err := store.SaveEndpoint(contextName, endpoint); err != nil {
+				return err
+			}
+
+			if _, err := fmt.Fprintf(streams.Out, "Endpoint set for context %q: %s\n", contextName, endpoint); err != nil {
+				return fmt.Errorf("%s: %w", ErrWriteOutput, err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().Bool("insecure-allow-http", false,
+		"Allow cleartext HTTP endpoints (development only)")
+
+	return cmd
+}
+
+// NewConfigCmd creates the "config" subcommand group.
+func NewConfigCmd(streams genericclioptions.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Manage oc-ols configuration",
+	}
+
+	cmd.AddCommand(NewSetEndpointCmd(streams))
+
+	return cmd
+}
+
+// resolveCurrentContext reads the kubeconfig to determine the active context name.
+func resolveCurrentContext(cmd *cobra.Command) (string, error) {
+	kubeconfigPath, err := cmd.Flags().GetString("kubeconfig")
+	if err != nil {
+		return "", err
+	}
+
+	rawConfig, err := loadRawKubeConfig(kubeconfigPath)
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", ErrResolveContext, err)
+	}
+
+	if rawConfig.CurrentContext == "" {
+		return "", fmt.Errorf("%s: no current context set in kubeconfig", ErrResolveContext)
+	}
+
+	return rawConfig.CurrentContext, nil
+}

--- a/cli/config/endpoint_test.go
+++ b/cli/config/endpoint_test.go
@@ -1,0 +1,188 @@
+package config
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+func fakeStreams() (genericclioptions.IOStreams, *bytes.Buffer, *bytes.Buffer) {
+	out := &bytes.Buffer{}
+	errOut := &bytes.Buffer{}
+	streams := genericclioptions.IOStreams{
+		In:     &bytes.Buffer{},
+		Out:    out,
+		ErrOut: errOut,
+	}
+	return streams, out, errOut
+}
+
+// writeKubeconfig creates a minimal kubeconfig file with the given context name.
+func writeKubeconfig(dir, contextName string) string {
+	path := filepath.Join(dir, "kubeconfig")
+	content := `apiVersion: v1
+kind: Config
+current-context: ` + contextName + `
+contexts:
+- name: ` + contextName + `
+  context:
+    cluster: test-cluster
+clusters:
+- name: test-cluster
+  cluster:
+    server: https://api.test.example.com:6443
+`
+	Expect(os.WriteFile(path, []byte(content), 0600)).To(Succeed())
+	return path
+}
+
+var _ = Describe("SetEndpointCmd", func() {
+	var (
+		tmpDir string
+	)
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "oc-ols-endpoint-test-*")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(tmpDir)).To(Succeed())
+	})
+
+	It("saves an HTTPS endpoint and prints confirmation", func() {
+		kubeconfigPath := writeKubeconfig(tmpDir, "my-cluster")
+		streams, out, _ := fakeStreams()
+		cmd := NewConfigCmd(streams)
+
+		// Inherit kubeconfig flag from a parent (simulating root command)
+		cmd.PersistentFlags().String("kubeconfig", "", "")
+		cmd.PersistentFlags().String("context", "", "")
+
+		// Override config dir to use temp directory
+		origUserConfigDir, hadConfigDir := os.LookupEnv("XDG_CONFIG_HOME")
+		Expect(os.Setenv("XDG_CONFIG_HOME", tmpDir)).To(Succeed())
+		defer func() {
+			if !hadConfigDir {
+				Expect(os.Unsetenv("XDG_CONFIG_HOME")).To(Succeed())
+			} else {
+				Expect(os.Setenv("XDG_CONFIG_HOME", origUserConfigDir)).To(Succeed())
+			}
+		}()
+
+		cmd.SetArgs([]string{"set-endpoint", "https://ols.example.com", "--kubeconfig", kubeconfigPath})
+		Expect(cmd.Execute()).To(Succeed())
+		Expect(out.String()).To(ContainSubstring(`Endpoint set for context "my-cluster"`))
+		Expect(out.String()).To(ContainSubstring("https://ols.example.com"))
+	})
+
+	It("rejects HTTP endpoints without --insecure-allow-http", func() {
+		kubeconfigPath := writeKubeconfig(tmpDir, "my-cluster")
+		streams, _, _ := fakeStreams()
+		cmd := NewConfigCmd(streams)
+		cmd.PersistentFlags().String("kubeconfig", "", "")
+		cmd.PersistentFlags().String("context", "", "")
+
+		cmd.SetArgs([]string{"set-endpoint", "http://ols.example.com", "--kubeconfig", kubeconfigPath})
+		err := cmd.Execute()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(ErrHTTPNotAllowed))
+	})
+
+	It("allows HTTP endpoints with --insecure-allow-http", func() {
+		kubeconfigPath := writeKubeconfig(tmpDir, "my-cluster")
+		streams, out, _ := fakeStreams()
+		cmd := NewConfigCmd(streams)
+		cmd.PersistentFlags().String("kubeconfig", "", "")
+		cmd.PersistentFlags().String("context", "", "")
+
+		origUserConfigDir, hadConfigDir := os.LookupEnv("XDG_CONFIG_HOME")
+		Expect(os.Setenv("XDG_CONFIG_HOME", tmpDir)).To(Succeed())
+		defer func() {
+			if !hadConfigDir {
+				Expect(os.Unsetenv("XDG_CONFIG_HOME")).To(Succeed())
+			} else {
+				Expect(os.Setenv("XDG_CONFIG_HOME", origUserConfigDir)).To(Succeed())
+			}
+		}()
+
+		cmd.SetArgs([]string{"set-endpoint", "http://localhost:8080", "--insecure-allow-http", "--kubeconfig", kubeconfigPath})
+		Expect(cmd.Execute()).To(Succeed())
+		Expect(out.String()).To(ContainSubstring("http://localhost:8080"))
+	})
+
+	It("rejects invalid URLs", func() {
+		streams, _, _ := fakeStreams()
+		cmd := NewConfigCmd(streams)
+		cmd.PersistentFlags().String("kubeconfig", "", "")
+		cmd.PersistentFlags().String("context", "", "")
+
+		cmd.SetArgs([]string{"set-endpoint", "not-a-url"})
+		err := cmd.Execute()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(ErrInvalidURL))
+	})
+
+	It("rejects URLs with empty host", func() {
+		streams, _, _ := fakeStreams()
+		cmd := NewConfigCmd(streams)
+		cmd.PersistentFlags().String("kubeconfig", "", "")
+		cmd.PersistentFlags().String("context", "", "")
+
+		cmd.SetArgs([]string{"set-endpoint", "https://"})
+		err := cmd.Execute()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(ErrInvalidURL))
+		Expect(err.Error()).To(ContainSubstring("missing host"))
+	})
+
+	It("rejects non-HTTP schemes", func() {
+		streams, _, _ := fakeStreams()
+		cmd := NewConfigCmd(streams)
+		cmd.PersistentFlags().String("kubeconfig", "", "")
+		cmd.PersistentFlags().String("context", "", "")
+
+		cmd.SetArgs([]string{"set-endpoint", "ftp://ols.example.com"})
+		err := cmd.Execute()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(ErrInvalidURL))
+	})
+
+	It("uses --context flag when provided", func() {
+		kubeconfigPath := writeKubeconfig(tmpDir, "default-ctx")
+		streams, out, _ := fakeStreams()
+		cmd := NewConfigCmd(streams)
+		cmd.PersistentFlags().String("kubeconfig", "", "")
+		cmd.PersistentFlags().String("context", "", "")
+
+		origUserConfigDir, hadConfigDir := os.LookupEnv("XDG_CONFIG_HOME")
+		Expect(os.Setenv("XDG_CONFIG_HOME", tmpDir)).To(Succeed())
+		defer func() {
+			if !hadConfigDir {
+				Expect(os.Unsetenv("XDG_CONFIG_HOME")).To(Succeed())
+			} else {
+				Expect(os.Setenv("XDG_CONFIG_HOME", origUserConfigDir)).To(Succeed())
+			}
+		}()
+
+		cmd.SetArgs([]string{"set-endpoint", "https://ols.example.com", "--kubeconfig", kubeconfigPath, "--context", "override-ctx"})
+		Expect(cmd.Execute()).To(Succeed())
+		Expect(out.String()).To(ContainSubstring(`Endpoint set for context "override-ctx"`))
+	})
+
+	It("requires exactly one argument", func() {
+		streams, _, _ := fakeStreams()
+		cmd := NewConfigCmd(streams)
+		cmd.PersistentFlags().String("kubeconfig", "", "")
+		cmd.PersistentFlags().String("context", "", "")
+
+		cmd.SetArgs([]string{"set-endpoint"})
+		err := cmd.Execute()
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/cli/config/kubeconfig.go
+++ b/cli/config/kubeconfig.go
@@ -1,0 +1,21 @@
+package config
+
+import (
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// loadRawKubeConfig loads the raw kubeconfig to resolve context names.
+// This is intentionally minimal — full kubeconfig processing (token extraction,
+// TLS config) lives in cli.LoadKubeConfig.
+func loadRawKubeConfig(kubeconfigPath string) (clientcmdapi.Config, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if kubeconfigPath != "" {
+		loadingRules.ExplicitPath = kubeconfigPath
+	}
+
+	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		loadingRules, &clientcmd.ConfigOverrides{})
+
+	return clientConfig.RawConfig()
+}

--- a/cli/config/persistence.go
+++ b/cli/config/persistence.go
@@ -1,0 +1,136 @@
+// Package config implements per-kubeconfig-context local file storage for the oc-ols CLI.
+package config
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+const (
+	appDirName   = "oc-ols"
+	contextDir   = "contexts"
+	endpointFile = "endpoint"
+
+	dirPermissions  os.FileMode = 0700
+	filePermissions os.FileMode = 0600
+
+	ErrInvalidContextName = "invalid context name"
+	ErrSaveEndpoint       = "failed to save endpoint"
+	ErrLoadEndpoint       = "failed to load endpoint"
+	ErrCreateConfigDir    = "failed to create config directory"
+	ErrConfigDir          = "failed to determine config directory"
+)
+
+// unsafeChars matches any character not in [a-zA-Z0-9._-].
+var unsafeChars = regexp.MustCompile(`[^a-zA-Z0-9._-]`)
+
+// ContextStore manages per-kubeconfig-context file storage under the user's config directory.
+type ContextStore struct {
+	baseDir string
+}
+
+// NewContextStore creates a ContextStore rooted at <UserConfigDir>/oc-ols/contexts.
+func NewContextStore() (*ContextStore, error) {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", ErrConfigDir, err)
+	}
+	return &ContextStore{
+		baseDir: filepath.Join(configDir, appDirName, contextDir),
+	}, nil
+}
+
+// NewContextStoreWithBase creates a ContextStore with a custom base directory (for testing).
+func NewContextStoreWithBase(baseDir string) *ContextStore {
+	return &ContextStore{baseDir: baseDir}
+}
+
+// SanitizeContextName replaces unsafe characters with underscores and rejects
+// empty names and path traversal attempts. When sanitization modifies the name,
+// a short hash of the original is appended to prevent collisions between names
+// that differ only in replaced characters (e.g., "a/b" vs "a:b").
+func SanitizeContextName(name string) (string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" || name == "." || name == ".." {
+		return "", fmt.Errorf("%s: %q", ErrInvalidContextName, name)
+	}
+	sanitized := unsafeChars.ReplaceAllString(name, "_")
+	if sanitized != name {
+		hash := sha256.Sum256([]byte(name))
+		sanitized = fmt.Sprintf("%s_%x", sanitized, hash[:4])
+	}
+	return sanitized, nil
+}
+
+// SaveEndpoint persists an endpoint URL for the given kubeconfig context.
+// Writes are atomic (temp file + rename) to prevent partial writes.
+func (s *ContextStore) SaveEndpoint(contextName string, endpoint string) error {
+	dir, err := s.contextDir(contextName)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(dir, dirPermissions); err != nil {
+		return fmt.Errorf("%s: %w", ErrCreateConfigDir, err)
+	}
+
+	target := filepath.Join(dir, endpointFile)
+
+	tmp, err := os.CreateTemp(dir, endpointFile+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("%s: %w", ErrSaveEndpoint, err)
+	}
+	tmpName := tmp.Name()
+
+	if _, err := tmp.WriteString(endpoint + "\n"); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("%s: %w", ErrSaveEndpoint, err)
+	}
+
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("%s: %w", ErrSaveEndpoint, err)
+	}
+
+	if err := os.Chmod(tmpName, filePermissions); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("%s: %w", ErrSaveEndpoint, err)
+	}
+
+	if err := os.Rename(tmpName, target); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("%s: %w", ErrSaveEndpoint, err)
+	}
+
+	return nil
+}
+
+// LoadEndpoint reads the persisted endpoint URL for the given kubeconfig context.
+// Returns empty string and an error if no endpoint is configured.
+func (s *ContextStore) LoadEndpoint(contextName string) (string, error) {
+	dir, err := s.contextDir(contextName)
+	if err != nil {
+		return "", err
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, endpointFile)) //#nosec G304 -- path derived from user's kubeconfig context name
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", ErrLoadEndpoint, err)
+	}
+
+	return strings.TrimSpace(string(data)), nil
+}
+
+// contextDir returns the storage directory path for a given context name.
+func (s *ContextStore) contextDir(contextName string) (string, error) {
+	sanitized, err := SanitizeContextName(contextName)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(s.baseDir, sanitized), nil
+}

--- a/cli/config/persistence_test.go
+++ b/cli/config/persistence_test.go
@@ -1,0 +1,129 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("SanitizeContextName", func() {
+	DescribeTable("valid context names",
+		func(input, expected string) {
+			result, err := SanitizeContextName(input)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(expected))
+		},
+		Entry("simple name", "my-cluster", "my-cluster"),
+		Entry("name with dots", "api.cluster.example.com", "api.cluster.example.com"),
+		Entry("name with colons", "admin:my-cluster", "admin_my-cluster_7b3dc15f"),
+		Entry("name with slashes", "context/with/slashes", "context_with_slashes_f4581c7c"),
+		Entry("path traversal attempt", "../../etc/passwd", ".._.._etc_passwd_3754d6cb"),
+		Entry("unicode characters", "клáстер", "________6b6c5c25"),
+		Entry("spaces replaced", "my cluster", "my_cluster_f3c5e5c4"),
+		Entry("leading/trailing spaces trimmed", "  my-cluster  ", "my-cluster"),
+	)
+
+	It("produces different keys for names that differ only in replaced characters", func() {
+		result1, err := SanitizeContextName("a/b")
+		Expect(err).NotTo(HaveOccurred())
+		result2, err := SanitizeContextName("a:b")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result1).NotTo(Equal(result2))
+	})
+
+	DescribeTable("invalid context names",
+		func(input string) {
+			_, err := SanitizeContextName(input)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(ErrInvalidContextName))
+		},
+		Entry("empty string", ""),
+		Entry("whitespace only", "   "),
+		Entry("single dot", "."),
+		Entry("double dot", ".."),
+	)
+})
+
+var _ = Describe("ContextStore", func() {
+	var (
+		tmpDir string
+		store  *ContextStore
+	)
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "oc-ols-test-*")
+		Expect(err).NotTo(HaveOccurred())
+		store = NewContextStoreWithBase(tmpDir)
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(tmpDir)).To(Succeed())
+	})
+
+	Describe("SaveEndpoint and LoadEndpoint", func() {
+		It("persists and retrieves an endpoint", func() {
+			Expect(store.SaveEndpoint("my-cluster", "https://ols.example.com")).To(Succeed())
+
+			endpoint, err := store.LoadEndpoint("my-cluster")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(endpoint).To(Equal("https://ols.example.com"))
+		})
+
+		It("overwrites an existing endpoint", func() {
+			Expect(store.SaveEndpoint("my-cluster", "https://old.example.com")).To(Succeed())
+			Expect(store.SaveEndpoint("my-cluster", "https://new.example.com")).To(Succeed())
+
+			endpoint, err := store.LoadEndpoint("my-cluster")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(endpoint).To(Equal("https://new.example.com"))
+		})
+
+		It("isolates endpoints by context name", func() {
+			Expect(store.SaveEndpoint("cluster-a", "https://a.example.com")).To(Succeed())
+			Expect(store.SaveEndpoint("cluster-b", "https://b.example.com")).To(Succeed())
+
+			endpointA, err := store.LoadEndpoint("cluster-a")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(endpointA).To(Equal("https://a.example.com"))
+
+			endpointB, err := store.LoadEndpoint("cluster-b")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(endpointB).To(Equal("https://b.example.com"))
+		})
+
+		It("returns an error when no endpoint is configured", func() {
+			_, err := store.LoadEndpoint("unconfigured-context")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(ErrLoadEndpoint))
+		})
+
+		It("returns an error for invalid context names", func() {
+			err := store.SaveEndpoint("", "https://ols.example.com")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(ErrInvalidContextName))
+
+			_, err = store.LoadEndpoint("")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(ErrInvalidContextName))
+		})
+
+		It("creates directories with restrictive permissions", func() {
+			Expect(store.SaveEndpoint("secure-ctx", "https://ols.example.com")).To(Succeed())
+
+			info, err := os.Stat(filepath.Join(tmpDir, "secure-ctx"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(info.Mode().Perm()).To(Equal(dirPermissions))
+		})
+
+		It("creates endpoint file with restrictive permissions", func() {
+			Expect(store.SaveEndpoint("secure-ctx", "https://ols.example.com")).To(Succeed())
+
+			info, err := os.Stat(filepath.Join(tmpDir, "secure-ctx", endpointFile))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(info.Mode().Perm()).To(Equal(filePermissions))
+		})
+	})
+})

--- a/cli/config/suite_test.go
+++ b/cli/config/suite_test.go
@@ -1,0 +1,13 @@
+package config
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CLI Config Suite")
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -2,10 +2,14 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/openshift/lightspeed-operator/cli/config"
 )
 
 const (
@@ -44,7 +48,44 @@ func NewRootCmd(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd.PersistentFlags().String("ca-cert", "",
 		"Path to CA certificate for TLS verification")
 
+	cmd.PersistentFlags().String("endpoint", "",
+		"OLS service endpoint URL (overrides persisted endpoint)")
+
 	cmd.AddCommand(NewVersionCmd(streams))
+	cmd.AddCommand(config.NewConfigCmd(streams))
 
 	return cmd
+}
+
+// ResolveEndpoint determines the OLS service endpoint using the resolution order:
+// 1. --endpoint flag (highest priority)
+// 2. Persisted endpoint for the current kubeconfig context
+// 3. Error with guidance
+func ResolveEndpoint(cmd *cobra.Command, contextName string) (string, error) {
+	endpoint, err := cmd.Flags().GetString("endpoint")
+	if err != nil {
+		return "", err
+	}
+	if endpoint != "" {
+		return endpoint, nil
+	}
+
+	store, err := config.NewContextStore()
+	if err != nil {
+		return "", err
+	}
+
+	endpoint, err = store.LoadEndpoint(contextName)
+	if err == nil {
+		return endpoint, nil
+	}
+
+	if errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf(
+			"no endpoint configured for context %q. Run: oc ols config set-endpoint <URL>",
+			contextName,
+		)
+	}
+
+	return "", err
 }

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -1,8 +1,12 @@
 package cli
 
 import (
+	"os"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/openshift/lightspeed-operator/cli/config"
 )
 
 var _ = Describe("RootCmd", func() {
@@ -25,9 +29,73 @@ var _ = Describe("RootCmd", func() {
 	It("registers global flags", func() {
 		streams, _, _ := fakeStreams()
 		cmd := NewRootCmd(streams)
-		for _, name := range []string{"kubeconfig", "context", "insecure-skip-tls-verify", "ca-cert"} {
+		for _, name := range []string{"kubeconfig", "context", "insecure-skip-tls-verify", "ca-cert", "endpoint"} {
 			Expect(cmd.PersistentFlags().Lookup(name)).NotTo(BeNil(), "expected persistent flag %q", name)
 		}
+	})
+
+	It("routes the config subcommand", func() {
+		streams, out, _ := fakeStreams()
+		cmd := NewRootCmd(streams)
+		cmd.SetArgs([]string{"config", "--help"})
+		Expect(cmd.Execute()).To(Succeed())
+		Expect(out.String()).To(ContainSubstring("set-endpoint"))
+	})
+
+	Describe("ResolveEndpoint", func() {
+		It("resolves endpoint from --endpoint flag", func() {
+			streams, _, _ := fakeStreams()
+			cmd := NewRootCmd(streams)
+			// Execute help to trigger flag merging, then test resolution
+			cmd.SetArgs([]string{"--endpoint", "https://flag.example.com"})
+			_ = cmd.Execute()
+
+			endpoint, err := ResolveEndpoint(cmd, "any-context")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(endpoint).To(Equal("https://flag.example.com"))
+		})
+
+		It("resolves endpoint from persisted store", func() {
+			tmpDir, err := os.MkdirTemp("", "oc-ols-resolve-test-*")
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { Expect(os.RemoveAll(tmpDir)).To(Succeed()) }()
+
+			// Save endpoint under the path that NewContextStore() will look for:
+			// <XDG_CONFIG_HOME>/oc-ols/contexts/<context-name>/endpoint
+			store := config.NewContextStoreWithBase(tmpDir + "/oc-ols/contexts")
+			Expect(store.SaveEndpoint("test-ctx", "https://persisted.example.com")).To(Succeed())
+
+			origConfigDir, hadConfigDir := os.LookupEnv("XDG_CONFIG_HOME")
+			Expect(os.Setenv("XDG_CONFIG_HOME", tmpDir)).To(Succeed())
+			defer func() {
+				if !hadConfigDir {
+					Expect(os.Unsetenv("XDG_CONFIG_HOME")).To(Succeed())
+				} else {
+					Expect(os.Setenv("XDG_CONFIG_HOME", origConfigDir)).To(Succeed())
+				}
+			}()
+
+			streams, _, _ := fakeStreams()
+			cmd := NewRootCmd(streams)
+			cmd.SetArgs([]string{})
+			_ = cmd.Execute()
+
+			endpoint, err := ResolveEndpoint(cmd, "test-ctx")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(endpoint).To(Equal("https://persisted.example.com"))
+		})
+
+		It("returns guidance error when no endpoint is configured", func() {
+			streams, _, _ := fakeStreams()
+			cmd := NewRootCmd(streams)
+			cmd.SetArgs([]string{})
+			_ = cmd.Execute()
+
+			_, err := ResolveEndpoint(cmd, "unconfigured-ctx")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(`no endpoint configured for context "unconfigured-ctx"`))
+			Expect(err.Error()).To(ContainSubstring("Run: oc ols config set-endpoint <URL>"))
+		})
 	})
 
 	It("dispatches unrecognized args to the default mode stub", func() {


### PR DESCRIPTION
## Description

Implements [OLS-3633](https://redhat.atlassian.net/browse/OLS-3633) — per-kubeconfig-context endpoint persistence and the `oc ols config set-endpoint` command.

**What this adds:**
- `cli/config/persistence.go` — `ContextStore` with `SaveEndpoint`/`LoadEndpoint`, stored under `<UserConfigDir>/oc-ols/contexts/<sanitized-context-name>/`
- `cli/config/endpoint.go` — `config set-endpoint <URL>` subcommand with URL validation (HTTPS required, `--insecure-allow-http` for dev)
- `cli/config/kubeconfig.go` — minimal kubeconfig loading for context name resolution
- `cli/root.go` — `--endpoint` persistent flag, `config` subcommand, `ResolveEndpoint()` (flag > persisted > error with guidance)

**Design decisions:**
- Storage key uses sanitized context name with short SHA-256 hash suffix when sanitization modifies the name (collision-resistant yet human-readable)
- `os.UserConfigDir()` for cross-platform config path (respects `$XDG_CONFIG_HOME` on Linux, `~/Library/Application Support` on macOS)
- HTTPS validated at `set-endpoint` time; persisted endpoints trusted on read; `--endpoint` flag not re-validated (power-user override)
- Atomic writes via `os.CreateTemp` + `os.Rename`; restrictive permissions (`0700` dirs, `0600` files)
- `ResolveEndpoint()` distinguishes file-not-found (shows guidance) from other I/O errors (surfaces actual error)

**Not in scope:** No HTTP client — pure file I/O and Cobra subcommand. `ResolveEndpoint()` is not called yet; the `ask` command ([OLS-3634](https://redhat.atlassian.net/browse/OLS-3634)) will be its first consumer.

**Spec divergence:** The spec originally described SHA-256 hashed storage keys with a `manifest.json`. This PR uses sanitized context names instead for readability — updated in `.ai/spec/how/cli.md`.

Depends on: #1936

## Type of change

- [x] New feature

## Related Tickets & Documents

- Closes [OLS-3633](https://redhat.atlassian.net/browse/OLS-3633)
- Epic: [OLS-1062](https://redhat.atlassian.net/browse/OLS-1062)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

```bash
# Unit tests — 48 Ginkgo specs
go test ./cli/... -v

# Lint
golangci-lint run --config=.golangci.yaml --build-tags "exclude_graphdriver_btrfs,containers_image_openpgp" ./cli/...

# End-to-end: save and verify
oc ols config set-endpoint https://lightspeed.apps.cluster.example.com
cat ~/.config/oc-ols/contexts/<your-context>/endpoint

# Verify HTTPS enforcement
oc ols config set-endpoint http://insecure.example.com  # → rejected
oc ols config set-endpoint http://localhost:8080 --insecure-allow-http  # → accepted

# Verify command tree
oc ols --help  # shows config subcommand and --endpoint flag
oc ols config set-endpoint --help
```

No new dependencies added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI support for configuring API endpoints per Kubernetes context.
  * Added `config set-endpoint` with HTTPS validation and optional HTTP support.
  * Added an `--endpoint` override for immediate endpoint selection.
  * Persisted endpoint settings securely and reused them automatically when no override is provided.
  * Added clear guidance when an endpoint has not been configured.

* **Documentation**
  * Updated CLI documentation to describe endpoint configuration and storage behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->