### PR TITLE
OLS-2190: require username and version for on-prem watsonx secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,28 @@ IMG="docker.io/username/ols-operator:0.10" make deploy
 2. Create a secret containing the API Key for Watsonx, OpenAI, Azure OpenAI. The key for API key is `apitoken`.
 
 > [!TIP]
-> Watsonx example
+> Watsonx (IBM Cloud) example. Only `apitoken` is required.
 
 ```yaml
 apiVersion: v1
 data:
   apitoken: <base64 encoded API Key>
+kind: Secret
+metadata:
+  name: watsonx-api-keys
+  namespace: openshift-lightspeed
+type: Opaque
+```
+
+> [!TIP]
+> Watsonx on Cloud Pak for Data (on-prem). Same secret as IBM Cloud, plus `username` and `version`. `instance_id` is optional.
+
+```yaml
+apiVersion: v1
+data:
+  apitoken: <base64 encoded API Key>
+  username: <base64 encoded CP4D username>
+  version: <base64 encoded CP4D version, for example 5.1>
 kind: Secret
 metadata:
   name: watsonx-api-keys

--- a/internal/controller/utils/constants.go
+++ b/internal/controller/utils/constants.go
@@ -142,6 +142,16 @@ const (
 	GoogleVertexAnthropicType = "google_vertex_anthropic"
 	// BedrockType is the name of the AWS Bedrock provider type
 	BedrockType = "bedrock"
+	// WatsonxType is the name of the IBM watsonx provider type
+	WatsonxType = "watsonx"
+	// WatsonxUsernameKey is the secret key for Cloud Pak for Data username (OLS-2190)
+	WatsonxUsernameKey = "username"
+	// WatsonxVersionKey is the secret key for Cloud Pak for Data version (OLS-2849)
+	WatsonxVersionKey = "version"
+	// WatsonxInstanceIDKey is the optional secret key for Cloud Pak for Data instance_id
+	WatsonxInstanceIDKey = "instance_id"
+	// IBMCloudWatsonxHostSuffix is the hostname suffix for IBM Cloud watsonx SaaS
+	IBMCloudWatsonxHostSuffix = "ml.cloud.ibm.com"
 	// DeploymentInProgress message
 	DeploymentInProgress = "In Progress"
 	// OLSSystemPromptFileName is the filename for the system prompt

--- a/internal/controller/utils/test_fixtures.go
+++ b/internal/controller/utils/test_fixtures.go
@@ -198,6 +198,16 @@ func WithBedrockProvider(cr *olsv1alpha1.OLSConfig) *olsv1alpha1.OLSConfig {
 	return cr
 }
 
+// WithWatsonxProvider configures the first LLM provider as IBM watsonx.
+// URL decides IBM Cloud vs Cloud Pak for Data credential requirements.
+func WithWatsonxProvider(cr *olsv1alpha1.OLSConfig, watsonxURL string) *olsv1alpha1.OLSConfig {
+	cr.Spec.LLMConfig.Providers[0].Name = "watsonx"
+	cr.Spec.LLMConfig.Providers[0].Type = WatsonxType
+	cr.Spec.LLMConfig.Providers[0].URL = watsonxURL
+	cr.Spec.LLMConfig.Providers[0].WatsonProjectID = "01234567-89ab-cdef-0123-456789abcdef"
+	return cr
+}
+
 // ========================================
 // Kubernetes Resource Generators
 // ========================================

--- a/internal/controller/utils/utils.go
+++ b/internal/controller/utils/utils.go
@@ -23,6 +23,7 @@ import (
 	"encoding/hex"
 	"encoding/pem"
 	"fmt"
+	"net/url"
 	"os"
 	"regexp"
 	"strings"
@@ -598,11 +599,27 @@ func GetCAFromSecret(rclient client.Client, ctx context.Context, namespace, secr
 	return string(caCert), nil
 }
 
+// IsIBMCloudWatsonxURL reports whether url is IBM Cloud watsonx SaaS.
+// Empty URL is treated as IBM Cloud because the service default is
+// https://us-south.ml.cloud.ibm.com.
+func IsIBMCloudWatsonxURL(rawURL string) bool {
+	if strings.TrimSpace(rawURL) == "" {
+		return true
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Hostname() == "" {
+		return false
+	}
+	host := strings.ToLower(parsed.Hostname())
+	return host == IBMCloudWatsonxHostSuffix || strings.HasSuffix(host, "."+IBMCloudWatsonxHostSuffix)
+}
+
 // ValidateLLMCredentials validates that all LLM provider credentials are present and usable.
 // For each provider it requires credentialsSecretRef, loads the secret, then checks Data keys:
 // Azure OpenAI accepts the default credential key or client_id/tenant_id/client_secret;
 // Google Vertex (and Anthropic) use credentialKey when set, otherwise the default key;
 // Bedrock accepts either the default credential key (Bearer token) or AWS IAM keys;
+// watsonx requires apitoken; on-prem Cloud Pak for Data URLs also require username and version;
 // all other supported types require the default credential key
 func ValidateLLMCredentials(r reconciler.Reconciler, ctx context.Context, cr *olsv1alpha1.OLSConfig) error {
 	for _, provider := range cr.Spec.LLMConfig.Providers {
@@ -669,6 +686,26 @@ func ValidateLLMCredentials(r reconciler.Reconciler, ctx context.Context, cr *ol
 				BedrockAccessKeyIDKey,
 				BedrockSecretAccessKeyKey,
 			)
+		} else if provider.Type == WatsonxType {
+			if _, ok := secret.Data[DefaultCredentialKey]; !ok {
+				return fmt.Errorf("LLM provider %s credential secret %s missing key '%s'", provider.Name, provider.CredentialsSecretRef.Name, DefaultCredentialKey)
+			}
+			// IBM Cloud watsonx keeps working with apitoken only. On-prem
+			// Cloud Pak for Data also needs username and version (OLS-2190, OLS-2849).
+			if !IsIBMCloudWatsonxURL(provider.URL) {
+				for _, key := range []string{WatsonxUsernameKey, WatsonxVersionKey} {
+					val, ok := secret.Data[key]
+					if !ok || strings.TrimSpace(string(val)) == "" {
+						return fmt.Errorf(
+							"LLM provider %s credential secret %s missing key '%s' (required for on-prem Cloud Pak for Data watsonx; IBM Cloud watsonx only needs '%s')",
+							provider.Name,
+							provider.CredentialsSecretRef.Name,
+							key,
+							DefaultCredentialKey,
+						)
+					}
+				}
+			}
 		} else {
 			// Standard providers: must contain the default credential key
 			if _, ok := secret.Data[DefaultCredentialKey]; !ok {

--- a/internal/controller/utils/utils_misc_test.go
+++ b/internal/controller/utils/utils_misc_test.go
@@ -1098,6 +1098,114 @@ cNHlzbRSivTDuHmXJdCYIdd8cnH6EbPm3zNg0jU5Au6OrvDZYifP+DtuiLmJct4=
 			Expect(err.Error()).To(ContainSubstring("aws_access_key_id"))
 		})
 
+		It("should accept IBM Cloud watsonx secret with apitoken only", func() {
+			testSecret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-watsonx-ibm-cloud-secret",
+					Namespace: OLSNamespaceDefault,
+				},
+				Data: map[string][]byte{
+					DefaultCredentialKey: []byte("ibm-cloud-token"),
+				},
+			}
+			err := k8sClient.Create(testCtx, testSecret)
+			Expect(err).NotTo(HaveOccurred())
+
+			testCR := WithWatsonxProvider(GetDefaultOLSConfigCR(), "https://us-south.ml.cloud.ibm.com")
+			testCR.Spec.LLMConfig.Providers[0].CredentialsSecretRef.Name = "test-watsonx-ibm-cloud-secret"
+
+			err = ValidateLLMCredentials(testReconciler, testCtx, testCR)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should accept IBM Cloud watsonx with empty URL (service default)", func() {
+			testSecret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-watsonx-default-url-secret",
+					Namespace: OLSNamespaceDefault,
+				},
+				Data: map[string][]byte{
+					DefaultCredentialKey: []byte("ibm-cloud-token"),
+				},
+			}
+			err := k8sClient.Create(testCtx, testSecret)
+			Expect(err).NotTo(HaveOccurred())
+
+			testCR := WithWatsonxProvider(GetDefaultOLSConfigCR(), "")
+			testCR.Spec.LLMConfig.Providers[0].CredentialsSecretRef.Name = "test-watsonx-default-url-secret"
+
+			err = ValidateLLMCredentials(testReconciler, testCtx, testCR)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should accept Cloud Pak for Data watsonx secret with username and version", func() {
+			testSecret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-watsonx-cpd-secret",
+					Namespace: OLSNamespaceDefault,
+				},
+				Data: map[string][]byte{
+					DefaultCredentialKey: []byte("cpd-token"),
+					WatsonxUsernameKey:   []byte("cpd-user"),
+					WatsonxVersionKey:    []byte("5.1"),
+				},
+			}
+			err := k8sClient.Create(testCtx, testSecret)
+			Expect(err).NotTo(HaveOccurred())
+
+			testCR := WithWatsonxProvider(GetDefaultOLSConfigCR(), "https://cpd-instance.apps.example.com")
+			testCR.Spec.LLMConfig.Providers[0].CredentialsSecretRef.Name = "test-watsonx-cpd-secret"
+
+			err = ValidateLLMCredentials(testReconciler, testCtx, testCR)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should reject Cloud Pak for Data watsonx secret missing username", func() {
+			testSecret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-watsonx-cpd-no-user-secret",
+					Namespace: OLSNamespaceDefault,
+				},
+				Data: map[string][]byte{
+					DefaultCredentialKey: []byte("cpd-token"),
+					WatsonxVersionKey:    []byte("5.1"),
+				},
+			}
+			err := k8sClient.Create(testCtx, testSecret)
+			Expect(err).NotTo(HaveOccurred())
+
+			testCR := WithWatsonxProvider(GetDefaultOLSConfigCR(), "https://cpd-instance.apps.example.com")
+			testCR.Spec.LLMConfig.Providers[0].CredentialsSecretRef.Name = "test-watsonx-cpd-no-user-secret"
+
+			err = ValidateLLMCredentials(testReconciler, testCtx, testCR)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("missing key 'username'"))
+			Expect(err.Error()).To(ContainSubstring("Cloud Pak for Data"))
+		})
+
+		It("should reject Cloud Pak for Data watsonx secret missing version", func() {
+			testSecret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-watsonx-cpd-no-version-secret",
+					Namespace: OLSNamespaceDefault,
+				},
+				Data: map[string][]byte{
+					DefaultCredentialKey: []byte("cpd-token"),
+					WatsonxUsernameKey:   []byte("cpd-user"),
+				},
+			}
+			err := k8sClient.Create(testCtx, testSecret)
+			Expect(err).NotTo(HaveOccurred())
+
+			testCR := WithWatsonxProvider(GetDefaultOLSConfigCR(), "https://cpd-instance.apps.example.com")
+			testCR.Spec.LLMConfig.Providers[0].CredentialsSecretRef.Name = "test-watsonx-cpd-no-version-secret"
+
+			err = ValidateLLMCredentials(testReconciler, testCtx, testCR)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("missing key 'version'"))
+			Expect(err.Error()).To(ContainSubstring("Cloud Pak for Data"))
+		})
+
 	})
 })
 


### PR DESCRIPTION
[OLS-2190](https://redhat.atlassian.net/browse/OLS-2190). Also OLS-2849.

IBM Cloud watsonx stays as it is: secret key `apitoken`. Empty URL is treated as IBM Cloud because the service default is `https://us-south.ml.cloud.ibm.com`.

If the provider URL is not `*.ml.cloud.ibm.com`, this is Cloud Pak for Data. Then the same secret also needs `username` and `version`. `instance_id` is optional. The operator already mounts the whole secret, so those keys are already on disk. We just start requiring them instead of letting the app die on `WATSONX_USERNAME` and then on version.

Do not tell people to set env vars on the app Deployment. We will revert that.

Service PR: https://github.com/openshift/lightspeed-service/pull/3081