### PR TITLE
OLS-3973 - Fix ClusterRole RBAC breaking operator informers

### DIFF
--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -932,6 +932,21 @@ spec:
                 - watch
             - apiGroups:
                 - rbac.authorization.k8s.io
+              resources:
+                - clusterrolebindings
+                - clusterroles
+              verbs:
+                - create
+                - list
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - rolebindings
+              verbs:
+                - create
+            - apiGroups:
+                - rbac.authorization.k8s.io
               resourceNames:
                 - lightspeed-agentic-alerts-adapter-agenticruns
                 - lightspeed-app-server-sar-role-binding
@@ -940,17 +955,7 @@ spec:
               verbs:
                 - delete
                 - get
-                - list
                 - update
-                - watch
-            - apiGroups:
-                - rbac.authorization.k8s.io
-              resources:
-                - clusterrolebindings
-                - clusterroles
-                - rolebindings
-              verbs:
-                - create
             - apiGroups:
                 - rbac.authorization.k8s.io
               resourceNames:
@@ -961,9 +966,7 @@ spec:
               verbs:
                 - delete
                 - get
-                - list
                 - update
-                - watch
             - apiGroups:
                 - rbac.authorization.k8s.io
               resourceNames:

--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     console.openshift.io/operator-monitoring-default: "true"
-    createdAt: "2026-08-20T16:46:46Z"
+    createdAt: "2026-08-24T06:57:41Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -940,9 +940,7 @@ spec:
               verbs:
                 - delete
                 - get
-                - list
                 - update
-                - watch
             - apiGroups:
                 - rbac.authorization.k8s.io
               resources:
@@ -951,6 +949,8 @@ spec:
                 - rolebindings
               verbs:
                 - create
+                - list
+                - watch
             - apiGroups:
                 - rbac.authorization.k8s.io
               resourceNames:
@@ -961,9 +961,7 @@ spec:
               verbs:
                 - delete
                 - get
-                - list
                 - update
-                - watch
             - apiGroups:
                 - rbac.authorization.k8s.io
               resourceNames:
@@ -973,9 +971,7 @@ spec:
               verbs:
                 - delete
                 - get
-                - list
                 - update
-                - watch
             - apiGroups:
                 - storage.k8s.io
               resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -175,17 +175,16 @@ rules:
   verbs:
   - delete
   - get
-  - list
   - update
-  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
   - clusterroles
-  - rolebindings
   verbs:
   - create
+  - list
+  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resourceNames:
@@ -196,9 +195,13 @@ rules:
   verbs:
   - delete
   - get
-  - list
   - update
-  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
 - apiGroups:
   - rbac.authorization.k8s.io
   resourceNames:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -175,9 +175,7 @@ rules:
   verbs:
   - delete
   - get
-  - list
   - update
-  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -186,6 +184,8 @@ rules:
   - rolebindings
   verbs:
   - create
+  - list
+  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resourceNames:
@@ -196,9 +196,7 @@ rules:
   verbs:
   - delete
   - get
-  - list
   - update
-  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resourceNames:
@@ -208,9 +206,7 @@ rules:
   verbs:
   - delete
   - get
-  - list
   - update
-  - watch
 - apiGroups:
   - storage.k8s.io
   resources:

--- a/internal/controller/olsconfig_controller.go
+++ b/internal/controller/olsconfig_controller.go
@@ -131,10 +131,11 @@ type OLSConfigReconciler struct {
 // +kubebuilder:rbac:groups=console.openshift.io,resources=consolelinks;consoleexternalloglinks;consoleplugins;consoleplugins/finalizers,verbs=get;create;update;delete
 // Modify console CR to activate console plugin
 // +kubebuilder:rbac:groups=operator.openshift.io,resources=consoles,verbs=watch;list;get;update
-// RBAC: split create (cannot use resourceNames) from get/update/delete/watch (pinned to named resources) (OLS-3886)
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=create
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,resourceNames=lightspeed-app-server-sar-role;lightspeed-agentic-alerts-adapter-agenticruns,verbs=get;list;update;delete;watch
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,resourceNames=lightspeed-app-server-sar-role-binding;lightspeed-agentic-alerts-adapter-agenticruns,verbs=get;list;update;delete;watch
+// RBAC: split create (cannot use resourceNames) from get/update/delete (pinned to named resources) (OLS-3886)
+// list+watch must be unscoped because Owns() sets up a cluster-wide informer that lists all resources of the type
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=create;list;watch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,resourceNames=lightspeed-app-server-sar-role;lightspeed-agentic-alerts-adapter-agenticruns,verbs=get;update;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,resourceNames=lightspeed-app-server-sar-role-binding;lightspeed-agentic-alerts-adapter-agenticruns,verbs=get;update;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=create
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,resourceNames=lightspeed-agentic-alerts-adapter-alertmanager,verbs=get;list;update;delete;watch
 // AgenticRun API for alerts adapter ClusterRole (operator must hold permissions it grants to operands)

--- a/internal/controller/olsconfig_controller.go
+++ b/internal/controller/olsconfig_controller.go
@@ -131,12 +131,13 @@ type OLSConfigReconciler struct {
 // +kubebuilder:rbac:groups=console.openshift.io,resources=consolelinks;consoleexternalloglinks;consoleplugins;consoleplugins/finalizers,verbs=get;create;update;delete
 // Modify console CR to activate console plugin
 // +kubebuilder:rbac:groups=operator.openshift.io,resources=consoles,verbs=watch;list;get;update
-// RBAC: split create (cannot use resourceNames) from get/update/delete/watch (pinned to named resources) (OLS-3886)
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=create
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,resourceNames=lightspeed-app-server-sar-role;lightspeed-agentic-alerts-adapter-agenticruns,verbs=get;list;update;delete;watch
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,resourceNames=lightspeed-app-server-sar-role-binding;lightspeed-agentic-alerts-adapter-agenticruns,verbs=get;list;update;delete;watch
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=create
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,resourceNames=lightspeed-agentic-alerts-adapter-alertmanager,verbs=get;list;update;delete;watch
+// RBAC: split create (cannot use resourceNames) from get/update/delete (pinned to named resources) (OLS-3886)
+// list+watch must be unscoped because Owns() sets up a cluster-wide informer that lists all resources of the type
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=create;list;watch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,resourceNames=lightspeed-app-server-sar-role;lightspeed-agentic-alerts-adapter-agenticruns,verbs=get;update;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,resourceNames=lightspeed-app-server-sar-role-binding;lightspeed-agentic-alerts-adapter-agenticruns,verbs=get;update;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=create;list;watch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,resourceNames=lightspeed-agentic-alerts-adapter-alertmanager,verbs=get;update;delete
 // AgenticRun API for alerts adapter ClusterRole (operator must hold permissions it grants to operands)
 // +kubebuilder:rbac:groups=agentic.openshift.io,resources=agenticruns,verbs=get;list;create
 // Alertmanager API for alerts adapter RoleBinding to monitoring-alertmanager-view (operator must hold permissions it grants)


### PR DESCRIPTION
## Description

[PR #1954](https://github.com/openshift/lightspeed-operator/pull/1954) (`OLS-3886 Tighten ClusterRole RBAC`) scoped `list` and `watch` on `clusterrolebindings` and `clusterroles` to specific `resourceNames`. The security intent was correct, but it broke the operator:

- `olsconfig_controller.go` uses `Owns(&rbacv1.ClusterRole{})` and `Owns(&rbacv1.ClusterRoleBinding{})`, which sets up **cluster-wide informers** via controller-runtime.
- Informers do an unfiltered `list` + `watch` (no resource-name selector exists at the API level).
- Kubernetes RBAC denies the unfiltered `list` because the permission was scoped to `resourceNames`.
- The informer can't sync → **all** caches time out → manager exits → no reconciliation → `lightspeed-app-server` deployment never created.

**Evidence:** [periodic e2e failure](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-lightspeed-service-main-4.21-e2e-ols-cluster-periodics/2090652650604335104/build-log.txt) — controller-manager logs show `clusterrolebindings.rbac.authorization.k8s.io is forbidden` followed by cache sync timeout and manager shutdown.

### Fix

Split read-only verbs (unscoped, required by informers) from mutating verbs (scoped to `resourceNames`, prevents privilege escalation):

- `list` + `watch` → **unscoped** (read-only, not a privilege escalation vector)
- `get` + `update` + `delete` → **scoped to `resourceNames`** (unchanged, still pinned)

### Security posture preserved

- `create` without `resourceNames` — unchanged (Kubernetes ignores `resourceNames` on `create`).
- `list` + `watch` unscoped — read-only, the operator could already read these via its informer before #1954.
- `update` + `delete` + `get` scoped to named resources — unchanged, still pinned to operator-managed resources only.
- RBAC validation tests in `internal/rbac/role_yaml_test.go` — all pass (they check `update`/`delete`/`patch` are pinned to `resourceNames`).

## Type of change

- [x] Bug fix

## Related Tickets & Documents

- Related Issue #1954
- Related failure: periodic-ci-openshift-lightspeed-service-main-4.21-e2e-ols-cluster-periodics #2090652650604335104

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

- `make test` passes — all unit tests including RBAC validation tests.
- `make manifests` regenerates `config/rbac/role.yaml` correctly from updated kubebuilder markers.
- Fix verified by tracing the controller-manager logs from the failing CI run: the `ClusterRoleBinding` informer list call requires unscoped `list`+`watch`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated access permissions for cluster roles and bindings to support reliable resource discovery and monitoring.
  * Limited resource-specific access to the required retrieve, update, and delete operations.
  * Improved permission consistency across cluster-wide and resource-specific operations.
  * No changes to application behavior or user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->