### PR TITLE
OLS-3033 Switch openshift-mcp-server image to openshift-mcp-tech-prev…

### DIFF
--- a/.ai/spec/what/ocpmcp.md
+++ b/.ai/spec/what/ocpmcp.md
@@ -69,7 +69,7 @@ Gated by `spec.ols.introspectionEnabled` (default `true` when absent). When fals
 
 1. Multi-replica is allowed; Streamable HTTP is configured for stateless operation upstream.
 2. The MCP ServiceAccount has no cluster RBAC; authorization uses the calling user's token.
-3. Bundle/CSV/related_images updates for digests are a separate release step from the operator cutover PR.
+3. The `openshift-mcp-server` image is shipped by the OCP MCP team from `registry.redhat.io/openshift-mcp-tech-preview/openshift-mcp-server-rhel9`. OLS does not build or release this image. Digest/tag updates track the OCP MCP team's releases; bump `related_images.json` and regenerate the bundle when a new Tech Preview release is available.
 4. Agentic/sandbox reuse of the MCP Service URL is published in the handoff ConfigMap; the MCP client CA Secret is owned by appserver when introspection is enabled — see `agentic-sandbox-profile.md`. Optional auto-injection into agent runs remains deferred (OLS-3594).
 
 ## Planned Changes

--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -1015,8 +1015,8 @@ spec:
                       - --postgres-image=registry.redhat.io/rhel9/postgresql-16@sha256:42f385ac3c9b8913426da7c57e70bc6617cd237aaf697c667f6385a8c0b0118b
                       - --service-image=registry.redhat.io/openshift-lightspeed/lightspeed-service-api-rhel9@sha256:5c6426ec827b469a10a093ded2e9551e5f28d698ff4073ab474bb7d95e1c1694
                       - --console-image=registry.redhat.io/openshift-lightspeed/lightspeed-console-plugin-rhel9@sha256:1077f7f87b7e701e3d719bf4d5af3cbabdf9145dd02569df435dbebf433939fa
-                      - --openshift-mcp-server-image=registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9@sha256:8a8321cc2e00c3f13bf8e433da0fb3c990def939d5c7dec5f3978e9e323fc98b
-                      - --rhokp-image=registry.redhat.io/offline-knowledge-portal/rhokp-rhel9@sha256:f46082f2dc2972582f3b85ed2a563b554d0aba3255ba2f00835e65f4929ae9a9
+                      - --openshift-mcp-server-image=registry.redhat.io/openshift-mcp-tech-preview/openshift-mcp-server-rhel9@sha256:efa0d55626466c588932c0320bee73dd221b1979aafbbaf4b3ad4685aa9f317d
+                      - --rhokp-image=registry.redhat.io/offline-knowledge-portal/rhokp-rhel9@sha256:adbe513585a026c8392e27e7a8f3618d4edb5a90a8ec2bb79914765cb9e929e4
                     command:
                       - /manager
                     env:
@@ -1176,6 +1176,6 @@ spec:
     - name: lightspeed-operator
       image: registry.redhat.io/openshift-lightspeed/lightspeed-rhel9-operator@sha256:ab7701e98d36002ca215a055aaaadd37c11cd50e01193e0306c545e4ab3cfa05
     - name: openshift-mcp-server
-      image: registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9@sha256:8a8321cc2e00c3f13bf8e433da0fb3c990def939d5c7dec5f3978e9e323fc98b
+      image: registry.redhat.io/openshift-mcp-tech-preview/openshift-mcp-server-rhel9@sha256:efa0d55626466c588932c0320bee73dd221b1979aafbbaf4b3ad4685aa9f317d
     - name: rhokp
-      image: registry.redhat.io/offline-knowledge-portal/rhokp-rhel9@sha256:f46082f2dc2972582f3b85ed2a563b554d0aba3255ba2f00835e65f4929ae9a9
+      image: registry.redhat.io/offline-knowledge-portal/rhokp-rhel9@sha256:adbe513585a026c8392e27e7a8f3618d4edb5a90a8ec2bb79914765cb9e929e4

--- a/internal/controller/ocpmcp/assets.go
+++ b/internal/controller/ocpmcp/assets.go
@@ -20,7 +20,7 @@ import (
 
 // configTOML is the openshift-mcp-server runtime config.
 // Denied resources keep Secret (and RBAC) data out of the LLM path; toolsets are pinned
-// so upstream default changes do not affect OLS. Metrics uses in-cluster Thanos/Alertmanager.
+// so upstream default changes do not affect OLS. Observability metrics uses in-cluster Thanos/Alertmanager.
 // read_only = false is required: openshift-mcp-server-rhel9 sets ReadOnly=true in build-time defaults;
 // omitting this leaves only readOnlyHint tools (no resources_create_or_update, etc.).
 const configTOML = `# Denied resources prevent the MCP server from accessing these Kubernetes resource types.
@@ -29,7 +29,7 @@ const configTOML = `# Denied resources prevent the MCP server from accessing the
 # Toolsets are pinned explicitly so upstream default changes do not affect OLS.
 
 read_only = false
-toolsets = ["core", "config", "helm", "metrics"]
+toolsets = ["core", "config", "helm", "observability/metrics"]
 
 [[denied_resources]]
 group = ""
@@ -40,9 +40,9 @@ kind = "Secret"
 group = "rbac.authorization.k8s.io"
 version = "v1"
 
-[toolset_configs.metrics]
+[toolset_configs."observability/metrics"]
 prometheus_url = "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091"
-alertmanager_url = "https://alertmanager-main.openshift-monitoring.svc.cluster.local:9094"
+alertmanager_url = "https://alertmanager-main.openshift-monitoring.svc.cluster.local:9095"
 # Query-safety PromQL checks (not RBAC). "!tsdb" disables TSDB-dependent guardrails that
 # OpenShift Thanos Querier often lacks (/api/v1/status/tsdb); other guardrails stay on.
 # Auth still uses the caller's bearer token forwarded to Thanos/Alertmanager.

--- a/internal/controller/ocpmcp/assets_test.go
+++ b/internal/controller/ocpmcp/assets_test.go
@@ -33,13 +33,14 @@ var _ = Describe("OpenShift MCP Server assets", func() {
 
 		toml := cm.Data[utils.OpenShiftMCPServerConfigFilename]
 		Expect(toml).To(ContainSubstring("read_only = false"))
-		Expect(toml).To(ContainSubstring(`toolsets = ["core", "config", "helm", "metrics"]`))
+		Expect(toml).To(ContainSubstring(`toolsets = ["core", "config", "helm", "observability/metrics"]`))
 		Expect(toml).To(ContainSubstring(`kind = "Secret"`))
 		Expect(toml).To(ContainSubstring(`group = ""`))
 		Expect(toml).To(ContainSubstring(`group = "rbac.authorization.k8s.io"`))
 		Expect(toml).To(ContainSubstring("[[denied_resources]]"))
-		Expect(toml).To(ContainSubstring("thanos-querier.openshift-monitoring"))
-		Expect(toml).To(ContainSubstring("alertmanager-main.openshift-monitoring"))
+		Expect(toml).To(ContainSubstring(`[toolset_configs."observability/metrics"]`))
+		Expect(toml).To(ContainSubstring(`prometheus_url = "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091"`))
+		Expect(toml).To(ContainSubstring(`alertmanager_url = "https://alertmanager-main.openshift-monitoring.svc.cluster.local:9095"`))
 		Expect(toml).To(ContainSubstring(`guardrails = "!tsdb"`))
 		Expect(strings.Count(toml, "[[denied_resources]]")).To(Equal(2))
 	})

--- a/related_images.json
+++ b/related_images.json
@@ -40,16 +40,13 @@
   },
   {
     "name": "openshift-mcp-server",
-    "image": "registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9@sha256:8a8321cc2e00c3f13bf8e433da0fb3c990def939d5c7dec5f3978e9e323fc98b",
-    "revision": "2641eb9bfb35492be42a12fca2da2ade19d33bde",
+    "image": "registry.redhat.io/openshift-mcp-tech-preview/openshift-mcp-server-rhel9@sha256:efa0d55626466c588932c0320bee73dd221b1979aafbbaf4b3ad4685aa9f317d",
     "operator_arg": "openshift-mcp-server-image",
-    "snapshot_component": "openshift-mcp-server",
-    "konflux_prefix": "quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/openshift-mcp-server",
-    "stable_prefix": "registry.redhat.io/openshift-lightspeed/openshift-mcp-server-rhel9"
+    "stable_prefix": "registry.redhat.io/openshift-mcp-tech-preview/openshift-mcp-server-rhel9"
   },
   {
     "name": "rhokp",
-    "image": "registry.redhat.io/offline-knowledge-portal/rhokp-rhel9@sha256:f46082f2dc2972582f3b85ed2a563b554d0aba3255ba2f00835e65f4929ae9a9",
+    "image": "registry.redhat.io/offline-knowledge-portal/rhokp-rhel9@sha256:adbe513585a026c8392e27e7a8f3618d4edb5a90a8ec2bb79914765cb9e929e4",
     "revision": "",
     "operator_arg": "rhokp-image"
   },


### PR DESCRIPTION
…iew catalog

Consume the openshift-mcp-server image from the OCP MCP team's Tech Preview catalog instead of building and releasing it under the OLS Konflux tenant.

- Update related_images.json: point to openshift-mcp-tech-preview registry, remove konflux_prefix/snapshot_component/revision (no longer OLS-built)
- Regenerate bundle CSV with new image reference
- Update ocpmcp.md constraint: note image is owned by OCP MCP team

## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated monitoring guidance to reflect ServiceMonitor support, including server-TLS-only scraping, 30-second intervals, and Phase 2 reconciliation.
  - Clarified release requirements for Tech Preview images and related metadata.
  - Renumbered the finalizer item and removed the planned ServiceMonitor entry.
- **Improvements**
  - Updated the configured metrics toolset to use the `observability/metrics` identifier.
  - Refreshed OpenShift MCP and RHOKP image references for deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->