### PR TITLE
OLS-3491: remove AgenticStepInstructions from OLSConfig CRD spec

### DIFF
--- a/.ai/spec/what/crd-api.md
+++ b/.ai/spec/what/crd-api.md
@@ -60,16 +60,11 @@ Field path (relative to `spec.agenticOLS`) | JSON key | Go type | Required | Def
 ---|---|---|---|---|---|---
 `sandboxMode` | `sandboxMode` | `SandboxMode` | No | `bare-pod` | Enum: `bare-pod`, `sandbox-claim` | How the agentic operator provisions sandbox pods
 `agenticSandboxConfig` | `agenticSandboxConfig` | `Config` | No | — | — | Resources, tolerations, nodeSelector for the thin sandbox PodSpec. Replicas ignored.
-`instructions` | `instructions` | `*AgenticStepInstructions` | No | — | — | [PLANNED: OLS-3491] Optional cluster-wide per-step system instructions (analysis / execution / verification / escalation). When set for a step, replaces the product built-in for that step for **new** AgenticRuns (and for escalation, when the escalation step runs). See agentic-operator `sandbox-execution.md`.
+`instructions` | `instructions` | `*AgenticStepInstructions` | No | — | — | ~~[SUPERSEDED]~~ Removed by OLS-3491 redesign. Per-step instructions now live on the `Agent` CR in `agentic.openshift.io`. See design spec `docs/superpowers/specs/2026-09-01-configurable-instructions-design.md`.
 
-#### AgenticStepInstructions Fields [PLANNED: OLS-3491]
+#### AgenticStepInstructions Fields ~~[SUPERSEDED by OLS-3491 redesign]~~
 
-Field path (relative to `spec.agenticOLS.instructions`) | JSON key | Go type | Required | Default | Validation | Description
----|---|---|---|---|---|---
-`analysis` | `analysis` | `string` | No | — | MaxLength=32768 | Cluster default system instructions for the analysis step
-`execution` | `execution` | `string` | No | — | MaxLength=32768 | Cluster default system instructions for the execution step
-`verification` | `verification` | `string` | No | — | MaxLength=32768 | Cluster default system instructions for the verification step
-`escalation` | `escalation` | `string` | No | — | MaxLength=32768 | Cluster default system instructions for the escalation step
+This section is removed. Per-step instructions now live on the `Agent` CR (`agentic.openshift.io`), not on `OLSConfig`. See design spec `docs/superpowers/specs/2026-09-01-configurable-instructions-design.md`.
 
 #### AgenticOLS Behavioral Rules
 
@@ -78,11 +73,7 @@ Field path (relative to `spec.agenticOLS.instructions`) | JSON key | Go type | R
 60. OpenAPI enum validation rejects values other than `bare-pod` and `sandbox-claim`.
 61. `agenticSandboxConfig` overrides default sandbox PodSpec scheduling/resources (requests-only defaults: 500m CPU / 128Mi memory). Replicas are ignored.
 62. Classic operator publishes handoff via appserver-owned client CA Secrets plus `agenticintegration` ConfigMap (`lightspeed-agentic-configuration`). See `agentic-sandbox-profile.md`.
-63. [PLANNED: OLS-3491] `spec.agenticOLS.instructions` is optional. Each step key is independently optional. Omitted or empty keys mean “no cluster default for that step” (agentic-operator falls through to product built-in unless an AgenticRun step override applies).
-64. [PLANNED: OLS-3491] When a step instruction string is set (non-empty), it is a **full replacement** of the built-in system instructions for that step (not an append). Task/request input remains separate (`AgenticRun.spec.request` and step query payloads).
-65. [PLANNED: OLS-3491] Classic operator MUST publish non-empty `instructions.*` values into the handoff ConfigMap (`lightspeed-agentic-configuration`) and delete cleared keys (see `agentic-sandbox-profile.md` rule 11a) so agentic-operator can consume them without importing `ols.openshift.io` types.
-66. [PLANNED: OLS-3491] `instructions` on `AgenticOLSSpec` MUST NOT be used for chat/classic OLS query prompts (`spec.ols.querySystemPrompt` remains the classic override).
-67. [PLANNED: OLS-3491] **Precedence (cross-component):** effective step system instructions resolve as `AgenticRun.spec.<step>.instructions` (creator-supplied or materialized) > `OLSConfig.spec.agenticOLS.instructions.<step>` (via handoff ConfigMap) > product built-in. For analysis / execution / verification, the selected value is **materialized into the AgenticRun spec at create time**; later cluster ConfigMap changes MUST NOT alter an existing run. Escalation has no run field and resolves at **call time** (cluster ConfigMap or built-in). Authoritative materialization rules: agentic-operator `what/crd-api.md` rules 10a–10c.
+63–67. ~~[SUPERSEDED by OLS-3491 redesign]~~ Rules 63–67 removed. Per-step instructions now live on the `Agent` CR in `agentic.openshift.io`, not on `OLSConfig`. The classic operator no longer participates in instruction delivery. See design spec `docs/superpowers/specs/2026-09-01-configurable-instructions-design.md`.
 
 ### LLM Provider Configuration (spec.llm)
 


### PR DESCRIPTION
Spec-only change. Supersedes rules 63-67 in crd-api.md — classic operator no longer participates in instruction delivery. Instructions move to Agent CR in agentic-operator.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the planned `spec.agenticOLS.instructions` field from the CRD API specification.
  * Removed documentation for the associated per-step instruction fields, including analysis, execution, verification, and escalation.
  * Per-step instructions are now specified on the `agentic.openshift.io` `Agent` custom resource rather than delivered through `OLSConfig`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->