### PR TITLE
OLS-2991 OLS-2992 Add OCP 4.23 and 5.0 release artifact spec

### DIFF
--- a/.ai/spec/README.md
+++ b/.ai/spec/README.md
@@ -46,6 +46,7 @@ AI agents (Claude). Content is optimized for precision and machine consumption o
 | Debug external resource watching | `what/resource-lifecycle.md` + `how/reconciliation.md` |
 | Add metrics or alerts | `what/observability.md` |
 | Understand the OLM bundle (both controllers) | `what/bundle-composition.md` |
+| Add a new OCP version / FBC release pipeline | `how/fbc-release.md` |
 
 ## Cross-Reference
 
@@ -58,6 +59,7 @@ When what/ and how/ file names don't match 1:1, this table maps behavioral specs
 | `console-ui.md`, `agentic-console-ui.md` | `how/deployment-generation.md` -- deployment/service/configmap generation; `how/reconciliation.md` -- ConsolePlugin lifecycle, activation, and cleanup |
 | `crd-api.md` | `how/config-generation.md` -- how CRD fields map to generated configuration |
 | `system-overview.md` | `how/project-structure.md` -- codebase layout, package responsibilities |
+| `bundle-composition.md` | `how/fbc-release.md` -- FBC Application naming, ReleasePlan structure, per-version steps |
 
 The `what/` specs are authoritative for behavior. The `how/` specs are authoritative for implementation. When they conflict, the `what/` spec wins and the `how/` spec should be updated.
 

--- a/.ai/spec/how/fbc-release.md
+++ b/.ai/spec/how/fbc-release.md
@@ -1,0 +1,78 @@
+# FBC Release Process
+
+How OLS operator bundles are published to OCP FBC (File-Based Catalog) indexes via Konflux for each supported OCP version.
+
+## Architecture
+
+Each supported OCP version has its own **FBC Konflux Application** (`ols-fbc-v4-XX` or `ols-fbc-v5-0`). The application holds the FBC fragment that declares the OLS operator entry point in that version's catalog index. ReleasePlan resources in `konflux-release-data` wire each application to the staging and production release pipelines.
+
+The v1 bundle (`1.x` line) is published to OCP 4.x FBC Applications. The v2 bundle (`2.x` line) is published to OCP 5.x FBC Applications via a separate Konflux Application representing the v2 bundle itself.
+
+## Naming Conventions
+
+| Resource | Pattern | Example |
+|---|---|---|
+| FBC Konflux Application | `ols-fbc-v<major>-<minor>` | `ols-fbc-v4-23`, `ols-fbc-v5-0` |
+| Prod ReleasePlan | `ols-fbc-releaseplan-prod-v<major>-<minor>` | `ols-fbc-releaseplan-prod-v4-23` |
+| Staging ReleasePlan | `ols-fbc-releaseplan-staging-v<major>-<minor>` | `ols-fbc-releaseplan-staging-v4-23` |
+| Bundle Konflux Application (v1) | `ols-bundle` | — |
+| Bundle Konflux Application (v2) | `ols-bundle-v2` | — |
+
+## Files in `konflux-release-data`
+
+All ReleasePlan resources for the `crt-nshift-lightspeed-tenant` namespace live under:
+
+```
+tenants-config/cluster/stone-prd-rh01/tenants/crt-nshift-lightspeed-tenant/
+  release-plan-fbc-prod.yaml     # prod ReleasePlan per OCP 4.x version (v1 bundle)
+  release-plan-fbc-staging.yaml  # staging ReleasePlan per OCP 4.x version (v1 bundle)
+  release-plan-bundle.yaml       # bundle-level release (v1)
+```
+
+For OCP 5.x (v2 bundle), analogous files are created in the same directory:
+
+```
+  release-plan-fbc-v2-prod.yaml     # prod ReleasePlan per OCP 5.x version (v2 bundle)
+  release-plan-fbc-v2-staging.yaml  # staging ReleasePlan per OCP 5.x version (v2 bundle)
+  release-plan-bundle-v2.yaml       # bundle-level release (v2)
+```
+
+## Adding a New OCP 4.x Version (e.g., 4.23)
+
+1. **Extend the v1 bundle annotation** in `bundle/metadata/annotations.yaml`:
+   ```
+   com.redhat.openshift.versions: v4.16-v4.23
+   ```
+
+2. **Create the FBC Konflux Application** `ols-fbc-v4-23` in the Konflux UI/API under the `crt-nshift-lightspeed-tenant` namespace.
+
+3. **Add ReleasePlan entries** to `konflux-release-data`:
+   - In `release-plan-fbc-prod.yaml` — add a new `---`-delimited document with:
+     - `name: ols-fbc-releaseplan-prod-v4-23`
+     - `spec.application: ols-fbc-v4-23`
+     - `auto-release: "false"`, admission `ols-fbc-prod-index`
+   - In `release-plan-fbc-staging.yaml` — add the matching document with:
+     - `name: ols-fbc-releaseplan-staging-v4-23`
+     - `auto-release: "true"`, admission `ols-fbc-staging-index`
+
+4. **Open a PR** against `konflux-release-data` with the ReleasePlan additions. The FBC Application creation is a separate Konflux-side step (not a PR to this repo).
+
+## Adding a New OCP 5.x Version (inaugural: 5.0) — [PLANNED: OLS-2992]
+
+OCP 5.0 is the first release using the v2 bundle and requires additional steps:
+
+1. **Create the v2 bundle Konflux Application** (`ols-bundle-v2`) and configure it to build the v2 bundle variant via `hack/update_bundle.sh v2`.
+
+2. **Create the FBC Konflux Application** `ols-fbc-v5-0` in the `crt-nshift-lightspeed-tenant` namespace.
+
+3. **Add ReleasePlan entries** in new files `release-plan-fbc-v2-prod.yaml` and `release-plan-fbc-v2-staging.yaml` following the same per-version document pattern, referencing the v2 bundle admissions.
+
+4. **Add bundle-level ReleasePlan** `release-plan-bundle-v2.yaml` for the v2 bundle image.
+
+5. **Verify the `olm.skipRange`** on the v2 channel head covers `">=1.0.0 <2.0.0"` so a cluster upgrading from OCP 4.x to 5.0 transitions from the v1 to v2 bundle automatically.
+
+## Constraints
+
+- The v1 and v2 bundle Konflux Applications are independent — shared component images are cross-referenced by digest.
+- Staging ReleasePlans set `auto-release: "true"` (triggered on every build); prod ReleasePlans set `auto-release: "false"` (triggered manually per advisory).
+- The `standing-attribution: "true"` label and `target: rhtap-releng-tenant` are required on all FBC ReleasePlans.

--- a/.ai/spec/what/bundle-composition.md
+++ b/.ai/spec/what/bundle-composition.md
@@ -21,7 +21,12 @@ the agentic resources described here.
 1. Both bundles are built from the same source under `bundle/` via selector-driven
    tooling (`hack/update_bundle.sh v1|v2`). The selector chooses the CSV template, the
    image set from `related_images.json`, and the `com.redhat.openshift.versions`
-   annotation. The v1 annotation is upper-bounded to 4.x; the v2 annotation is `>=v5.0`.
+   annotation. The v1 annotation covers `v4.16-v4.22` (current); it must be extended to
+   include each new OCP 4.x minor as it ships — [PLANNED: OLS-2991] to `v4.16-v4.23`.
+   The v2 annotation is `>=v5.0` — [PLANNED: OLS-2992] first release for OCP 5.0.
+   Each new OCP version also requires a matching FBC Konflux Application
+   (`ols-fbc-v4-XX` or `ols-fbc-v5-0`) and ReleasePlan entries in
+   `konflux-release-data`. See `how/fbc-release.md` for the full process.
 2. The **v1 CSV** defines one deployment (the lightspeed-operator controller). The **v2
    CSV** defines two deployments: the lightspeed-operator controller and the
    lightspeed-agentic-operator controller.
@@ -88,3 +93,5 @@ the agentic resources described here.
 |---|---|
 | OLS-3236 | Remove agentic console deployment from agentic-operator CSV (lightspeed-operator now reconciles the plugin and wires `--agentic-console-image` / `--alerts-adapter-image` in its CSV). Productize agentic operand images to SHA-pinned `registry.redhat.io` entries. |
 | OLS-3899 | Split into two version-gated bundles (v1 classic / v2 full). Add `bundles` tags to `related_images.json`, selector-driven `update_bundle.sh v1\|v2`, two CSV templates, v2-only agentic CRDs/RBAC/operands, and 5.x FBC catalogs. Sync agentic RBAC (`agentic-operator-manager-role`, `agentic-run-approver`) from the agentic-operator repo into the v2 bundle. See decision 0037. |
+| OLS-2991 | OCP 4.23 release artifacts — extend v1 bundle annotation to `v4.16-v4.23`; create `ols-fbc-v4-23` Konflux Application; add staging and prod ReleasePlan entries to `konflux-release-data`. |
+| OLS-2992 | OCP 5.0 release artifacts — create v2 bundle Konflux Application; create `ols-fbc-v5-0` FBC Konflux Application; add staging and prod ReleasePlan entries to `konflux-release-data`; inaugural release of the full agentic stack. |


### PR DESCRIPTION
Document the FBC release pipeline process in how/fbc-release.md: FBC Application naming, ReleasePlan structure, per-version steps for 4.x and the inaugural 5.0 v2 bundle release.

Update bundle-composition.md to track current v1 annotation range (v4.16-v4.22) and mark [OLS-2991](https://redhat.atlassian.net/browse/OLS-2991)/OLS-2992 as planned extensions.

## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for publishing OLS operator bundles to OCP File-Based Catalog indexes through Konflux.
  - Documented naming conventions, release configuration, required labels, and per-version setup steps.
  - Clarified bundle version coverage for OCP 4.x and planned OCP 5.0 support.
  - Added cross-references and quick-start links for release pipeline tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->