### PR TITLE
OLS-3680 Note ocp-mcp _meta RBAC publishing (RFE)

### DIFF
--- a/.ai/spec/what/ocpmcp.md
+++ b/.ai/spec/what/ocpmcp.md
@@ -75,3 +75,5 @@ Gated by `spec.ols.introspectionEnabled` (default `true` when absent). When fals
 ## Planned Changes
 
 None for the standalone HTTPS cutover itself. Optional agentic auto-injection remains planned (OLS-3594). [PLANNED: OLS-3697] ServiceMonitor for Prometheus scraping of MCP server `/metrics` endpoint via HTTPS.
+
+[PLANNED: OLS-3680] Publish per-tool RBAC in the `tools/list` response `_meta["openshift.io/rbac"]` so agentic execution can derive least-privilege RBAC for MCP tool calls (subresources, generic pass-throughs, manifest-embedded GVKs). Requires an RFE to the OpenShift MCP server (upstream `kubernetes-mcp-server`). The Secret/RBAC deny-list (rule 16) is mirrored consumer-side as a hard deny ceiling on materialized RBAC. See the workspace-level spec `ols/.ai/spec/what/mcp-tool-rbac.md`.


### PR DESCRIPTION
Spec-only change. Adds a Planned Changes entry to `ocpmcp.md`: the shipped `openshift-mcp-server` publishes per-tool RBAC in `tools/list` `_meta["openshift.io/rbac"]` so agentic execution can derive least-privilege RBAC for MCP tool calls. Requires an RFE to upstream `kubernetes-mcp-server`; the Secret/RBAC deny-list is mirrored consumer-side as a hard ceiling. Child of the parent spec openshift/ols#76 (`what/mcp-tool-rbac.md`, [OLS-3680](https://redhat.atlassian.net/browse/OLS-3680)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented a planned enhancement to expose per-tool access-control metadata, including metadata for subresources and manifest-defined resources.
  - Recorded that consumer-side access controls will continue honoring existing Secret and RBAC restrictions as the maximum permitted access.
  - This change describes future compatibility requirements and does not introduce user-facing functionality yet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->