### PR TITLE
OLS-3450 Update operator specs for credential hot-reload

### DIFF
--- a/.ai/spec/how/config-generation.md
+++ b/.ai/spec/how/config-generation.md
@@ -104,6 +104,7 @@ ols_config:
     alpha: <default 0.8>
     top_k: <default 10>
     threshold: <default 0.01>
+  credential_hot_reload: <credentialHotReload>         # OLS-3450; true when CR flag enabled
   tools_approval:                                    # always present
     approval_type: <default "tool_annotations">
     approval_timeout: <default 600>

--- a/.ai/spec/what/crd-api.md
+++ b/.ai/spec/what/crd-api.md
@@ -277,6 +277,16 @@ Field | JSON key | Go type | Required | Validation
 39. `spec.ols.storage.size` -- `resource.Quantity`, optional. Size of the requested persistent volume.
 40. `spec.ols.storage.class` -- `string`, optional. Storage class name.
 
+#### Credential Hot-Reload (spec.ols.credentialHotReload) [OLS-3450]
+
+40a. `spec.ols.credentialHotReload` -- `bool`, optional. Default: `false`. When `true`:
+  - The operator does **not** annotate LLM credential secrets with `ols.openshift.io/watcher: cluster` (and removes existing annotations). This prevents the watcher from triggering pod restarts on LLM secret `.data` changes.
+  - The operator writes `credential_hot_reload: true` into the generated `olsconfig.yaml`.
+  - The service re-reads LLM credentials from disk on each request (instead of using startup-cached values). On read failure, the last good credential is retained.
+  - A warning log is emitted during reconciliation when the flag is enabled.
+  - Non-LLM secrets (TLS, MCP headers, system) are unaffected — they are always annotated and always trigger restarts.
+  - Changing `credentialsSecretRef.name` in the CR still triggers a standard reconciliation and restart (volume mount change).
+
 #### Boolean/String Fields
 
 41. `spec.ols.byokRAGOnly` -- `bool`, optional. When true, only BYOK RAG sources are used: the operator does not deploy the standalone RHOKP operand, does not write `solr_hybrid` into `olsconfig.yaml`, and does not set `OCP_CLUSTER_VERSION` on the app-server pod.
@@ -504,6 +514,7 @@ Path | Type | Default | Required | Validation | Description
 `spec.ols.storage` | `*Storage` | -- | No | -- | Persistent storage
 `spec.ols.storage.size` | `resource.Quantity` | -- | No | -- | Volume size
 `spec.ols.storage.class` | `string` | -- | No | -- | Storage class
+`spec.ols.credentialHotReload` | `bool` | `false` | No | -- | Opt-in LLM credential hot-reload: skip secret watching/restart, service re-reads per request (OLS-3450)
 `spec.ols.byokRAGOnly` | `bool` | -- | No | -- | Disable operator-managed OKP; BYOK FAISS only
 `spec.ols.querySystemPrompt` | `string` | -- | No | -- | Custom system prompt
 `spec.ols.maxIterations` | `int` | `5` | No | Min=1 | Max agent iterations
@@ -558,6 +569,7 @@ Path | Type | Default | Required | Validation | Description
 
 ## Planned Changes
 
+- [OLS-3450] Added `spec.ols.credentialHotReload` boolean field. When enabled, the operator skips annotating LLM credential secrets (no restart on rotation) and writes `credential_hot_reload: true` into `olsconfig.yaml`. See design spec `docs/superpowers/specs/2026-09-01-credential-hot-reload-design.md`.
 - [PLANNED: OLS-3442] Add `reasoningConfig` field (`map[string]interface{}`) to `ModelParametersSpec`. Freeform map passed through to the service as `reasoning_config` for provider-specific reasoning/thinking parameters. Includes release notes and user-facing documentation for valid keys per provider.
 - [DONE: OLS-3683 / OLS-3684] `spec.agenticOLS` (`sandboxMode`, `agenticSandboxConfig`), appserver-owned client CA Secrets, and handoff ConfigMap (`lightspeed-agentic-configuration`). See `agentic-sandbox-profile.md`.
 - [DONE: OLS-3697] Change `spec.ols.deployment.rhokp` from `ContainerConfig` to `Config`. RHOKP becomes a standalone Deployment with replicas (forced to 1), resources, tolerations, and nodeSelector. See `rhokp.md`.

--- a/.ai/spec/what/resource-lifecycle.md
+++ b/.ai/spec/what/resource-lifecycle.md
@@ -23,6 +23,7 @@ The operator manages two categories of Kubernetes resources: owned resources (cr
 ### Annotation-Based Watching
 
 11. The operator annotates each user-provided external resource with `ols.openshift.io/watcher: cluster` to mark it for watching.
+11a. **Credential hot-reload exception (OLS-3450):** When `spec.ols.credentialHotReload` is `true`, LLM credential secrets (those with source prefix `llm-provider-*`) are excluded from annotation. Instead, `removeSecretAnnotationIfNeeded()` removes the watcher annotation if it was previously set. This prevents the watcher predicate from matching these secrets, so `SecretUpdateHandler` never fires for them. Non-LLM secrets (TLS, MCP headers) are always annotated regardless of the flag.
 12. On each reconciliation, the operator clears the `AnnotatedSecretMapping` and `AnnotatedConfigMapMapping` in `WatcherConfig` and repopulates them from the current CR spec via `ForEachExternalSecret()` and `ForEachExternalConfigMap()`, then annotates any resources that lack the annotation.
 13. The watcher predicate on Update events checks for two conditions: (a) the resource has the `ols.openshift.io/watcher` annotation, or (b) the resource is a configured system resource. Create events are allowed for all resources in the operator namespace (to handle recreated resources that have not been annotated yet). Create events also verify the resource is referenced in the CR before acting. Delete events are always ignored.
 
@@ -62,4 +63,4 @@ Resource lifecycle behavior is not directly user-configurable. External resource
 
 ## Planned Changes
 
-None.
+- [OLS-3450] Credential hot-reload: `removeSecretAnnotationIfNeeded()` added to remove watcher annotations from LLM credential secrets when `credentialHotReload` is enabled. See design spec `docs/superpowers/specs/2026-09-01-credential-hot-reload-design.md`.


### PR DESCRIPTION
Spec-only change for [OLS-3450](https://redhat.atlassian.net/browse/OLS-3450). Updated crd-api.md, resource-lifecycle.md, config-generation.md for credential hot-reload CRD field and annotation skip logic.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support documentation for enabling credential hot-reload through `spec.ols.credentialHotReload`.
  - When enabled, LLM credentials are refreshed per request without restarting pods when secret data changes.
  - Clarified that non-LLM secret updates continue to trigger restarts, while changing the referenced secret still triggers reconciliation.

- **Documentation**
  - Documented the generated configuration setting, resource-watching behavior, and configuration reference details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->