### PR TITLE
OLS-3548 Regenerate bundle for temperatureSupported

### DIFF
--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -177,6 +177,9 @@ spec:
           - description: Max tokens for response. The default is 2048 tokens.
             displayName: Max Tokens For Response
             path: llm.providers[0].models[0].parameters.maxTokensForResponse
+          - description: Whether the model accepts the temperature parameter. Leave unset for models that support it; set to false for models that reject it (e.g. claude-sonnet-5). When unset, the service default (true) applies.
+            displayName: Temperature Supported
+            path: llm.providers[0].models[0].parameters.temperatureSupported
           - description: Ratio of context window size allocated for tool token budget. Must be between 0.1 and 0.5. The default is 0.5.
             displayName: Tool Budget Ratio
             path: llm.providers[0].models[0].parameters.toolBudgetRatio

--- a/bundle/manifests/ols.openshift.io_olsconfigs.yaml
+++ b/bundle/manifests/ols.openshift.io_olsconfigs.yaml
@@ -289,6 +289,12 @@ spec:
                                     description: Max tokens for response. The default
                                       is 2048 tokens.
                                     type: integer
+                                  temperatureSupported:
+                                    description: |-
+                                      Whether the model accepts the temperature parameter. Leave unset for models
+                                      that support it; set to false for models that reject it (e.g. claude-sonnet-5).
+                                      When unset, the service default (true) applies.
+                                    type: boolean
                                   toolBudgetRatio:
                                     default: 0.5
                                     description: Ratio of context window size allocated


### PR DESCRIPTION
Depends on #1993 and should be merged after it.

This PR contains only the generated bundle manifest updates for temperatureSupported, split out so #1993 can run/pass the operator tests first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the model temperature support setting.
  * Clarified that leaving the setting unset defaults to supported, while disabling it applies to models that reject temperature parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->