### PR TITLE
chore: update OLSConfig crd

### DIFF
--- a/config/crd/bases/ols.openshift.io_olsconfigs.yaml
+++ b/config/crd/bases/ols.openshift.io_olsconfigs.yaml
@@ -320,8 +320,11 @@ spec:
                             custom:
                               description: |-
                                 custom is a user-defined TLS security profile. Be extremely careful using a custom
-                                profile as invalid configurations can be catastrophic. An example custom profile
-                                looks like this:
+                                profile as invalid configurations can be catastrophic.
+
+                                The supported groups list for this profile is empty by default.
+
+                                An example custom profile looks like this:
 
                                   minTLSVersion: VersionTLS11
                                   ciphers:
@@ -346,6 +349,46 @@ spec:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
+                                groups:
+                                  description: |-
+                                    groups is an optional, ordered field used to specify the supported groups (formerly known as
+                                    elliptic curves) that are used during the TLS handshake.  The order of the groups represents
+                                    a suggested preference, with the most preferred group first. Note that not all platform
+                                    components honor the ordering: Go-based components use Go's internal preference order and
+                                    treat this list as a filter of allowed groups rather than an ordered preference.
+                                    Operators may remove entries their operands do not support.
+
+                                    When omitted, this means no opinion and the platform is left to choose reasonable defaults which are
+                                    subject to change over time and may be different per platform component depending on the underlying TLS
+                                    libraries they use. If specified, the list must contain at least one and at most 7 groups,
+                                    and each group must be unique.
+
+                                    For example, to use X25519 and secp256r1 (yaml):
+
+                                      groups:
+                                        - X25519
+                                        - secp256r1
+                                  items:
+                                    description: |-
+                                      TLSGroup is a supported group identifier that can be used in TLSProfile.Groups.
+                                      There is a one-to-one mapping between these names and the group IDs defined
+                                      in Go's crypto/tls package based on IANA's "TLS Supported Groups" registry:
+                                      https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8
+                                      Note that X25519MLKEM768 is a post-quantum hybrid group that is not
+                                      FIPS-approved and should be ignored by components running in FIPS mode.
+                                    enum:
+                                    - X25519
+                                    - secp256r1
+                                    - secp384r1
+                                    - secp521r1
+                                    - X25519MLKEM768
+                                    - SecP256r1MLKEM768
+                                    - SecP384r1MLKEM1024
+                                    type: string
+                                  maxItems: 7
+                                  minItems: 1
+                                  type: array
+                                  x-kubernetes-list-type: set
                                 minTLSVersion:
                                   description: |-
                                     minTLSVersion is used to specify the minimal version of the TLS protocol
@@ -366,6 +409,10 @@ spec:
                                 legacy clients and want to remain highly secure while being compatible with
                                 most clients currently in use.
 
+                                The supported groups list includes by default the following groups
+                                in suggested preference order (ordering may not be honored by all implementations):
+                                X25519MLKEM768, X25519, secp256r1, secp384r1.
+
                                 This profile is equivalent to a Custom profile specified as:
                                   minTLSVersion: VersionTLS12
                                   ciphers:
@@ -384,7 +431,9 @@ spec:
                               description: |-
                                 modern is a TLS security profile for use with clients that support TLS 1.3 and
                                 do not need backward compatibility for older clients.
-
+                                The supported groups list includes by default the following groups
+                                in suggested preference order (ordering may not be honored by all implementations):
+                                X25519MLKEM768, X25519, secp256r1, secp384r1.
                                 This profile is equivalent to a Custom profile specified as:
                                   minTLSVersion: VersionTLS13
                                   ciphers:
@@ -397,6 +446,10 @@ spec:
                               description: |-
                                 old is a TLS profile for use when services need to be accessed by very old
                                 clients or libraries and should be used only as a last resort.
+
+                                The supported groups list includes by default the following groups
+                                in suggested preference order (ordering may not be honored by all implementations):
+                                X25519MLKEM768, X25519, secp256r1, secp384r1.
 
                                 This profile is equivalent to a Custom profile specified as:
                                   minTLSVersion: VersionTLS10
@@ -414,11 +467,14 @@ spec:
                                     - ECDHE-RSA-AES128-SHA256
                                     - ECDHE-ECDSA-AES128-SHA
                                     - ECDHE-RSA-AES128-SHA
+                                    - ECDHE-ECDSA-AES256-SHA384
+                                    - ECDHE-RSA-AES256-SHA384
                                     - ECDHE-ECDSA-AES256-SHA
                                     - ECDHE-RSA-AES256-SHA
                                     - AES128-GCM-SHA256
                                     - AES256-GCM-SHA384
                                     - AES128-SHA256
+                                    - AES256-SHA256
                                     - AES128-SHA
                                     - AES256-SHA
                                     - DES-CBC3-SHA
@@ -429,10 +485,16 @@ spec:
                                 type is one of Old, Intermediate, Modern or Custom. Custom provides the
                                 ability to specify individual TLS security profile parameters.
 
-                                The profiles are based on version 5.7 of the Mozilla Server Side TLS
-                                configuration guidelines. The cipher lists consist of the configuration's
-                                "ciphersuites" followed by the Go-specific "ciphers" from the guidelines.
-                                See: https://ssl-config.mozilla.org/guidelines/5.7.json
+                                The cipher and groups lists in these profiles are based on version 5.8 of the
+                                Mozilla Server Side TLS configuration guidelines.
+                                See: https://ssl-config.mozilla.org/guidelines/5.8.json
+
+                                The groups are listed in suggested preference order, with the most preferred group first.
+                                Note that not all platform components honor the ordering: Go-based components use Go's
+                                internal preference order and treat this list as a filter of allowed groups rather than
+                                an ordered preference.
+                                Note that X25519MLKEM768 is a post-quantum hybrid group that is not
+                                FIPS-approved and should be ignored by components running in FIPS mode.
 
                                 The profiles are intent based, so they may change over time as new ciphers are
                                 developed and existing ciphers are found to be insecure. Depending on
@@ -1948,8 +2010,11 @@ spec:
                       custom:
                         description: |-
                           custom is a user-defined TLS security profile. Be extremely careful using a custom
-                          profile as invalid configurations can be catastrophic. An example custom profile
-                          looks like this:
+                          profile as invalid configurations can be catastrophic.
+
+                          The supported groups list for this profile is empty by default.
+
+                          An example custom profile looks like this:
 
                             minTLSVersion: VersionTLS11
                             ciphers:
@@ -1974,6 +2039,46 @@ spec:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
+                          groups:
+                            description: |-
+                              groups is an optional, ordered field used to specify the supported groups (formerly known as
+                              elliptic curves) that are used during the TLS handshake.  The order of the groups represents
+                              a suggested preference, with the most preferred group first. Note that not all platform
+                              components honor the ordering: Go-based components use Go's internal preference order and
+                              treat this list as a filter of allowed groups rather than an ordered preference.
+                              Operators may remove entries their operands do not support.
+
+                              When omitted, this means no opinion and the platform is left to choose reasonable defaults which are
+                              subject to change over time and may be different per platform component depending on the underlying TLS
+                              libraries they use. If specified, the list must contain at least one and at most 7 groups,
+                              and each group must be unique.
+
+                              For example, to use X25519 and secp256r1 (yaml):
+
+                                groups:
+                                  - X25519
+                                  - secp256r1
+                            items:
+                              description: |-
+                                TLSGroup is a supported group identifier that can be used in TLSProfile.Groups.
+                                There is a one-to-one mapping between these names and the group IDs defined
+                                in Go's crypto/tls package based on IANA's "TLS Supported Groups" registry:
+                                https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8
+                                Note that X25519MLKEM768 is a post-quantum hybrid group that is not
+                                FIPS-approved and should be ignored by components running in FIPS mode.
+                              enum:
+                              - X25519
+                              - secp256r1
+                              - secp384r1
+                              - secp521r1
+                              - X25519MLKEM768
+                              - SecP256r1MLKEM768
+                              - SecP384r1MLKEM1024
+                              type: string
+                            maxItems: 7
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: set
                           minTLSVersion:
                             description: |-
                               minTLSVersion is used to specify the minimal version of the TLS protocol
@@ -1994,6 +2099,10 @@ spec:
                           legacy clients and want to remain highly secure while being compatible with
                           most clients currently in use.
 
+                          The supported groups list includes by default the following groups
+                          in suggested preference order (ordering may not be honored by all implementations):
+                          X25519MLKEM768, X25519, secp256r1, secp384r1.
+
                           This profile is equivalent to a Custom profile specified as:
                             minTLSVersion: VersionTLS12
                             ciphers:
@@ -2012,7 +2121,9 @@ spec:
                         description: |-
                           modern is a TLS security profile for use with clients that support TLS 1.3 and
                           do not need backward compatibility for older clients.
-
+                          The supported groups list includes by default the following groups
+                          in suggested preference order (ordering may not be honored by all implementations):
+                          X25519MLKEM768, X25519, secp256r1, secp384r1.
                           This profile is equivalent to a Custom profile specified as:
                             minTLSVersion: VersionTLS13
                             ciphers:
@@ -2025,6 +2136,10 @@ spec:
                         description: |-
                           old is a TLS profile for use when services need to be accessed by very old
                           clients or libraries and should be used only as a last resort.
+
+                          The supported groups list includes by default the following groups
+                          in suggested preference order (ordering may not be honored by all implementations):
+                          X25519MLKEM768, X25519, secp256r1, secp384r1.
 
                           This profile is equivalent to a Custom profile specified as:
                             minTLSVersion: VersionTLS10
@@ -2042,11 +2157,14 @@ spec:
                               - ECDHE-RSA-AES128-SHA256
                               - ECDHE-ECDSA-AES128-SHA
                               - ECDHE-RSA-AES128-SHA
+                              - ECDHE-ECDSA-AES256-SHA384
+                              - ECDHE-RSA-AES256-SHA384
                               - ECDHE-ECDSA-AES256-SHA
                               - ECDHE-RSA-AES256-SHA
                               - AES128-GCM-SHA256
                               - AES256-GCM-SHA384
                               - AES128-SHA256
+                              - AES256-SHA256
                               - AES128-SHA
                               - AES256-SHA
                               - DES-CBC3-SHA
@@ -2057,10 +2175,16 @@ spec:
                           type is one of Old, Intermediate, Modern or Custom. Custom provides the
                           ability to specify individual TLS security profile parameters.
 
-                          The profiles are based on version 5.7 of the Mozilla Server Side TLS
-                          configuration guidelines. The cipher lists consist of the configuration's
-                          "ciphersuites" followed by the Go-specific "ciphers" from the guidelines.
-                          See: https://ssl-config.mozilla.org/guidelines/5.7.json
+                          The cipher and groups lists in these profiles are based on version 5.8 of the
+                          Mozilla Server Side TLS configuration guidelines.
+                          See: https://ssl-config.mozilla.org/guidelines/5.8.json
+
+                          The groups are listed in suggested preference order, with the most preferred group first.
+                          Note that not all platform components honor the ordering: Go-based components use Go's
+                          internal preference order and treat this list as a filter of allowed groups rather than
+                          an ordered preference.
+                          Note that X25519MLKEM768 is a post-quantum hybrid group that is not
+                          FIPS-approved and should be ignored by components running in FIPS mode.
 
                           The profiles are intent based, so they may change over time as new ciphers are
                           developed and existing ciphers are found to be insecure. Depending on


### PR DESCRIPTION
## Description

running `make test` runs controller-gen and updated OLSConfig CRD.

The CRD update adds a groups field to the TLS custom profile — for specifying supported TLS groups (elliptic curves + post-quantum hybrids like X25519MLKEM768). Also updates descriptions for the intermediate and modern profiles to list their default groups. All generated by controller-gen from the openshift/api dependency bumped to 20260818 in the Aug 19 CVE commit.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [x] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added manifest verification to the test workflow.
  * Tests now detect unexpected changes to generated CRDs, RBAC, and API files.
* **Chores**
  * Added a command to regenerate and validate generated manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->