### PR TITLE
OLS-3635: Add troubleshoot command, refactor shared query logic

### DIFF
--- a/.ai/spec/how/cli.md
+++ b/.ai/spec/how/cli.md
@@ -18,13 +18,14 @@ Audience: AI agents. This document describes **code layout, client wiring, and I
 | `root.go` | — | `NewRootCmd(streams)` — registers subcommands, default mode dispatching, global flags |
 | `version.go` | Package var `Version` (default `dev`) | `NewVersionCmd(streams)` |
 | `kubeconfig.go` | `KubeConfig` | `LoadKubeConfig(kubeconfigPath, contextName, insecureSkipTLS, caCertPath)` — bearer token extraction, TLS config |
-| `ask.go` | `AskOptions` | `NewAskCmd`, `Complete`, `Validate`, `Run` — streams query in `ask` mode |
-| `troubleshoot.go` | `TroubleshootOptions` | `NewTroubleshootCmd`, `Complete`, `Validate`, `Run` — streams query in `troubleshooting` mode |
+| `query.go` | `commandOptions` | `complete`, `validate`, `queryRun` — shared options, validation, and streaming query logic |
+| `ask.go` | — | `NewAskCmd` — thin command wiring, delegates to `queryRun` with `mode: "ask"` |
+| `troubleshoot.go` | — | `NewTroubleshootCmd` — thin command wiring, delegates to `queryRun` with `mode: "troubleshooting"` |
 | `streaming.go` | `SSEClient` | `NewSSEClient`, `StreamQuery` — shared HTTP + SSE streaming logic |
 | `attachments.go` | — | `ReadAttachments(paths)` — reads files, builds attachment array |
 | `render.go` | — | `RenderMarkdown(text)` — terminal markdown rendering via glamour |
 
-*Implemented: `root.go`, `version.go`, `kubeconfig.go` (OLS-3632); `config/endpoint.go`, `config/persistence.go`, `config/kubeconfig.go` (OLS-3633). Remaining files are planned.*
+*Implemented: `root.go`, `version.go`, `kubeconfig.go` (OLS-3632); `config/endpoint.go`, `config/persistence.go`, `config/kubeconfig.go` (OLS-3633); `ask.go`, `streaming.go`, `types.go`, `query.go` (OLS-3634); `troubleshoot.go` (OLS-3635). Remaining files are planned.*
 
 ---
 

--- a/cli/ask.go
+++ b/cli/ask.go
@@ -1,13 +1,6 @@
 package cli
 
 import (
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"net/url"
-	"strings"
-
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
@@ -20,203 +13,27 @@ const (
 	ErrMissingEnd       = "stream ended without end event"
 )
 
-// AskOptions holds the configuration for the ask command.
-type AskOptions struct {
-	streams           genericclioptions.IOStreams
-	query             string
-	endpoint          string
-	kubeConfig        *KubeConfig
-	mode              string
-	insecureAllowHTTP bool
-
-	// conversationID is extracted from the start event during Run.
-	// Available after Run completes for conversation persistence (OLS-3636).
-	conversationID string
-
-	// capturedEvents accumulates non-token, non-end events (start, reasoning,
-	// tool_call, tool_result) during Run. Not displayed in default mode but
-	// available for --output json (OLS-3639).
-	capturedEvents []SSEEvent
-}
-
 // NewAskCmd creates the "ask" subcommand that sends a question to OLS
 // and streams back the response.
 func NewAskCmd(streams genericclioptions.IOStreams) *cobra.Command {
-	o := &AskOptions{
-		streams: streams,
-		mode:    "ask",
-	}
+	o := &commandOptions{streams: streams}
 
 	cmd := &cobra.Command{
 		Use:   "ask [question]",
 		Short: "Ask OpenShift Lightspeed a question",
 		Long:  "Send a question to OpenShift Lightspeed and stream the response.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := o.Complete(cmd, args); err != nil {
+			if err := o.complete(cmd, args); err != nil {
 				return err
 			}
-			if err := o.Validate(); err != nil {
+			if err := o.validate(); err != nil {
 				return err
 			}
-			return o.Run(cmd)
+			return queryRun(cmd, o, "ask")
 		},
 		Args:         cobra.ArbitraryArgs,
 		SilenceUsage: true,
 	}
 
 	return cmd
-}
-
-// Complete resolves the query string, kubeconfig, and endpoint.
-func (o *AskOptions) Complete(cmd *cobra.Command, args []string) error {
-	o.query = strings.Join(args, " ")
-
-	kubeconfigPath, _ := cmd.Flags().GetString("kubeconfig")
-	contextName, _ := cmd.Flags().GetString("context")
-	insecureSkipTLS, _ := cmd.Flags().GetBool("insecure-skip-tls-verify")
-	caCertPath, _ := cmd.Flags().GetString("ca-cert")
-	insecureAllowHTTP, _ := cmd.Flags().GetBool("insecure-allow-http")
-
-	kc, err := LoadKubeConfig(kubeconfigPath, contextName, insecureSkipTLS, caCertPath)
-	if err != nil {
-		return err
-	}
-	o.kubeConfig = kc
-	o.insecureAllowHTTP = insecureAllowHTTP
-
-	endpoint, err := ResolveEndpoint(cmd, kc.ContextName)
-	if err != nil {
-		return err
-	}
-	o.endpoint = endpoint
-
-	return nil
-}
-
-// Validate checks that required fields are populated.
-func (o *AskOptions) Validate() error {
-	if strings.TrimSpace(o.query) == "" {
-		return fmt.Errorf("%s: provide a question as arguments", ErrQueryEmpty)
-	}
-	if o.endpoint == "" {
-		return errors.New(ErrNoEndpoint)
-	}
-	// Reject cleartext HTTP to prevent sending bearer token unencrypted.
-	parsed, err := url.Parse(o.endpoint)
-	if err != nil {
-		return fmt.Errorf("invalid endpoint URL: %w", err)
-	}
-	if parsed.Scheme == "http" && !o.insecureAllowHTTP {
-		return fmt.Errorf("cleartext HTTP endpoint %q is not allowed: bearer token would be sent unencrypted. Use https:// or reconfigure with: oc ols config set-endpoint", o.endpoint)
-	}
-	return nil
-}
-
-// Run executes the ask command: sends the query via SSE and streams
-// token data to stdout. Referenced documents from the end event are
-// printed to stdout along with the response.
-func (o *AskOptions) Run(cmd *cobra.Command) error {
-	client := NewSSEClient(o.endpoint, o.kubeConfig.BearerToken, o.kubeConfig.TLSConfig)
-
-	req := LLMRequest{
-		Query:     o.query,
-		Mode:      o.mode,
-		MediaType: "application/json",
-	}
-
-	ctx := cmd.Context()
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	events, errc, err := client.StreamQuery(ctx, req)
-	if err != nil {
-		return err
-	}
-
-	var endData *EndEventData
-	var hasTokens bool
-	var endParseErr error
-	o.capturedEvents = nil
-
-	for ev := range events {
-		switch ev.Type {
-		case EventToken:
-			var td TokenEventData
-			if err := json.Unmarshal([]byte(ev.Data), &td); err != nil {
-				// If token data isn't JSON, use raw string as fallback
-				td.Token = ev.Data
-			}
-			hasTokens = true
-			if _, err := fmt.Fprint(o.streams.Out, td.Token); err != nil {
-				return fmt.Errorf("%s: %w", ErrWriteOutput, err)
-			}
-		case EventStart:
-			// Extract conversation_id for persistence (OLS-3636).
-			var sd StartEventData
-			if err := json.Unmarshal([]byte(ev.Data), &sd); err == nil {
-				o.conversationID = sd.ConversationID
-			}
-			o.capturedEvents = append(o.capturedEvents, ev)
-		case EventEnd:
-			var ed EndEventData
-			if err := json.Unmarshal([]byte(ev.Data), &ed); err != nil {
-				endParseErr = err
-			} else {
-				endData = &ed
-			}
-		case EventReasoning, EventToolCall, EventToolResult:
-			// Captured but not displayed in default mode.
-			// Available via o.capturedEvents for --output json (OLS-3639).
-			o.capturedEvents = append(o.capturedEvents, ev)
-		default:
-			// Unknown event types are silently ignored.
-		}
-	}
-
-	// Check for stream-level errors
-	if streamErr := <-errc; streamErr != nil {
-		if _, err := fmt.Fprintf(o.streams.ErrOut, "Warning: %s\n", ErrStreamIncomplete); err != nil {
-			return fmt.Errorf("%s: %w", ErrWriteOutput, err)
-		}
-		return streamErr
-	}
-
-	// Print trailing newline only if tokens were emitted
-	if hasTokens {
-		if _, err := fmt.Fprintln(o.streams.Out); err != nil {
-			return fmt.Errorf("%s: %w", ErrWriteOutput, err)
-		}
-	}
-
-	// Malformed or missing end event means the stream was not fully valid
-	if endParseErr != nil {
-		if _, err := fmt.Fprintf(o.streams.ErrOut, "Warning: %s: %v\n", ErrMalformedEnd, endParseErr); err != nil {
-			return fmt.Errorf("%s: %w", ErrWriteOutput, err)
-		}
-		return fmt.Errorf("%s: %w", ErrMalformedEnd, endParseErr)
-	}
-
-	if endData == nil {
-		if _, err := fmt.Fprintf(o.streams.ErrOut, "Warning: %s\n", ErrStreamIncomplete); err != nil {
-			return fmt.Errorf("%s: %w", ErrWriteOutput, err)
-		}
-		return errors.New(ErrMissingEnd)
-	}
-
-	// Display referenced documents on stdout
-	if endData != nil && len(endData.ReferencedDocuments) > 0 {
-		if _, err := fmt.Fprintf(o.streams.Out, "\nReferences:\n"); err != nil {
-			return fmt.Errorf("%s: %w", ErrWriteOutput, err)
-		}
-		for _, doc := range endData.ReferencedDocuments {
-			if _, err := fmt.Fprintf(o.streams.Out, "  - %s: %s\n", doc.DocTitle, doc.DocURL); err != nil {
-				return fmt.Errorf("%s: %w", ErrWriteOutput, err)
-			}
-		}
-	}
-
-	return nil
 }

--- a/cli/ask_test.go
+++ b/cli/ask_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 var _ = Describe("AskCmd", func() {
-	// sseServer creates a test HTTP server that returns a canned SSE response.
 	sseServer := func(sseBody string) *httptest.Server {
 		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "text/event-stream")
@@ -19,7 +18,6 @@ var _ = Describe("AskCmd", func() {
 		}))
 	}
 
-	// buildEndEvent builds an end event payload matching the real server format.
 	buildEndEvent := func(docs []ReferencedDocument) string {
 		payload := map[string]interface{}{
 			"referenced_documents": docs,
@@ -31,7 +29,7 @@ var _ = Describe("AskCmd", func() {
 		return sseEndEvent(payload)
 	}
 
-	Describe("Run", func() {
+	Describe("queryRun with ask mode", func() {
 		It("streams token events to stdout and extracts conversation_id", func() {
 			body := sseEvent(EventStart, map[string]interface{}{"conversation_id": "conv-123"}) +
 				sseEvent(EventToken, map[string]interface{}{"id": 0, "token": "Hello"}) +
@@ -42,19 +40,16 @@ var _ = Describe("AskCmd", func() {
 			defer server.Close()
 
 			streams, out, _ := fakeStreams()
-			o := &AskOptions{
+			o := &commandOptions{
 				streams:           streams,
 				query:             "test question",
 				endpoint:          server.URL,
 				insecureAllowHTTP: true,
-				mode:              "ask",
-				kubeConfig: &KubeConfig{
-					BearerToken: "test-token",
-				},
+				kubeConfig:        &KubeConfig{BearerToken: "test-token"},
 			}
 
 			cmd := NewAskCmd(streams)
-			Expect(o.Run(cmd)).To(Succeed())
+			Expect(queryRun(cmd, o, "ask")).To(Succeed())
 			Expect(out.String()).To(Equal("Hello world\n"))
 			Expect(o.conversationID).To(Equal("conv-123"))
 		})
@@ -71,19 +66,16 @@ var _ = Describe("AskCmd", func() {
 			defer server.Close()
 
 			streams, out, _ := fakeStreams()
-			o := &AskOptions{
-				streams:  streams,
-				query:    "test",
-				endpoint: server.URL,
+			o := &commandOptions{
+				streams:           streams,
+				query:             "test",
+				endpoint:          server.URL,
 				insecureAllowHTTP: true,
-				mode:     "ask",
-				kubeConfig: &KubeConfig{
-					BearerToken: "test-token",
-				},
+				kubeConfig:        &KubeConfig{BearerToken: "test-token"},
 			}
 
 			cmd := NewAskCmd(streams)
-			Expect(o.Run(cmd)).To(Succeed())
+			Expect(queryRun(cmd, o, "ask")).To(Succeed())
 			Expect(out.String()).To(ContainSubstring("References:"))
 			Expect(out.String()).To(ContainSubstring("Pod Debugging"))
 			Expect(out.String()).To(ContainSubstring("https://docs.example.com/pods"))
@@ -97,19 +89,16 @@ var _ = Describe("AskCmd", func() {
 			defer server.Close()
 
 			streams, out, _ := fakeStreams()
-			o := &AskOptions{
-				streams:  streams,
-				query:    "test",
-				endpoint: server.URL,
+			o := &commandOptions{
+				streams:           streams,
+				query:             "test",
+				endpoint:          server.URL,
 				insecureAllowHTTP: true,
-				mode:     "ask",
-				kubeConfig: &KubeConfig{
-					BearerToken: "test-token",
-				},
+				kubeConfig:        &KubeConfig{BearerToken: "test-token"},
 			}
 
 			cmd := NewAskCmd(streams)
-			Expect(o.Run(cmd)).To(Succeed())
+			Expect(queryRun(cmd, o, "ask")).To(Succeed())
 			Expect(out.String()).To(ContainSubstring("simple answer"))
 			Expect(out.String()).NotTo(ContainSubstring("References:"))
 		})
@@ -121,19 +110,16 @@ var _ = Describe("AskCmd", func() {
 			defer server.Close()
 
 			streams, _, _ := fakeStreams()
-			o := &AskOptions{
-				streams:  streams,
-				query:    "test",
-				endpoint: server.URL,
+			o := &commandOptions{
+				streams:           streams,
+				query:             "test",
+				endpoint:          server.URL,
 				insecureAllowHTTP: true,
-				mode:     "ask",
-				kubeConfig: &KubeConfig{
-					BearerToken: "bad-token",
-				},
+				kubeConfig:        &KubeConfig{BearerToken: "bad-token"},
 			}
 
 			cmd := NewAskCmd(streams)
-			err := o.Run(cmd)
+			err := queryRun(cmd, o, "ask")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(ErrAuthFailed))
 		})
@@ -150,27 +136,22 @@ var _ = Describe("AskCmd", func() {
 			defer server.Close()
 
 			streams, out, errOut := fakeStreams()
-			o := &AskOptions{
+			o := &commandOptions{
 				streams:           streams,
 				query:             "test",
 				endpoint:          server.URL,
 				insecureAllowHTTP: true,
-				mode:              "ask",
-				kubeConfig: &KubeConfig{
-					BearerToken: "test-token",
-				},
+				kubeConfig:        &KubeConfig{BearerToken: "test-token"},
 			}
 
 			cmd := NewAskCmd(streams)
-			Expect(o.Run(cmd)).To(Succeed())
+			Expect(queryRun(cmd, o, "ask")).To(Succeed())
 
-			// Not displayed to stdout or stderr
 			Expect(out.String()).To(Equal("result\n"))
 			Expect(errOut.String()).NotTo(ContainSubstring("thinking"))
 			Expect(errOut.String()).NotTo(ContainSubstring("search"))
 			Expect(errOut.String()).NotTo(ContainSubstring("found it"))
 
-			// But captured internally for --output json (OLS-3639)
 			// start + reasoning + tool_call + tool_result = 4 captured events
 			Expect(o.capturedEvents).To(HaveLen(4))
 			Expect(o.capturedEvents[0].Type).To(Equal(EventStart))
@@ -180,8 +161,6 @@ var _ = Describe("AskCmd", func() {
 		})
 
 		It("warns on malformed end event JSON", func() {
-			// Simulate an end event where the inner data is not valid EndEventData
-			// but the envelope is still valid JSON
 			body := sseEvent(EventToken, map[string]interface{}{"id": 0, "token": "answer"}) +
 				sseEvent(EventEnd, "not-a-json-object")
 
@@ -189,19 +168,16 @@ var _ = Describe("AskCmd", func() {
 			defer server.Close()
 
 			streams, _, errOut := fakeStreams()
-			o := &AskOptions{
-				streams:  streams,
-				query:    "test",
-				endpoint: server.URL,
+			o := &commandOptions{
+				streams:           streams,
+				query:             "test",
+				endpoint:          server.URL,
 				insecureAllowHTTP: true,
-				mode:     "ask",
-				kubeConfig: &KubeConfig{
-					BearerToken: "test-token",
-				},
+				kubeConfig:        &KubeConfig{BearerToken: "test-token"},
 			}
 
 			cmd := NewAskCmd(streams)
-			err := o.Run(cmd)
+			err := queryRun(cmd, o, "ask")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(ErrMalformedEnd))
 			Expect(errOut.String()).To(ContainSubstring(ErrMalformedEnd))
@@ -214,19 +190,16 @@ var _ = Describe("AskCmd", func() {
 			defer server.Close()
 
 			streams, _, errOut := fakeStreams()
-			o := &AskOptions{
-				streams:  streams,
-				query:    "test",
-				endpoint: server.URL,
+			o := &commandOptions{
+				streams:           streams,
+				query:             "test",
+				endpoint:          server.URL,
 				insecureAllowHTTP: true,
-				mode:     "ask",
-				kubeConfig: &KubeConfig{
-					BearerToken: "test-token",
-				},
+				kubeConfig:        &KubeConfig{BearerToken: "test-token"},
 			}
 
 			cmd := NewAskCmd(streams)
-			err := o.Run(cmd)
+			err := queryRun(cmd, o, "ask")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(ErrMissingEnd))
 			Expect(errOut.String()).To(ContainSubstring(ErrStreamIncomplete))
@@ -239,79 +212,59 @@ var _ = Describe("AskCmd", func() {
 			defer server.Close()
 
 			streams, out, _ := fakeStreams()
-			o := &AskOptions{
-				streams:  streams,
-				query:    "test",
-				endpoint: server.URL,
+			o := &commandOptions{
+				streams:           streams,
+				query:             "test",
+				endpoint:          server.URL,
 				insecureAllowHTTP: true,
-				mode:     "ask",
-				kubeConfig: &KubeConfig{
-					BearerToken: "test-token",
-				},
+				kubeConfig:        &KubeConfig{BearerToken: "test-token"},
 			}
 
 			cmd := NewAskCmd(streams)
-			Expect(o.Run(cmd)).To(Succeed())
+			Expect(queryRun(cmd, o, "ask")).To(Succeed())
 			Expect(out.String()).To(Equal(""))
 		})
 	})
 
-	Describe("Validate", func() {
+	Describe("validate", func() {
 		It("rejects empty query", func() {
-			o := &AskOptions{
-				query:    "",
-				endpoint: "https://example.com",
-			}
-			err := o.Validate()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(ErrQueryEmpty))
+			o := &commandOptions{query: "", endpoint: "https://example.com"}
+			Expect(o.validate()).To(MatchError(ContainSubstring(ErrQueryEmpty)))
 		})
 
 		It("rejects whitespace-only query", func() {
-			o := &AskOptions{
-				query:    "   ",
-				endpoint: "https://example.com",
-			}
-			err := o.Validate()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(ErrQueryEmpty))
+			o := &commandOptions{query: "   ", endpoint: "https://example.com"}
+			Expect(o.validate()).To(MatchError(ContainSubstring(ErrQueryEmpty)))
 		})
 
 		It("rejects missing endpoint", func() {
-			o := &AskOptions{
-				query:    "test question",
-				endpoint: "",
-			}
-			err := o.Validate()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(ErrNoEndpoint))
+			o := &commandOptions{query: "test question", endpoint: ""}
+			Expect(o.validate()).To(MatchError(ContainSubstring(ErrNoEndpoint)))
 		})
 
 		It("accepts valid options", func() {
-			o := &AskOptions{
-				query:    "why is my pod crashing",
-				endpoint: "https://ols.example.com",
-			}
-			Expect(o.Validate()).To(Succeed())
+			o := &commandOptions{query: "why is my pod crashing", endpoint: "https://ols.example.com"}
+			Expect(o.validate()).To(Succeed())
 		})
 
 		It("rejects cleartext HTTP endpoint by default", func() {
-			o := &AskOptions{
-				query:    "test",
-				endpoint: "http://ols.example.com",
-			}
-			err := o.Validate()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("cleartext HTTP"))
+			o := &commandOptions{query: "test", endpoint: "http://ols.example.com"}
+			Expect(o.validate()).To(MatchError(ContainSubstring("cleartext HTTP")))
 		})
 
-		It("allows cleartext HTTP with --insecure-allow-http", func() {
-			o := &AskOptions{
-				query:             "test",
-				endpoint:          "http://ols.example.com",
-				insecureAllowHTTP: true,
-			}
-			Expect(o.Validate()).To(Succeed())
+		It("allows cleartext HTTP with insecureAllowHTTP", func() {
+			o := &commandOptions{query: "test", endpoint: "http://ols.example.com", insecureAllowHTTP: true}
+			Expect(o.validate()).To(Succeed())
+		})
+
+		It("rejects endpoint without host", func() {
+			o := &commandOptions{query: "test", endpoint: "https:///v1"}
+			Expect(o.validate()).To(MatchError(ContainSubstring("host is required")))
+		})
+
+		It("rejects unsupported scheme", func() {
+			o := &commandOptions{query: "test", endpoint: "ftp://ols.example.com"}
+			Expect(o.validate()).To(MatchError(ContainSubstring("unsupported endpoint scheme")))
 		})
 	})
 

--- a/cli/integration_test.go
+++ b/cli/integration_test.go
@@ -192,4 +192,87 @@ users:
 			Expect(err.Error()).To(ContainSubstring(ErrQueryEmpty))
 		})
 	})
+
+	Describe("troubleshoot subcommand", func() {
+		It("sends query with mode troubleshooting", func() {
+			var capturedBody []byte
+
+			body := sseEvent(EventStart, map[string]interface{}{"conversation_id": "conv-ts-int"}) +
+				sseEvent(EventToken, map[string]interface{}{"id": 0, "token": "restart the pod"}) +
+				buildEndEvent([]ReferencedDocument{})
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedBody, _ = io.ReadAll(r.Body)
+				w.Header().Set("Content-Type", "text/event-stream")
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, body)
+			}))
+			defer server.Close()
+
+			kubeconfigPath := createKubeconfig("https://k8s.example.com", "test-token")
+			defer os.Remove(kubeconfigPath)
+
+			streams, out, _ := fakeStreams()
+			cmd := NewRootCmd(streams)
+			cmd.SetArgs([]string{
+				"--kubeconfig", kubeconfigPath,
+				"--endpoint", server.URL,
+				"--insecure-skip-tls-verify",
+				"--insecure-allow-http",
+				"troubleshoot", "pod keeps restarting",
+			})
+
+			Expect(cmd.Execute()).To(Succeed())
+
+			// Verify mode is "troubleshooting" in request body
+			var reqBody LLMRequest
+			Expect(json.Unmarshal(capturedBody, &reqBody)).To(Succeed())
+			Expect(reqBody.Query).To(Equal("pod keeps restarting"))
+			Expect(reqBody.Mode).To(Equal("troubleshooting"))
+			Expect(reqBody.MediaType).To(Equal("application/json"))
+
+			Expect(out.String()).To(ContainSubstring("restart the pod"))
+		})
+
+		It("returns error when no query is provided", func() {
+			kubeconfigPath := createKubeconfig("https://k8s.example.com", "token")
+			defer os.Remove(kubeconfigPath)
+
+			streams, _, _ := fakeStreams()
+			cmd := NewRootCmd(streams)
+			cmd.SetArgs([]string{
+				"--kubeconfig", kubeconfigPath,
+				"--endpoint", "https://ols.example.com",
+				"troubleshoot",
+			})
+
+			err := cmd.Execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(ErrQueryEmpty))
+		})
+
+		It("returns error on HTTP 401", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+			}))
+			defer server.Close()
+
+			kubeconfigPath := createKubeconfig("https://k8s.example.com", "expired-token")
+			defer os.Remove(kubeconfigPath)
+
+			streams, _, _ := fakeStreams()
+			cmd := NewRootCmd(streams)
+			cmd.SetArgs([]string{
+				"--kubeconfig", kubeconfigPath,
+				"--endpoint", server.URL,
+				"--insecure-skip-tls-verify",
+				"--insecure-allow-http",
+				"troubleshoot", "something broke",
+			})
+
+			err := cmd.Execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(ErrAuthFailed))
+		})
+	})
 })

--- a/cli/query.go
+++ b/cli/query.go
@@ -1,0 +1,200 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+// commandOptions holds shared configuration for commands that send
+// streaming queries to OLS (ask, troubleshoot).
+type commandOptions struct {
+	streams           genericclioptions.IOStreams
+	query             string
+	endpoint          string
+	kubeConfig        *KubeConfig
+	insecureAllowHTTP bool
+
+	// conversationID is extracted from the start event during streaming.
+	// Available after queryRun completes for conversation persistence (OLS-3636).
+	conversationID string
+
+	// capturedEvents accumulates non-token, non-end events (start, reasoning,
+	// tool_call, tool_result). Not displayed in default mode but available
+	// for --output json (OLS-3639).
+	capturedEvents []SSEEvent
+}
+
+// complete resolves the query string, kubeconfig, and endpoint from
+// command args and flags.
+func (o *commandOptions) complete(cmd *cobra.Command, args []string) error {
+	o.query = strings.Join(args, " ")
+
+	kubeconfigPath, _ := cmd.Flags().GetString("kubeconfig")
+	contextName, _ := cmd.Flags().GetString("context")
+	insecureSkipTLS, _ := cmd.Flags().GetBool("insecure-skip-tls-verify")
+	caCertPath, _ := cmd.Flags().GetString("ca-cert")
+	insecureAllowHTTP, _ := cmd.Flags().GetBool("insecure-allow-http")
+
+	kc, err := LoadKubeConfig(kubeconfigPath, contextName, insecureSkipTLS, caCertPath)
+	if err != nil {
+		return err
+	}
+	o.kubeConfig = kc
+	o.insecureAllowHTTP = insecureAllowHTTP
+
+	endpoint, err := ResolveEndpoint(cmd, kc.ContextName)
+	if err != nil {
+		return err
+	}
+	o.endpoint = endpoint
+
+	return nil
+}
+
+// validate checks that required fields are populated and the endpoint
+// URL is well-formed with a valid scheme.
+func (o *commandOptions) validate() error {
+	if strings.TrimSpace(o.query) == "" {
+		return fmt.Errorf("%s: provide a question as arguments", ErrQueryEmpty)
+	}
+	if o.endpoint == "" {
+		return errors.New(ErrNoEndpoint)
+	}
+
+	parsed, err := url.Parse(o.endpoint)
+	if err != nil {
+		return fmt.Errorf("invalid endpoint URL: %w", err)
+	}
+	if parsed.Host == "" {
+		return fmt.Errorf("invalid endpoint URL %q: host is required", o.endpoint)
+	}
+	// Reject anything that isn't HTTPS (or HTTP with explicit opt-in)
+	// to prevent sending the bearer token over an insecure transport.
+	switch parsed.Scheme {
+	case "https":
+		// OK
+	case "http":
+		if !o.insecureAllowHTTP {
+			return fmt.Errorf("cleartext HTTP endpoint %q is not allowed: bearer token would be sent unencrypted. Use https:// or reconfigure with: oc ols config set-endpoint", o.endpoint)
+		}
+	default:
+		return fmt.Errorf("unsupported endpoint scheme %q in %q: use https://", parsed.Scheme, o.endpoint)
+	}
+	return nil
+}
+
+// queryRun executes a streaming query against the OLS service. It handles
+// SSE event parsing, token output, end event validation, and reference
+// display. Both ask and troubleshoot commands delegate to this function.
+func queryRun(cmd *cobra.Command, opts *commandOptions, mode string) error {
+	client := NewSSEClient(opts.endpoint, opts.kubeConfig.BearerToken, opts.kubeConfig.TLSConfig)
+
+	req := LLMRequest{
+		Query:     opts.query,
+		Mode:      mode,
+		MediaType: "application/json",
+	}
+
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	events, errc, err := client.StreamQuery(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	opts.capturedEvents = nil
+	var endData *EndEventData
+	var hasTokens bool
+	var endParseErr error
+
+	for ev := range events {
+		switch ev.Type {
+		case EventToken:
+			var td TokenEventData
+			if err := json.Unmarshal([]byte(ev.Data), &td); err != nil {
+				// If token data isn't JSON, use raw string as fallback.
+				td.Token = ev.Data
+			}
+			hasTokens = true
+			if _, err := fmt.Fprint(opts.streams.Out, td.Token); err != nil {
+				return fmt.Errorf("%s: %w", ErrWriteOutput, err)
+			}
+		case EventStart:
+			// Extract conversation_id for persistence (OLS-3636).
+			var sd StartEventData
+			if err := json.Unmarshal([]byte(ev.Data), &sd); err == nil {
+				opts.conversationID = sd.ConversationID
+			}
+			opts.capturedEvents = append(opts.capturedEvents, ev)
+		case EventEnd:
+			var ed EndEventData
+			if err := json.Unmarshal([]byte(ev.Data), &ed); err != nil {
+				endParseErr = err
+			} else {
+				endData = &ed
+			}
+		case EventReasoning, EventToolCall, EventToolResult:
+			// Captured but not displayed in default mode.
+			// Available via capturedEvents for --output json (OLS-3639).
+			opts.capturedEvents = append(opts.capturedEvents, ev)
+		default:
+			// Unknown event types are silently ignored.
+		}
+	}
+
+	// Check for stream-level errors.
+	if streamErr := <-errc; streamErr != nil {
+		if _, err := fmt.Fprintf(opts.streams.ErrOut, "Warning: %s\n", ErrStreamIncomplete); err != nil {
+			return fmt.Errorf("%s: %w", ErrWriteOutput, err)
+		}
+		return streamErr
+	}
+
+	// Print trailing newline only if tokens were emitted.
+	if hasTokens {
+		if _, err := fmt.Fprintln(opts.streams.Out); err != nil {
+			return fmt.Errorf("%s: %w", ErrWriteOutput, err)
+		}
+	}
+
+	// Malformed or missing end event means the stream was not fully valid.
+	if endParseErr != nil {
+		if _, err := fmt.Fprintf(opts.streams.ErrOut, "Warning: %s: %v\n", ErrMalformedEnd, endParseErr); err != nil {
+			return fmt.Errorf("%s: %w", ErrWriteOutput, err)
+		}
+		return fmt.Errorf("%s: %w", ErrMalformedEnd, endParseErr)
+	}
+
+	if endData == nil {
+		if _, err := fmt.Fprintf(opts.streams.ErrOut, "Warning: %s\n", ErrStreamIncomplete); err != nil {
+			return fmt.Errorf("%s: %w", ErrWriteOutput, err)
+		}
+		return errors.New(ErrMissingEnd)
+	}
+
+	// Display referenced documents on stdout.
+	if len(endData.ReferencedDocuments) > 0 {
+		if _, err := fmt.Fprintf(opts.streams.Out, "\nReferences:\n"); err != nil {
+			return fmt.Errorf("%s: %w", ErrWriteOutput, err)
+		}
+		for _, doc := range endData.ReferencedDocuments {
+			if _, err := fmt.Fprintf(opts.streams.Out, "  - %s: %s\n", doc.DocTitle, doc.DocURL); err != nil {
+				return fmt.Errorf("%s: %w", ErrWriteOutput, err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -18,10 +18,7 @@ const (
 
 // NewRootCmd creates the root oc-ols command and registers subcommands.
 func NewRootCmd(streams genericclioptions.IOStreams) *cobra.Command {
-	askOpts := &AskOptions{
-		streams: streams,
-		mode:    "ask",
-	}
+	o := &commandOptions{streams: streams}
 
 	cmd := &cobra.Command{
 		Use:   "oc-ols [command]",
@@ -32,13 +29,13 @@ func NewRootCmd(streams genericclioptions.IOStreams) *cobra.Command {
 				return cmd.Help()
 			}
 			// Default mode: dispatch unrecognized args to ask
-			if err := askOpts.Complete(cmd, args); err != nil {
+			if err := o.complete(cmd, args); err != nil {
 				return err
 			}
-			if err := askOpts.Validate(); err != nil {
+			if err := o.validate(); err != nil {
 				return err
 			}
-			return askOpts.Run(cmd)
+			return queryRun(cmd, o, "ask")
 		},
 		SilenceUsage: true,
 		Args:         cobra.ArbitraryArgs,
@@ -65,6 +62,7 @@ func NewRootCmd(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd.AddCommand(NewVersionCmd(streams))
 	cmd.AddCommand(config.NewConfigCmd(streams))
 	cmd.AddCommand(NewAskCmd(streams))
+	cmd.AddCommand(NewTroubleshootCmd(streams))
 
 	return cmd
 }

--- a/cli/troubleshoot.go
+++ b/cli/troubleshoot.go
@@ -1,0 +1,31 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+// NewTroubleshootCmd creates the "troubleshoot" subcommand that sends a
+// troubleshooting query to OLS and streams back the response.
+func NewTroubleshootCmd(streams genericclioptions.IOStreams) *cobra.Command {
+	o := &commandOptions{streams: streams}
+
+	cmd := &cobra.Command{
+		Use:   "troubleshoot [question]",
+		Short: "Troubleshoot an OpenShift issue with Lightspeed",
+		Long:  "Send a troubleshooting question to OpenShift Lightspeed and stream the response.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.complete(cmd, args); err != nil {
+				return err
+			}
+			if err := o.validate(); err != nil {
+				return err
+			}
+			return queryRun(cmd, o, "troubleshooting")
+		},
+		Args:         cobra.ArbitraryArgs,
+		SilenceUsage: true,
+	}
+
+	return cmd
+}

--- a/cli/troubleshoot_test.go
+++ b/cli/troubleshoot_test.go
@@ -1,0 +1,172 @@
+package cli
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("TroubleshootCmd", func() {
+	sseServer := func(sseBody string) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, sseBody)
+		}))
+	}
+
+	buildEndEvent := func(docs []ReferencedDocument) string {
+		payload := map[string]interface{}{
+			"referenced_documents": docs,
+			"truncated":            false,
+			"input_tokens":         100,
+			"output_tokens":        50,
+			"reasoning_tokens":     0,
+		}
+		return sseEndEvent(payload)
+	}
+
+	Describe("queryRun with troubleshooting mode", func() {
+		It("streams token events to stdout and extracts conversation_id", func() {
+			body := sseEvent(EventStart, map[string]interface{}{"conversation_id": "conv-ts-1"}) +
+				sseEvent(EventToken, map[string]interface{}{"id": 0, "token": "Check"}) +
+				sseEvent(EventToken, map[string]interface{}{"id": 1, "token": " logs"}) +
+				buildEndEvent([]ReferencedDocument{})
+
+			server := sseServer(body)
+			defer server.Close()
+
+			streams, out, _ := fakeStreams()
+			o := &commandOptions{
+				streams:           streams,
+				query:             "pod keeps crashing",
+				endpoint:          server.URL,
+				insecureAllowHTTP: true,
+				kubeConfig:        &KubeConfig{BearerToken: "test-token"},
+			}
+
+			cmd := NewTroubleshootCmd(streams)
+			Expect(queryRun(cmd, o, "troubleshooting")).To(Succeed())
+			Expect(out.String()).To(Equal("Check logs\n"))
+			Expect(o.conversationID).To(Equal("conv-ts-1"))
+		})
+
+		It("displays referenced documents on stdout", func() {
+			docs := []ReferencedDocument{
+				{DocTitle: "Troubleshooting Guide", DocURL: "https://docs.example.com/troubleshoot"},
+			}
+			body := sseEvent(EventToken, map[string]interface{}{"id": 0, "token": "answer"}) +
+				buildEndEvent(docs)
+
+			server := sseServer(body)
+			defer server.Close()
+
+			streams, out, _ := fakeStreams()
+			o := &commandOptions{
+				streams:           streams,
+				query:             "test",
+				endpoint:          server.URL,
+				insecureAllowHTTP: true,
+				kubeConfig:        &KubeConfig{BearerToken: "test-token"},
+			}
+
+			cmd := NewTroubleshootCmd(streams)
+			Expect(queryRun(cmd, o, "troubleshooting")).To(Succeed())
+			Expect(out.String()).To(ContainSubstring("References:"))
+			Expect(out.String()).To(ContainSubstring("Troubleshooting Guide"))
+		})
+
+		It("propagates HTTP errors from SSEClient", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+			}))
+			defer server.Close()
+
+			streams, _, _ := fakeStreams()
+			o := &commandOptions{
+				streams:           streams,
+				query:             "test",
+				endpoint:          server.URL,
+				insecureAllowHTTP: true,
+				kubeConfig:        &KubeConfig{BearerToken: "bad-token"},
+			}
+
+			cmd := NewTroubleshootCmd(streams)
+			err := queryRun(cmd, o, "troubleshooting")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(ErrAuthFailed))
+		})
+
+		It("captures reasoning and tool events without displaying them", func() {
+			body := sseEvent(EventStart, map[string]interface{}{"conversation_id": "conv-ts-2"}) +
+				sseEvent(EventReasoning, map[string]interface{}{"content": "analyzing..."}) +
+				sseEvent(EventToken, map[string]interface{}{"id": 0, "token": "fixed"}) +
+				sseEvent(EventToolCall, map[string]interface{}{"name": "kubectl", "args": map[string]string{"cmd": "get pods"}, "id": "call_1", "type": "tool_call"}) +
+				buildEndEvent([]ReferencedDocument{})
+
+			server := sseServer(body)
+			defer server.Close()
+
+			streams, out, errOut := fakeStreams()
+			o := &commandOptions{
+				streams:           streams,
+				query:             "test",
+				endpoint:          server.URL,
+				insecureAllowHTTP: true,
+				kubeConfig:        &KubeConfig{BearerToken: "test-token"},
+			}
+
+			cmd := NewTroubleshootCmd(streams)
+			Expect(queryRun(cmd, o, "troubleshooting")).To(Succeed())
+
+			Expect(out.String()).To(Equal("fixed\n"))
+			Expect(errOut.String()).NotTo(ContainSubstring("analyzing"))
+			Expect(errOut.String()).NotTo(ContainSubstring("kubectl"))
+
+			// start + reasoning + tool_call = 3 captured events
+			Expect(o.capturedEvents).To(HaveLen(3))
+			Expect(o.capturedEvents[0].Type).To(Equal(EventStart))
+			Expect(o.capturedEvents[1].Type).To(Equal(EventReasoning))
+			Expect(o.capturedEvents[2].Type).To(Equal(EventToolCall))
+		})
+
+		It("returns error when stream has no end event", func() {
+			body := sseEvent(EventToken, map[string]interface{}{"id": 0, "token": "partial"})
+
+			server := sseServer(body)
+			defer server.Close()
+
+			streams, _, errOut := fakeStreams()
+			o := &commandOptions{
+				streams:           streams,
+				query:             "test",
+				endpoint:          server.URL,
+				insecureAllowHTTP: true,
+				kubeConfig:        &KubeConfig{BearerToken: "test-token"},
+			}
+
+			cmd := NewTroubleshootCmd(streams)
+			err := queryRun(cmd, o, "troubleshooting")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(ErrMissingEnd))
+			Expect(errOut.String()).To(ContainSubstring(ErrStreamIncomplete))
+		})
+	})
+
+	Describe("NewTroubleshootCmd", func() {
+		It("creates command with correct use string", func() {
+			streams, _, _ := fakeStreams()
+			cmd := NewTroubleshootCmd(streams)
+			Expect(cmd.Use).To(Equal("troubleshoot [question]"))
+		})
+
+		It("accepts arbitrary args", func() {
+			streams, _, _ := fakeStreams()
+			cmd := NewTroubleshootCmd(streams)
+			Expect(cmd.Args).NotTo(BeNil())
+		})
+	})
+})


### PR DESCRIPTION
## Description

Add `oc ols troubleshoot` command that sends queries with `mode: "troubleshooting"` to `/v1/streaming_query`.

This PR also refactors the ask command to extract shared logic into `query.go`. The previous `AskOptions` struct with its `Complete`, `Validate`, and `Run` methods is replaced by a shared `commandOptions` struct and a `queryRun` function that both `ask` and `troubleshoot` delegate to. This means `ask.go` went from ~190 lines to ~37 lines of thin cobra wiring. The refactor is needed because troubleshoot is identical to ask except for the mode string, and duplicating all that logic would cause maintenance drift as PRs 5-10 add flags and behaviors to the shared streaming path.

The file count in this PR is high because of the refactor. Here's what's actually new vs restructured:

**New files:**
- `cli/troubleshoot.go` (31 lines) — thin command constructor
- `cli/troubleshoot_test.go` (172 lines) — unit tests
- `cli/query.go` (200 lines) — shared `commandOptions`/`queryRun`, extracted from `ask.go`

**Changed files:**
- `cli/ask.go` — shrunk from 190 to 37 lines, now a thin wrapper like troubleshoot
- `cli/ask_test.go` — updated to use `commandOptions` instead of `AskOptions`, added endpoint validation tests
- `cli/integration_test.go` — added 3 troubleshoot integration tests (mode verification, empty query, 401)
- `cli/root.go` — registered troubleshoot subcommand, default dispatch uses shared `commandOptions`

**Endpoint validation hardening** (applies to both commands via shared `validate`):
- reject endpoints without a host (`https:///v1`)
- reject unsupported schemes (`ftp://`) with a distinct error message
- previously these slipped through and failed later in `StreamQuery`

AI-assisted: code was written with AI tooling (pi coding agent, Opus 4.6). All code reviewed and tested manually.

## Type of change

- [x] Refactor
- [x] New feature

## Related Tickets & Documents

- Closes [OLS-3635](https://redhat.atlassian.net/browse/OLS-3635)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

Unit and integration tests (108 specs total, 0 lint issues):
```
go test ./cli/...
golangci-lint run ./cli/...
```

Manual verification was done against a live OLS cluster:
```
# Default dispatch (ask mode) — regression test
oc ols "Why is my pod stuck in Pending state?"

# Explicit ask — regression test
oc ols ask "How do I increase the replica count of a Deployment?"

# Troubleshoot — new command
oc ols troubleshoot "My pod is in CrashLoopBackOff and the logs show OOMKilled"

# Validation
oc ols troubleshoot                                                    # empty query error
oc ols --endpoint ftp://example.com troubleshoot "test"                # unsupported scheme
oc ols --endpoint "https:///v1" troubleshoot "test"                    # missing host
oc ols --endpoint http://example.com troubleshoot "test"               # cleartext HTTP rejected
oc ols --endpoint http://example.com --insecure-allow-http troubleshoot "test"  # HTTP allowed
```

Server logs confirm `"mode":"troubleshooting"` in request body for troubleshoot command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `troubleshoot` CLI command for streaming troubleshooting responses.
  - Troubleshooting output includes referenced documents and conversation identifiers when available.
  - Added support for streamed tokens and clear reporting of authentication and incomplete-response errors.

- **Bug Fixes**
  - Improved endpoint validation, including host requirements and secure scheme checks.
  - Standardized query, ask, and troubleshoot command behavior and error handling.

- **Documentation**
  - Updated CLI documentation to cover query, ask, and troubleshoot functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->