### PR TITLE
OLS-4160 Bump BUNDLE_TAG and CSV to 1.1.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ IMAGE_TAG_BASE ?= quay.io/openshift-lightspeed/lightspeed-operator
 
 # BUNDLE_TAG defines the version of the bundle.
 # You can use it as an arg. (E.g make bundle BUNDLE_TAG=0.0.1)
-BUNDLE_TAG ?= 1.1.3
+BUNDLE_TAG ?= 1.1.4
 
 # set the base image for docker files
 # You can use it as an arg.  (E.g make bundle BASE_IMG=registry.redhat.io/ubi9/ubi-minimal)

--- a/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lightspeed-operator.clusterserviceversion.yaml
@@ -55,7 +55,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.36.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/openshift/lightspeed-operator
-  name: lightspeed-operator.v1.1.3
+  name: lightspeed-operator.v1.1.4
   namespace: openshift-lightspeed
 spec:
   apiservicedefinitions: {}
@@ -1169,7 +1169,7 @@ spec:
   provider:
     name: Red Hat, Inc
     url: https://github.com/openshift/lightspeed-service
-  version: 1.1.3
+  version: 1.1.4
   relatedImages:
     - name: lightspeed-to-dataverse-exporter
       image: registry.redhat.io/lightspeed-core/dataverse-exporter-rhel9@sha256:1c7ffaead23adfb1dc6bd3adfe75c80f284d6d31f13ca427d754703c78514cb2


### PR DESCRIPTION
The 1.1.4 bump only updated the generated CSV and bundle.Dockerfile labels but left BUNDLE_TAG at 1.1.3 in the Makefile. hack/update_bundle.sh regenerates the CSV from $(BUNDLE_TAG), so the snapshot-sync bot reverted the CSV to 1.1.3 (commit e2f848e6). Bump BUNDLE_TAG so regenerations produce 1.1.4, and restore the CSV name/version to 1.1.4.

## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the operator bundle version from 1.1.3 to 1.1.4.
  * Updated the published bundle metadata to reflect version 1.1.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->