### PR TITLE
OLS-3989 - fix operator-e2e-direct tests

### DIFF
--- a/.tekton/lightspeed-operator-pull-request.yaml
+++ b/.tekton/lightspeed-operator-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
       target_branch == "main" &&
-      (".tekton/lightspeed-operator-pull-request.yaml".pathChanged() || "Dockerfile".pathChanged() || "LICENSE".pathChanged() || "go.*".pathChanged() || "cmd/***".pathChanged() || "api/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged())
+      (".tekton/lightspeed-operator-pull-request.yaml".pathChanged() || "Dockerfile".pathChanged() || "LICENSE".pathChanged() || "go.*".pathChanged() || "cmd/***".pathChanged() || "api/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged() || "hack/install/***".pathChanged())
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: ols

--- a/hack/install/install-operator-direct.sh
+++ b/hack/install/install-operator-direct.sh
@@ -56,6 +56,13 @@ direct_deploy_skip_idms() {
 	local operator_img="$IMG"
 	local kustomize="${localbin}/kustomize"
 	local jqbin="${localbin}/jq"
+	if [[ ! -x "$jqbin" ]]; then
+		jqbin=$(command -v jq 2>/dev/null || true)
+	fi
+	if [[ -z "$jqbin" ]]; then
+		echo "error: jq not found (install jq or run make jq)" >&2
+		exit 1
+	fi
 	local kubectlbin="${KUBECTL:-kubectl}"
 	local yq_cmd
 


### PR DESCRIPTION
## Description

Root cause: hack/install/install-operator-direct.sh:58 hardcodes
  jqbin="${localbin}/jq" (i.e., bin/jq). In Konflux CI, jq is installed
  system-wide via dnf, not downloaded to bin/ by the Makefile. The Makefile's
  make jq target correctly detects system jq and skips the download — but the
  install script ignores system jq and unconditionally uses the bin/ path.

  Failure chain:
  1. image_args::substitute_deployment_patch is called with bin/jq → bin/jq: No 
     such file or directory
  2. The process substitution silently produces no output → the while loop body
     never executes → no image placeholders are substituted (except the operator
     image itself, which uses a separate sed)
  3. Kubernetes deploys a postgres pod with image name
     __REPLACE_LIGHTSPEED_POSTGRESQL__ → InvalidImageName → postgres never
     starts
  4. wait-for-postgres init container on lightspeed-app-server blocks forever →
     deployment timeout → every test that needs the app server fails

 Fix: hack/install/install-operator-direct.sh — fall back to system jq when
  bin/jq doesn't exist (same pattern the function already uses for yq).

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation reliability by using the repository-provided `jq` when available.
  * Added a clear error when `jq` cannot be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->